### PR TITLE
[GH-35] broker-backed E2E release gate hardening

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,9 +42,12 @@ jobs:
           GF_SECURITY_ADMIN_PASSWORD: local-e2e
         run: |
           docker compose -f .github/e2e.compose.yml up -d kafka-1
+      - name: Sync locked dependencies
+        run: |
+          uv sync --frozen --group dev
       - name: Wait for Kafka readiness
         run: |
-          python - <<'PY'
+          uv run python - <<'PY'
           import time
 
           from confluent_kafka.admin import AdminClient
@@ -62,9 +65,6 @@ jobs:
               "Kafka did not become metadata-ready on localhost:9092 within 60 seconds"
           )
           PY
-      - name: Sync locked dependencies
-        run: |
-          uv sync --frozen --group dev
       - name: Run E2E tests
         env:
           PYRALLEL_E2E_REQUIRE_BROKER: "1"

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,4 +1,4 @@
-name: e2e
+name: release-verify
 
 on:
   push:
@@ -9,16 +9,7 @@ on:
       - "uv.lock"
       - "docker-compose.yml"
       - ".github/e2e.compose.yml"
-      - ".github/workflows/e2e.yml"
-  pull_request:
-    branches: [main, develop]
-    types: [opened, reopened, ready_for_review, synchronize]
-    paths:
-      - "**/*.py"
-      - "pyproject.toml"
-      - "uv.lock"
-      - "docker-compose.yml"
-      - ".github/e2e.compose.yml"
+      - ".github/workflows/release-verify.yml"
       - ".github/workflows/e2e.yml"
   workflow_dispatch:
 
@@ -26,9 +17,9 @@ permissions:
   contents: read
 
 jobs:
-  e2e:
+  verify:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -37,20 +28,23 @@ jobs:
       - name: Install uv
         run: |
           python -m pip install --upgrade pip uv
-      - name: Start Kafka
+      - name: Sync locked dependencies
+        run: |
+          uv sync --frozen --group dev
+      - name: Start Kafka for broker-backed E2E gate
         env:
           GF_SECURITY_ADMIN_PASSWORD: local-e2e
         run: |
           docker compose -f .github/e2e.compose.yml up -d kafka-1
-      - name: Wait for Kafka readiness
+      - name: Wait for Kafka metadata readiness
         run: |
-          python - <<'PY'
+          uv run python - <<'PY'
           import time
 
           from confluent_kafka.admin import AdminClient
 
           client = AdminClient({"bootstrap.servers": "127.0.0.1:9092"})
-          deadline = time.time() + 60
+          deadline = time.time() + 90
           while time.time() < deadline:
               try:
                   metadata = client.list_topics(timeout=5)
@@ -59,24 +53,49 @@ jobs:
               except Exception:
                   time.sleep(1)
           raise SystemExit(
-              "Kafka did not become metadata-ready on localhost:9092 within 60 seconds"
+              "Kafka did not become metadata-ready on localhost:9092 within 90 seconds"
           )
           PY
-      - name: Sync locked dependencies
+      - name: Run Ruff
         run: |
-          uv sync --frozen --group dev
-      - name: Run E2E tests
+          uv run ruff check .
+      - name: Run mypy
+        run: |
+          uv run mypy pyrallel_consumer
+      - name: Run Bandit
+        run: |
+          uv run bandit -q -lll -r pyrallel_consumer
+      - name: Run unit tests
+        run: |
+          uv run pytest tests/unit -q --ignore=tests/unit/benchmarks --maxfail=1
+      - name: Run integration tests
+        run: |
+          uv run pytest tests/integration -q --maxfail=1
+      - name: Run broker-backed E2E tests (release gate)
         env:
           PYRALLEL_E2E_REQUIRE_BROKER: "1"
         run: |
           mkdir -p .artifacts
-          uv run pytest tests/e2e -q --maxfail=1 --junitxml=.artifacts/e2e-junit.xml
+          uv run pytest tests/e2e -q --maxfail=1 --junitxml=.artifacts/release-e2e-junit.xml
+      - name: Build distributions
+        run: |
+          rm -rf dist
+          uv build
+      - name: Check distribution metadata
+        run: |
+          uv run twine check dist/pyrallel_consumer-*
       - name: Upload broker-backed E2E report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-junit-${{ github.run_id }}
-          path: .artifacts/e2e-junit.xml
+          name: release-verify-e2e-junit-${{ github.run_id }}
+          path: .artifacts/release-e2e-junit.xml
+      - name: Upload distributions
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/*
       - name: Stop Kafka
         if: always()
         env:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,9 @@
 # Pyrallel Consumer - 개발 현황 및 인수인계 문서
 
-*최종 업데이트: 2026년 3월 27일 금요일*
+*최종 업데이트: 2026년 4월 17일 금요일*
+
+## 최근 업데이트 (2026-04-17)
+- Release gate evidence 문서 보강 (2026-04-17): QA 변경요청에 따라 `docs/operations/release-readiness.md`의 P0 구간에 `P0/E2E Gate (broker-backed release gate)` 라인을 추가했습니다. fresh evidence로 `e2e` run/artifact(`https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725840`, `https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725840/artifacts/6488389048`)와 `release-verify` run/artifact(`https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725833`, `https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725833/artifacts/6488394673`)를 고정 집계했고, `Run broker-backed E2E tests (release gate)` step success 확인 근거를 함께 명시했습니다.
 
 ## 최근 업데이트 (2026-03-27)
 - Release prep (2026-03-27): PyPI prerelease를 `0.1.2a1`에서 `0.1.2a2`로 올리기 위해 `pyproject.toml`과 `uv.lock`의 package version을 갱신했고, README/README.ko의 release policy 문구도 `0.1.2a2` 기준으로 맞췄습니다. release artifact는 `PATH=".venv/bin:$PATH" python -m build --no-isolation --outdir dist/release-0.1.2a2`로 fresh sdist/wheel을 만들었고, `PATH=".venv/bin:$PATH" twine check dist/release-0.1.2a2/*`도 모두 PASSED였습니다.

--- a/docs/operations/release-readiness.md
+++ b/docs/operations/release-readiness.md
@@ -31,6 +31,16 @@
   - Evidence: `tests/e2e/test_ordering.py`와 `tests/e2e/test_process_recovery.py`에서 process mode 실브로커 E2E가 통과한다.
   - Owner hint: `tests/e2e/`, `.github/workflows/e2e.yml`
 
+- [x] **P0/E2E Gate (broker-backed release gate)**
+  - What: 릴리스 경로에서 broker-backed E2E가 skip 없이 실행되고, run/artifact 증거가 문서에 고정 집계되어야 한다.
+  - Evidence: `e2e` run/artifact + `release-verify` run/artifact를 함께 기록하고, `Run broker-backed E2E tests (release gate)` step success를 확인한다.
+  - Fresh evidence (2026-04-17):
+    - `e2e` run: https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725840
+    - `e2e` artifact: https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725840/artifacts/6488389048
+    - `release-verify` run: https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725833
+    - `release-verify` artifact: https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725833/artifacts/6488394673
+  - Owner hint: `.github/workflows/e2e.yml`, `.github/workflows/release-verify.yml`, `docs/operations/release-readiness.md`
+
 - [ ] **CI quality gate 강화**
   - What: 최소한 lint/type/security/build/artifact check가 PR과 push에서 자동으로 검증돼야 한다.
   - Evidence: GitHub Actions가 `ruff`, `mypy`, `bandit`, `uv build`, `twine check`를 수행한다.

--- a/tests/e2e/test_ordering.py
+++ b/tests/e2e/test_ordering.py
@@ -1,6 +1,7 @@
 # tests/e2e/test_ordering.py
 import asyncio
 import json
+import os
 import random
 import sys
 import time
@@ -31,6 +32,9 @@ E2E_ENABLE_AUTO_COMMIT = False
 
 
 def _require_kafka() -> None:
+    strict_ci_gate = os.environ.get(
+        "PYRALLEL_E2E_REQUIRE_BROKER", ""
+    ).strip().lower() in {"1", "true", "yes", "on"}
     admin = AdminClient(
         {
             "bootstrap.servers": E2E_BOOTSTRAP_SERVERS,
@@ -38,9 +42,14 @@ def _require_kafka() -> None:
         }
     )
     try:
-        admin.list_topics(timeout=3)
+        metadata = admin.list_topics(timeout=5)
+        if not getattr(metadata, "brokers", None):
+            raise RuntimeError("Kafka metadata response did not include broker entries")
     except Exception as exc:
-        pytest.skip(f"Kafka broker not available for e2e tests: {exc}")
+        message = f"Kafka broker not available for e2e tests: {exc}"
+        if strict_ci_gate:
+            pytest.fail(message)
+        pytest.skip(message)
 
 
 # --- Result Verification Helper ---

--- a/tests/e2e/test_process_recovery.py
+++ b/tests/e2e/test_process_recovery.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import time
 import uuid
 from collections import Counter
@@ -33,6 +34,9 @@ E2E_CONF = {
 
 
 def _require_kafka() -> None:
+    strict_ci_gate = os.environ.get(
+        "PYRALLEL_E2E_REQUIRE_BROKER", ""
+    ).strip().lower() in {"1", "true", "yes", "on"}
     admin = AdminClient(
         {
             "bootstrap.servers": BOOTSTRAP_SERVERS,
@@ -40,9 +44,14 @@ def _require_kafka() -> None:
         }
     )
     try:
-        admin.list_topics(timeout=3)
+        metadata = admin.list_topics(timeout=5)
+        if not getattr(metadata, "brokers", None):
+            raise RuntimeError("Kafka metadata response did not include broker entries")
     except Exception as exc:
-        pytest.skip(f"Kafka broker not available for recovery e2e tests: {exc}")
+        message = f"Kafka broker not available for recovery e2e tests: {exc}"
+        if strict_ci_gate:
+            pytest.fail(message)
+        pytest.skip(message)
 
 
 class _BlockingPartitionWorker:


### PR DESCRIPTION
## Summary
- enforce broker-backed readiness in `.github/workflows/e2e.yml` using metadata probe
- add strict broker requirement (`PYRALLEL_E2E_REQUIRE_BROKER=1`) in CI e2e paths
- add `.github/workflows/release-verify.yml` release-path gate including broker-backed E2E
- fail (not skip) e2e broker checks in tests when strict env is enabled
- upload junit artifacts for broker-backed e2e evidence

## Validation
- e2e (green): https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725840
- release-verify (green): https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725833
