### PR TITLE
chore(release): align 1.0.0 stable metadata and release posture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project follows [Semantic Versioning](https://semver.org/) once it leaves prerelease status.
+and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
@@ -13,6 +13,17 @@ and this project follows [Semantic Versioning](https://semver.org/) once it leav
 
 ### Changed
 - CI quality gate will validate lint/type/security/build/artifact checks before stable promotion
+
+## [1.0.0] - 2026-04-17
+
+### Changed
+- Promoted package metadata from prerelease to stable (`version = 1.0.0`, `Development Status :: 5 - Production/Stable`)
+- Aligned release posture language in `README.md` and `README.ko.md` with the stable support policy
+
+### Migration notes
+- If you pinned `pyrallel-consumer==0.1.2a2`, upgrade to `pyrallel-consumer==1.0.0`
+- Keep Python `>=3.12` (unchanged from the prerelease line)
+- Regenerate lockfiles/environments after upgrade (`uv sync`)
 
 ## [0.1.2a2] - 2026-03-27
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,9 @@
 # Pyrallel Consumer - 개발 현황 및 인수인계 문서
 
-*최종 업데이트: 2026년 3월 27일 금요일*
+*최종 업데이트: 2026년 4월 17일 금요일*
+
+## 최근 업데이트 (2026-04-17)
+- Issue #33 stable metadata/posture 정렬 단계 (2026-04-17): `pyproject.toml`과 `uv.lock`의 package version을 `1.0.0`으로 올리고 classifier를 `Development Status :: 5 - Production/Stable`로 갱신했습니다. `README.md`/`README.ko.md` release policy를 stable 라인 기준으로 정리했고, `CHANGELOG.md`에 `1.0.0` 릴리스 내러티브와 마이그레이션 노트를 추가했습니다. 또한 `docs/operations/release-readiness.md`의 P0 `알파 메타데이터 제거` 항목을 완료 처리하고 evidence를 연결했습니다.
 
 ## 최근 업데이트 (2026-03-27)
 - Release prep (2026-03-27): PyPI prerelease를 `0.1.2a1`에서 `0.1.2a2`로 올리기 위해 `pyproject.toml`과 `uv.lock`의 package version을 갱신했고, README/README.ko의 release policy 문구도 `0.1.2a2` 기준으로 맞췄습니다. release artifact는 `PATH=".venv/bin:$PATH" python -m build --no-isolation --outdir dist/release-0.1.2a2`로 fresh sdist/wheel을 만들었고, `PATH=".venv/bin:$PATH" twine check dist/release-0.1.2a2/*`도 모두 PASSED였습니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,6 +4,7 @@
 
 ## 최근 업데이트 (2026-04-17)
 - Issue #33 stable metadata/posture 정렬 단계 (2026-04-17): `pyproject.toml`과 `uv.lock`의 package version을 `1.0.0`으로 올리고 classifier를 `Development Status :: 5 - Production/Stable`로 갱신했습니다. `README.md`/`README.ko.md` release policy를 stable 라인 기준으로 정리했고, `CHANGELOG.md`에 `1.0.0` 릴리스 내러티브와 마이그레이션 노트를 추가했습니다. 또한 `docs/operations/release-readiness.md`의 P0 `알파 메타데이터 제거` 항목을 완료 처리하고 evidence를 GitHub issue #33 / PR #38로 연결했습니다.
+- MQU-153 문서 갭 보완 단계 (2026-04-17): `README.md`/`README.ko.md`에 `SECURITY.md` 및 support-policy 직링크를 추가하고, `docs/operations/support-policy.md`를 신설해 지원 라인/호환 범위/보안 연계/폐기 정책을 명시했습니다. `docs/operations/playbooks.md`에는 `Release Rollback Runbook`과 `Release Incident Response` 절차를 추가했으며, `docs/operations/release-readiness.md`의 Security/Support/Rollback 항목에 증거 링크를 반영해 완료 처리했습니다.
 
 ## 최근 업데이트 (2026-03-27)
 - Release prep (2026-03-27): PyPI prerelease를 `0.1.2a1`에서 `0.1.2a2`로 올리기 위해 `pyproject.toml`과 `uv.lock`의 package version을 갱신했고, README/README.ko의 release policy 문구도 `0.1.2a2` 기준으로 맞췄습니다. release artifact는 `PATH=".venv/bin:$PATH" python -m build --no-isolation --outdir dist/release-0.1.2a2`로 fresh sdist/wheel을 만들었고, `PATH=".venv/bin:$PATH" twine check dist/release-0.1.2a2/*`도 모두 PASSED였습니다.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,7 +3,7 @@
 *최종 업데이트: 2026년 4월 17일 금요일*
 
 ## 최근 업데이트 (2026-04-17)
-- Issue #33 stable metadata/posture 정렬 단계 (2026-04-17): `pyproject.toml`과 `uv.lock`의 package version을 `1.0.0`으로 올리고 classifier를 `Development Status :: 5 - Production/Stable`로 갱신했습니다. `README.md`/`README.ko.md` release policy를 stable 라인 기준으로 정리했고, `CHANGELOG.md`에 `1.0.0` 릴리스 내러티브와 마이그레이션 노트를 추가했습니다. 또한 `docs/operations/release-readiness.md`의 P0 `알파 메타데이터 제거` 항목을 완료 처리하고 evidence를 연결했습니다.
+- Issue #33 stable metadata/posture 정렬 단계 (2026-04-17): `pyproject.toml`과 `uv.lock`의 package version을 `1.0.0`으로 올리고 classifier를 `Development Status :: 5 - Production/Stable`로 갱신했습니다. `README.md`/`README.ko.md` release policy를 stable 라인 기준으로 정리했고, `CHANGELOG.md`에 `1.0.0` 릴리스 내러티브와 마이그레이션 노트를 추가했습니다. 또한 `docs/operations/release-readiness.md`의 P0 `알파 메타데이터 제거` 항목을 완료 처리하고 evidence를 GitHub issue #33 / PR #38로 연결했습니다.
 
 ## 최근 업데이트 (2026-03-27)
 - Release prep (2026-03-27): PyPI prerelease를 `0.1.2a1`에서 `0.1.2a2`로 올리기 위해 `pyproject.toml`과 `uv.lock`의 package version을 갱신했고, README/README.ko의 release policy 문구도 `0.1.2a2` 기준으로 맞췄습니다. release artifact는 `PATH=".venv/bin:$PATH" python -m build --no-isolation --outdir dist/release-0.1.2a2`로 fresh sdist/wheel을 만들었고, `PATH=".venv/bin:$PATH" twine check dist/release-0.1.2a2/*`도 모두 PASSED였습니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -16,13 +16,13 @@
 
 Java 생태계의 `confluentinc/parallel-consumer`에서 영감을 받아, 병렬성을 극대화하면서도 데이터 정합성과 순서 보장을 유지하도록 설계되었습니다.
 
-> **릴리즈 정책:** 현재 배포 버전은 alpha/prerelease(`0.1.2a2`)입니다. 버전/분류 정책이 alpha를 벗어나기 전까지는 `main` 브랜치를 안정화가 계속 진행 중인 hardening 브랜치로 보는 것이 맞습니다.
+> **릴리즈 정책:** 현재 배포 라인은 stable(`1.0.0`)입니다. `main` 브랜치는 Semantic Versioning 기준의 stable 패치/마이너 안정화 및 기능 개발 브랜치로 운영합니다.
 
 ## 지원 / 호환성 정책
 
 - **Python:** 현재 패키지 메타데이터 기준 지원 대상은 `>=3.12`이며, 배포 classifier는 Python `3.12`, `3.13`을 명시합니다.
 - **Kafka:** 지금 적극적으로 검증된 브로커 경로는 프로젝트의 로컬 Docker / CI 기반 Kafka E2E 흐름입니다. 그 외 브로커 배포판이나 더 오래된 client/broker 조합은, 별도 호환성 매트릭스가 문서화되고 자동화되기 전까지는 best-effort로 보는 편이 맞습니다.
-- **릴리즈 지원:** 현재는 최신 공개 prerelease만 적극 유지보수 대상으로 보고, 더 오래된 prerelease 빌드는 stable 전환 전까지 best-effort 범위로 취급합니다.
+- **릴리즈 지원:** 최신 stable 라인(`1.x`)을 적극 유지보수 대상으로 삼습니다. 과거 prerelease 빌드(`0.1.xa*`)는 best-effort 범위이며 수정 보장을 제공하지 않습니다.
 
 ## 🌟 주요 특징
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -17,6 +17,9 @@
 Java 생태계의 `confluentinc/parallel-consumer`에서 영감을 받아, 병렬성을 극대화하면서도 데이터 정합성과 순서 보장을 유지하도록 설계되었습니다.
 
 > **릴리즈 정책:** 현재 배포 라인은 stable(`1.0.0`)입니다. `main` 브랜치는 Semantic Versioning 기준의 stable 패치/마이너 안정화 및 기능 개발 브랜치로 운영합니다.
+>
+> **보안 제보 경로:** [`SECURITY.md`](./SECURITY.md)를 확인하세요.  
+> **지원/호환성 정책:** [`docs/operations/support-policy.md`](./docs/operations/support-policy.md)를 확인하세요.
 
 ## 지원 / 호환성 정책
 
@@ -410,6 +413,8 @@ uv run python benchmarks/run_parallel_benchmark.py \
 -   **`prd_dev.md`**: 개발자를 위한 요약 문서. 프로젝트의 주요 기능, 아키텍처, 개발 방법론 등을 간결하게 설명합니다.
 -   **`prd.md`**: 상세 설계 해설서. 각 컴포넌트의 의도, 기술 선정 이유, 인터페이스 정의 등 "왜"라는 질문에 대한 깊이 있는 답변을 제공하는 문서입니다.
 -   **`docs/operations/playbooks.md`**: 운영 플레이북과 튜닝 가이드. 프로필별 권장 설정, 장애 대응, 모니터링/알람 기준, 튜닝 절차를 제공합니다.
+-   **`docs/operations/support-policy.md`**: 지원 버전, 호환 범위, 폐기 정책, 지원 기대치를 정의합니다.
+-   **`SECURITY.md`**: 취약점 비공개 제보 채널과 보안 응답 목표를 안내합니다.
 
 ## 📊 모니터링 스택 (Prometheus + Grafana)
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ If you are looking for a **parallel consumer for Kafka in Python**, this project
 Inspired by Java's `confluentinc/parallel-consumer`, it is designed to maximize parallelism while preserving ordering guarantees and data consistency.
 
 > **Release policy:** current published line is stable (`1.0.0`). Treat `main` as the active branch for stable patch/minor hardening and feature delivery under Semantic Versioning.
+>
+> **Security reporting:** see [`SECURITY.md`](./SECURITY.md).  
+> **Support/compatibility policy:** see [`docs/operations/support-policy.md`](./docs/operations/support-policy.md).
 
 ## Support / Compatibility Policy
 
@@ -294,6 +297,8 @@ uv run python benchmarks/run_parallel_benchmark.py \
 - `prd_dev.md`: concise developer-oriented summary
 - `prd.md`: full design rationale and architecture details
 - `docs/operations/playbooks.md`: ops playbook, tuning guide, incident response
+- `docs/operations/support-policy.md`: supported versions, compatibility window, deprecation and support expectations
+- `SECURITY.md`: vulnerability reporting channel and security response expectations
 
 ## 📊 Monitoring Stack (Prometheus + Grafana)
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ If you are looking for a **parallel consumer for Kafka in Python**, this project
 
 Inspired by Java's `confluentinc/parallel-consumer`, it is designed to maximize parallelism while preserving ordering guarantees and data consistency.
 
-> **Release policy:** current published versions are alpha/prerelease (`0.1.2a2`). Treat `main` as an active hardening branch until the version/classifier policy is promoted beyond alpha.
+> **Release policy:** current published line is stable (`1.0.0`). Treat `main` as the active branch for stable patch/minor hardening and feature delivery under Semantic Versioning.
 
 ## Support / Compatibility Policy
 
 - **Python:** the current package metadata targets Python `>=3.12`, and the published classifiers currently advertise Python `3.12` and `3.13`.
 - **Kafka:** the actively verified broker path today is the local Docker / CI-backed Kafka flow used by the project's E2E suite. Treat other broker distributions or older client/broker combinations as best-effort until a broader compatibility matrix is documented and automated.
-- **Release support:** only the latest published prerelease is treated as an actively maintained support target right now. Older prerelease builds are best-effort until the project graduates from alpha/hardening status.
+- **Release support:** the latest stable line (`1.x`) is the actively maintained support target. Historical prerelease builds (`0.1.xa*`) are best-effort and receive no guaranteed fixes.
 
 ## 🌟 Key Features
 

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -6,9 +6,11 @@
 - **[guide.en.md](./guide.en.md)** - English operations guide
 - **[playbooks.md](./playbooks.md)** - 운영 플레이북과 튜닝 절차
 - **[release-readiness.md](./release-readiness.md)** - stable release 승격 전 우선순위 체크리스트
+- **[support-policy.md](./support-policy.md)** - 지원 범위/호환성/폐기 정책
 
 빠르게 보려면:
 
 - 운영 지표와 해석 기준은 `guide.*.md`
 - 장애 대응, 프로필별 권장 설정, 튜닝 절차는 `playbooks.md`
 - 출시 전 점검 항목과 증거 기준은 `release-readiness.md`
+- 지원/호환성 기준과 보안 연계 정책은 `support-policy.md`

--- a/docs/operations/playbooks.md
+++ b/docs/operations/playbooks.md
@@ -10,6 +10,28 @@
 - **Worker crash/timeout**: `CompletionStatus.FAILURE` with attempt=max_retries. Action: inspect worker logs, reduce `task_timeout_ms` for faster detection, increase `max_retries` only with idempotent workers.
 - **Rebalance stalls**: commits paused by gaps; monitor `consumer_parallel_lag` and `consumer_gap_count`. Action: verify `blocking_cache_ttl`, ensure `WorkManager` queues stay bounded (see queue cleanup), consider lowering `poll_batch_size`.
 
+## Release Rollback Runbook
+Trigger conditions:
+- new stable release에서 ordering 깨짐, DLQ 급증, 또는 지속적인 lag/gap 증가가 관측됨
+- 릴리스 인시던트 triage에서 `sev-high` 이상으로 분류됨
+
+Rollback steps:
+1. Freeze rollout: 새 버전 배포 확장 중단 및 신규 롤아웃 차단.
+2. Snapshot evidence: 현재 배포 SHA/tag, 오류 로그, 핵심 메트릭(`consumer_parallel_lag`, `consumer_gap_count`, failure rate) 저장.
+3. Roll back: 이전 stable tag로 재배포하고 consumer group health를 확인.
+4. Verify recovery: 최소 E2E smoke (`tests/e2e/test_ordering.py`, `tests/e2e/test_process_recovery.py` 기준 항목)와 운영 메트릭 정상화 확인.
+5. Communicate: 영향 범위/롤백 시각/현재 상태를 릴리스 이슈 및 인시던트 채널에 공유.
+6. Follow-up: 문제 릴리스는 hotfix 계획이 확정될 때까지 재배포 금지.
+
+## Release Incident Response
+1. Detect & declare: 릴리스 직후 이상 징후 감지 시 incident owner를 지정하고 상태를 `investigating`으로 선언.
+2. Triage: 재현 가능성, 데이터 영향도, 롤백 필요성(yes/no), 임시 완화책을 15분 단위로 업데이트.
+3. Decide path:
+   - 빠른 완화 가능: hotfix 브랜치 + 검증 후 재배포
+   - 완화 불가 또는 영향 큼: 즉시 롤백 runbook 실행
+4. Document timeline: 탐지/판단/조치 시점을 릴리스 이슈 코멘트와 후속 postmortem 초안에 남김.
+5. Exit criteria: lag/gap/failure 지표가 정상 범위로 회복되고, 재발 방지 액션 아이템이 생성되면 incident 종료.
+
 ## Observability & Alerts
 - **Backpressure**: `consumer_backpressure_active == 1` for >1 minute → alert; check `max_in_flight` and queue depth.
 - **Lag/Gap**: `consumer_parallel_lag` or `consumer_gap_count` growing for 5m → investigate stuck offsets, slow workers.

--- a/docs/operations/release-readiness.md
+++ b/docs/operations/release-readiness.md
@@ -42,10 +42,11 @@
   - Evidence: release build 절차가 문서화되고 `twine check` 대상이 fresh artifact로 고정된다.
   - Owner hint: `CHANGELOG.md`, release workflow/commands, `GEMINI.md`
 
-- [ ] **보안 연락 경로와 책임 명시**
+- [x] **보안 연락 경로와 책임 명시**
   - What: 공개 이슈가 아닌 보안 제보 채널과 응답 기대치를 문서화한다.
   - Evidence: `SECURITY.md` 존재, README/저장소 표면에서 쉽게 찾을 수 있다.
-  - Owner hint: `SECURITY.md`
+  - Evidence link: `README.md`, `README.ko.md`의 `SECURITY.md` 직링크 + `SECURITY.md`
+  - Owner hint: `SECURITY.md`, `README*`
 
 ## P1: Stable 직전 권장
 
@@ -54,14 +55,16 @@
   - Evidence: soak 시나리오 문서와 결과 기록, 반복 가능한 명령 또는 workflow.
   - Owner hint: `benchmarks/`, `tests/e2e/`, `docs/operations/playbooks.md`
 
-- [ ] **지원 범위와 호환성 정책 문서화**
+- [x] **지원 범위와 호환성 정책 문서화**
   - What: 지원 Python 버전, Kafka 브로커/클라이언트 호환 범위, deprecation policy를 정의한다.
   - Evidence: 문서에 compatibility/support section이 생기고 릴리스 노트에서 참조된다.
-  - Owner hint: `README*`, `SECURITY.md`, dedicated support doc
+  - Evidence link: `docs/operations/support-policy.md`, `README.md`, `README.ko.md`
+  - Owner hint: `README*`, `SECURITY.md`, `docs/operations/support-policy.md`
 
-- [ ] **업그레이드/롤백 가이드 추가**
+- [x] **업그레이드/롤백 가이드 추가**
   - What: alpha 사용자 또는 이전 버전 사용자가 stable로 올릴 때 확인할 설정/동작 차이를 안내한다.
   - Evidence: upgrade/rollback 섹션 또는 별도 운영 문서.
+  - Evidence link: `docs/operations/playbooks.md`의 `Release Rollback Runbook`/`Release Incident Response`
   - Owner hint: `docs/operations/*`, `CHANGELOG.md`
 
 - [ ] **성능 회귀 기준선 고정**

--- a/docs/operations/release-readiness.md
+++ b/docs/operations/release-readiness.md
@@ -16,9 +16,10 @@
 
 ## P0: Stable 승격 전 필수
 
-- [ ] **알파 메타데이터 제거**
+- [x] **알파 메타데이터 제거**
   - What: `version`, classifier, README release policy가 stable 상태와 일치해야 한다.
-  - Evidence: `pyproject.toml`에서 alpha classifier 제거, stable 버전 반영, README 정책 문구 수정.
+  - Evidence: `pyproject.toml`에서 alpha classifier 제거, stable 버전(`1.0.0`) 반영, README 정책 문구 수정.
+  - Evidence link: GitHub [#33](https://github.com/tomorrow9913/Pyrallel-Consumer/issues/33), PR 링크는 생성 후 추가.
   - Owner hint: `pyproject.toml`, `README.md`, `README.ko.md`
 
 - [ ] **핵심 public contract 동결**
@@ -118,9 +119,9 @@ UV_CACHE_DIR=.uv-cache uv run twine check dist/pyrallel_consumer-*
 
 ## Current Assessment Snapshot
 
-- 현재 상태는 **hardening된 alpha**로 보는 것이 맞다.
+- 현재 상태는 **stable metadata/posture(`1.0.0`)가 반영된 릴리스 라인**으로 본다.
 - `key_hash`/`partition` ordering에 더해 process mode의 retry, DLQ, in-flight rebalance, restart/offset continuity에 대한 실브로커 E2E도 확보됐다.
-- 당장 stable 승격을 막는 핵심은 이제 `알파 메타데이터`, `남은 public contract 결정`, 그리고 P1 성격의 장시간/운영 성숙도 검증 쪽에 더 가깝다.
+- 남은 안정화 핵심은 `남은 public contract 결정`, 그리고 P1 성격의 장시간/운영 성숙도 검증 쪽에 더 가깝다.
 - 이번 라운드에서는 process recovery 경로의 실브로커 증거를 확보했고, 이후 라운드는 문서 정책 정리와 release gate 정밀화에 집중하면 된다.
 
 ## Type Ignore Inventory Snapshot

--- a/docs/operations/release-readiness.md
+++ b/docs/operations/release-readiness.md
@@ -19,7 +19,7 @@
 - [x] **알파 메타데이터 제거**
   - What: `version`, classifier, README release policy가 stable 상태와 일치해야 한다.
   - Evidence: `pyproject.toml`에서 alpha classifier 제거, stable 버전(`1.0.0`) 반영, README 정책 문구 수정.
-  - Evidence link: GitHub [#33](https://github.com/tomorrow9913/Pyrallel-Consumer/issues/33), PR 링크는 생성 후 추가.
+  - Evidence link: GitHub [#33](https://github.com/tomorrow9913/Pyrallel-Consumer/issues/33), PR [#38](https://github.com/tomorrow9913/Pyrallel-Consumer/pull/38)
   - Owner hint: `pyproject.toml`, `README.md`, `README.ko.md`
 
 - [ ] **핵심 public contract 동결**

--- a/docs/operations/support-policy.md
+++ b/docs/operations/support-policy.md
@@ -1,0 +1,37 @@
+# Support & Compatibility Policy
+
+이 문서는 stable 운영 기준의 지원 범위와 호환성/폐기 정책을 정의한다.
+
+## Supported Release Lines
+
+| Release line | Support status | Notes |
+| --- | --- | --- |
+| `1.x` (latest stable) | Active support | security fix/bugfix 대상 |
+| `0.1.xa*` prerelease | Best effort | API/behavior compatibility 미보장 |
+
+- `1.x`는 운영 기준 primary support line이다.
+- prerelease는 실험/검증 목적이며, patch 제공이나 strict SLA를 보장하지 않는다.
+
+## Runtime Compatibility Scope
+
+- Python: package metadata 기준 `>=3.12` (현재 classifier: `3.12`, `3.13`)
+- Kafka broker/client: 프로젝트의 Docker/CI 기반 E2E 경로(`localhost:9092` 기준)를 compatibility baseline으로 간주
+- Baseline 밖 조합(다른 배포판, 구버전 broker/client 조합)은 best-effort로 취급
+
+## Security Support
+
+- 보안 제보 채널과 응답 목표는 [`SECURITY.md`](../../SECURITY.md)를 따른다.
+- 보안 수정은 원칙적으로 active stable line(`1.x`)에 우선 제공한다.
+- prerelease line에 대한 보안 백포트는 case-by-case best-effort다.
+
+## Deprecation & EOL Policy
+
+- stable line에서 breaking change가 필요한 경우, 다음 minor/major 계획과 migration note를 `CHANGELOG.md`에 사전 공지한다.
+- deprecation은 최소 한 번의 stable minor window 동안 경고/문서 안내를 유지한 후 제거를 검토한다.
+- line EOL 시점에는 릴리스 노트/README에 종료 일정을 명시하고 대체 line으로의 업그레이드 경로를 제공한다.
+
+## Support Expectations
+
+- 일반 운영 이슈: 재현 정보 기준으로 우선순위를 분류해 triage한다.
+- 릴리스 인시던트/롤백 절차는 [`playbooks.md`](./playbooks.md)를 따른다.
+- 릴리스 승인 전 체크는 [`release-readiness.md`](./release-readiness.md) 증거 항목 기준으로 판단한다.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
 [project]
 authors = [{name = "Pyrallel Consumer Authors"}]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
@@ -49,7 +49,7 @@ license-files = ["LICENSE"]
 name = "pyrallel-consumer"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.1.2a2"
+version = "1.0.0"
 
 [project.urls]
 Documentation = "https://github.com/tomorrow9913/Pyrallel-Consumer#readme"

--- a/uv.lock
+++ b/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "pyrallel-consumer"
-version = "0.1.2a2"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
- promote package metadata to stable posture (`1.0.0`, `Development Status :: 5 - Production/Stable`)
- align English/Korean README release policy and support policy with the stable line
- add a `1.0.0` changelog narrative + migration notes
- mark P0 metadata item as done in release-readiness checklist and reference GH #33

## Validation
- `UV_CACHE_DIR=.uv-cache uv run pytest tests/unit/test_config.py -q`
- `UV_CACHE_DIR=.uv-cache uv run --with build python -m build --outdir dist/release-1.0.0`
- `UV_CACHE_DIR=.uv-cache uv run twine check dist/release-1.0.0/*`

Closes #33