### PR TITLE
docs(operations): clarify process-mode metrics guidance

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -446,6 +446,7 @@ docker compose up -d
 - 예시 쿼리: `consumer_processed_total`, `consumer_processing_latency_seconds_bucket`, `consumer_in_flight_count`.
 - process batch 관측 예시: `consumer_process_batch_flush_count{reason="timer"}`, `consumer_process_batch_avg_size`, `consumer_process_batch_buffered_age_seconds`.
 - process timing 분해 예시: `consumer_process_batch_avg_main_to_worker_ipc_seconds`, `consumer_process_batch_avg_worker_exec_seconds`, `consumer_process_batch_avg_worker_to_main_ipc_seconds`.
+- 위 process-mode 메트릭의 해석 기준과 운영자 대응 흐름은 `docs/operations/guide.ko.md`, `docs/operations/guide.en.md`를 기준 문서로 사용하십시오.
 
 ## 🤝 기여하기
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,10 @@ docker compose up -d
 - `consumer_process_batch_avg_worker_exec_seconds`
 - `consumer_process_batch_avg_worker_to_main_ipc_seconds`
 
+Interpretation and operator actions for these metrics live in:
+- `docs/operations/guide.en.md`
+- `docs/operations/guide.ko.md`
+
 ## 🤝 Contributing
 
 All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

--- a/docs/operations/guide.en.md
+++ b/docs/operations/guide.en.md
@@ -26,7 +26,48 @@ Kafka's default Lag (`LogEndOffset - CommittedOffset`) alone cannot accurately r
 - **Meaning**: Represents the current system load.
 - **Tip**: When this value reaches the `max_in_flight` setting, **Backpressure** activates, and Kafka consumption is `Paused`.
 
-### 1.5. Engine Capability Boundary
+### 1.5. Process Batch Flush Count
+- **Prometheus query**: `consumer_process_batch_flush_count{reason="size|timer|close|demand"}`
+- **Meaning**:
+    - `size`: batches are reaching the configured batch size and flushing efficiently.
+    - `timer`: input is sparse or `max_batch_wait_ms` is expiring before the batch fills.
+    - `demand`: the active flush policy is force-flushing buffered work before the normal size/timer path.
+    - `close`: buffered work was flushed during shutdown or rebalance cleanup.
+- **Tip**:
+    - If `timer` dominates and `consumer_process_batch_avg_size` stays low, batching efficiency is poor. Reduce `batch_size` or increase `max_batch_wait_ms` only if the latency budget allows it.
+    - If `demand` keeps growing, the workload is spending more time on latency-first forced flushes than on full batches. Revisit `flush_policy`, `demand_flush_min_residence_ms`, `process_count`, and ordering skew together.
+
+### 1.6. Process Batch Buffer Health
+- **Prometheus queries**:
+    - `consumer_process_batch_avg_size`
+    - `consumer_process_batch_last_size`
+    - `consumer_process_batch_last_wait_seconds`
+    - `consumer_process_batch_buffered_items`
+    - `consumer_process_batch_buffered_age_seconds`
+- **Meaning**:
+    - `avg/last_size` show real micro-batch efficiency.
+    - `last_wait_seconds` and `buffered_age_seconds` show how long work sat before flush.
+    - `buffered_items` means work is still accumulating in the main-process batch buffer and has not reached worker queues yet.
+- **Tip**:
+    - If `buffered_items` and `buffered_age_seconds` rise together, the bottleneck is before worker execution, in the batching handoff path. Interpret them together with `consumer_in_flight_count`, `consumer_backpressure_active`, and `consumer_internal_queue_depth`.
+    - If `last_size` stays around 1-2 while `last_wait_seconds` keeps climbing, the producer rate is sparse or the batch policy is oversized for this workload.
+
+### 1.7. IPC / Worker Timing Split
+- **Prometheus queries**:
+    - `consumer_process_batch_avg_main_to_worker_ipc_seconds`
+    - `consumer_process_batch_avg_worker_exec_seconds`
+    - `consumer_process_batch_avg_worker_to_main_ipc_seconds`
+    - Inspect the matching `last_*` gauges when you need the most recent sample.
+- **Meaning**:
+    - `main_to_worker`: serialization plus task-queue transfer cost.
+    - `worker_exec`: actual user-worker execution time.
+    - `worker_to_main`: completion transfer cost back into the main process.
+- **Tip**:
+    - High `main_to_worker` alone points to payload size, pickle cost, or queue pressure.
+    - High `worker_exec` alone points to CPU saturation or slow handler logic; tune `process_count`, optimize the worker, or tighten timeout/DLQ policy.
+    - High `worker_to_main` with rising `buffered_items` or `total_in_flight` suggests completion drain is lagging. Check main-process load, completion polling cadence, and overly chatty logging/metrics loops.
+
+### 1.8. Engine Capability Boundary
 - **Definition**: The control plane only depends on the shared execution-engine contract.
 - **Meaning**: Process-only safety data such as minimum in-flight offsets should be exposed as an optional engine capability, not by branching on a concrete engine class inside `BrokerPoller`.
 - **Tip**: When validating refactors, run the same control-plane checks against async and process engines (or mocks) to confirm the boundary stays polymorphic.
@@ -56,6 +97,17 @@ Kafka's default Lag (`LogEndOffset - CommittedOffset`) alone cannot accurately r
 ### 3.2. Frequent Rebalancing
 - Increase `max_poll_interval_ms`. With parallel processing, individual message processing might be delayed, causing the Kafka broker to assume the consumer is dead.
 - Use `max_revoke_grace_ms` to ensure cleanup time during rebalancing.
+
+### 3.3. Low throughput with growing lag in process mode
+1. Inspect `consumer_process_batch_flush_count{reason="timer"}` together with `consumer_process_batch_avg_size`.
+2. If timer-driven flushes dominate and average batch size is small, batching efficiency is poor. Reduce `batch_size` or increase `max_batch_wait_ms` within your latency budget.
+3. If batch size looks healthy but `consumer_process_batch_avg_main_to_worker_ipc_seconds` is high, the bottleneck is payload serialization or IPC pressure. Check message size, serialization cost, and `queue_size`.
+4. If IPC looks normal but `consumer_process_batch_avg_worker_exec_seconds` is high, the worker logic is the bottleneck. Check CPU saturation, downstream I/O, and timeout/DLQ behavior.
+
+### 3.4. Repeating queue/backpressure oscillation in process mode
+1. Inspect `consumer_backpressure_active`, `consumer_in_flight_count`, and `consumer_process_batch_buffered_items` together.
+2. If `buffered_items` and `consumer_internal_queue_depth` are both high, the main batch buffer and partition queues are backing up together. Revisit `max_in_flight_messages`, `queue_size`, and ordering skew.
+3. If `buffered_items` stays low but `worker_to_main_ipc_seconds` is high, completion draining may be the bottleneck. Check main-process load and completion polling cadence.
 
 ## 4. Monitoring Dashboard (Grafana Recommended)
 
@@ -90,6 +142,20 @@ Assuming `get_metrics()` results are collected via Prometheus, the following pan
     - Type: Bar Gauge
     - Query: `consumer_internal_queue_depth`
     - Insight: Checks the backlog status of virtual partition queues.
+
+### 4.4. Process Mode Health (Row)
+- **Flush Reason Mix**:
+    - Type: Time Series
+    - Query: `consumer_process_batch_flush_count`
+    - Insight: In steady state, `size` should usually dominate while `timer` and `demand` remain secondary. A `timer`-heavy mix means small batches; a `demand`-heavy mix means frequent forced flushes.
+- **Batch Efficiency**:
+    - Type: Time Series
+    - Query: `consumer_process_batch_avg_size`, `consumer_process_batch_last_size`, `consumer_process_batch_buffered_age_seconds`
+    - Insight: Falling batch size plus rising buffered age usually means the current batching policy does not match the workload.
+- **IPC vs Worker Time Split**:
+    - Type: Time Series
+    - Query: `consumer_process_batch_avg_main_to_worker_ipc_seconds`, `consumer_process_batch_avg_worker_exec_seconds`, `consumer_process_batch_avg_worker_to_main_ipc_seconds`
+    - Insight: Split these three values to quickly decide whether the bottleneck is serialization/IPC, worker execution, or completion draining.
 
 ---
 © 2026 Pyrallel Consumer Project

--- a/docs/operations/guide.ko.md
+++ b/docs/operations/guide.ko.md
@@ -26,7 +26,48 @@ Kafka의 기본 Lag(`LogEndOffset - CommittedOffset`)만으로는 병렬 처리 
 - **의미**: 시스템 부하 상태를 나타냅니다.
 - **운영 팁**: 이 값이 `max_in_flight` 설정값에 도달하면 **Backpressure**가 동작하여 Kafka 소비를 일시 중지(`Pause`)합니다.
 
-### 1.5. Engine Capability Boundary (엔진 capability 경계)
+### 1.5. Process Batch Flush Count (process 배치 flush 이유)
+- **Prometheus 쿼리**: `consumer_process_batch_flush_count{reason="size|timer|close|demand"}`
+- **의미**:
+    - `size`: 배치 크기가 설정값에 도달해 정상적으로 묶여 전송되었습니다.
+    - `timer`: 입력이 느리거나 `max_batch_wait_ms`가 먼저 도달해 작은 배치가 자주 전송되고 있습니다.
+    - `demand`: 현재 flush policy가 size/timer 경로보다 먼저 누적 버퍼를 강제로 비우고 있습니다.
+    - `close`: 종료나 rebalance 정리 과정에서 잔여 버퍼를 배출했습니다.
+- **운영 팁**:
+    - `timer` 비중이 높고 `consumer_process_batch_avg_size`가 낮으면 batching 효율이 떨어진 상태입니다. 지연 예산이 허용하면 `batch_size`를 낮추거나 `max_batch_wait_ms`를 늘리는 쪽을 검토하십시오.
+    - `demand`가 계속 증가하면 latency-first 강제 flush가 많다는 뜻입니다. `flush_policy`, `demand_flush_min_residence_ms`, `process_count`, ordering skew를 함께 확인하십시오.
+
+### 1.6. Process Batch Buffer Health (버퍼 적체 상태)
+- **Prometheus 쿼리**:
+    - `consumer_process_batch_avg_size`
+    - `consumer_process_batch_last_size`
+    - `consumer_process_batch_last_wait_seconds`
+    - `consumer_process_batch_buffered_items`
+    - `consumer_process_batch_buffered_age_seconds`
+- **의미**:
+    - `avg/last_size`는 실제 micro-batch 효율을 보여줍니다.
+    - `last_wait_seconds`와 `buffered_age_seconds`는 flush 전 대기 시간을 보여줍니다.
+    - `buffered_items`가 높으면 아직 worker queue로 내려가지 못한 작업이 main process 버퍼에 쌓여 있다는 뜻입니다.
+- **운영 팁**:
+    - `buffered_items`와 `buffered_age_seconds`가 같이 증가하면 process-mode 진입 이전(main thread batching 단계)에서 적체가 발생한 것입니다. `queue_size`만 보기보다 `consumer_in_flight_count`, `consumer_backpressure_active`, `consumer_internal_queue_depth`와 함께 해석하십시오.
+    - `last_size`가 계속 1~2 수준이고 `last_wait_seconds`만 늘어나면 producer 입력이 듬성듬성하거나, 배치 정책이 현재 workload에 비해 과하게 큽니다.
+
+### 1.7. IPC / Worker Timing Split (IPC와 워커 실행 시간 분해)
+- **Prometheus 쿼리**:
+    - `consumer_process_batch_avg_main_to_worker_ipc_seconds`
+    - `consumer_process_batch_avg_worker_exec_seconds`
+    - `consumer_process_batch_avg_worker_to_main_ipc_seconds`
+    - 필요 시 `last_*` gauge를 함께 확인
+- **의미**:
+    - `main_to_worker`: 직렬화 + task queue 전달 비용입니다.
+    - `worker_exec`: 실제 사용자 worker 코드 실행 시간입니다.
+    - `worker_to_main`: completion payload를 main process가 회수하는 비용입니다.
+- **운영 팁**:
+    - `main_to_worker`만 높으면 payload가 크거나 pickle/IPC 비용이 병목입니다. batch payload 크기, message size, queue saturation을 점검하십시오.
+    - `worker_exec`만 높으면 CPU saturation 또는 느린 사용자 로직 문제입니다. `process_count` 증설, worker 최적화, timeout/DLQ 정책 점검이 우선입니다.
+    - `worker_to_main`이 높고 `buffered_items`나 `total_in_flight`도 높으면 completion drain이 밀리고 있을 가능성이 큽니다. main process 부하, completion polling cadence, 과도한 로그/metrics 갱신 빈도를 확인하십시오.
+
+### 1.8. Engine Capability Boundary (엔진 capability 경계)
 - **정의**: Control Plane은 공통 실행 엔진 계약에만 의존합니다.
 - **의미**: 최소 in-flight offset 같은 Process 전용 안전 정보는 `BrokerPoller` 내부의 구체 클래스 분기 대신, 선택적 엔진 capability로 노출되어야 합니다.
 - **운영 팁**: 리팩터링 검증 시 async/process 엔진(또는 mock) 모두에 동일한 control-plane 검증을 적용해 polymorphic 경계가 유지되는지 확인하십시오.
@@ -56,6 +97,17 @@ Kafka의 기본 Lag(`LogEndOffset - CommittedOffset`)만으로는 병렬 처리 
 ### 3.2. 리밸런싱이 너무 잦을 때
 - `max_poll_interval_ms`를 늘리십시오. 병렬 처리로 인해 개별 메시지 처리가 늦어지면 Kafka 브로커가 컨슈머를 죽은 것으로 오해할 수 있습니다.
 - `max_revoke_grace_ms` 설정을 통해 리밸런싱 시 정리 시간을 확보하십시오.
+
+### 3.3. Process-mode에서 처리량은 낮고 lag만 늘어날 때
+1. `consumer_process_batch_flush_count{reason="timer"}`와 `consumer_process_batch_avg_size`를 같이 보십시오.
+2. `timer` flush가 지배적이고 평균 배치가 작으면 batching 비효율입니다. latency budget 안에서 `batch_size`를 낮추거나 `max_batch_wait_ms`를 늘리십시오.
+3. 배치 크기는 충분한데 `consumer_process_batch_avg_main_to_worker_ipc_seconds`가 높으면 payload/IPC 비용이 병목입니다. message size, serialization 비용, `queue_size` 포화를 먼저 확인하십시오.
+4. IPC는 정상인데 `consumer_process_batch_avg_worker_exec_seconds`만 높으면 worker 로직이 병목입니다. CPU saturation, 외부 I/O, timeout/DLQ를 점검하십시오.
+
+### 3.4. Process-mode에서 queue/backpressure가 반복될 때
+1. `consumer_backpressure_active`, `consumer_in_flight_count`, `consumer_process_batch_buffered_items`를 같이 보십시오.
+2. `buffered_items`와 `consumer_internal_queue_depth`가 동시에 높으면 main buffer와 partition queue가 함께 밀리는 상태입니다. `max_in_flight_messages`, `queue_size`, ordering skew를 점검하십시오.
+3. `buffered_items`는 낮은데 `worker_to_main_ipc_seconds`만 높으면 completion 회수가 병목일 수 있습니다. main process 부하와 polling cadence를 점검하십시오.
 
 ## 4. 모니터링 대시보드 (Grafana 권장)
 
@@ -90,6 +142,20 @@ Kafka의 기본 Lag(`LogEndOffset - CommittedOffset`)만으로는 병렬 처리 
     - Type: Bar Gauge
     - Query: `consumer_internal_queue_depth`
     - Insight: 가상 파티션 큐의 백로그 상태를 확인합니다.
+
+### 4.4. Process Mode Health (Row)
+- **Flush Reason Mix**:
+    - Type: Time Series
+    - Query: `consumer_process_batch_flush_count`
+    - Insight: steady-state에서 `size`가 주도하고 `timer`/`demand`는 보조적으로 나타나는 편이 일반적입니다. `timer` 편중은 작은 배치, `demand` 편중은 잦은 강제 배출 신호입니다.
+- **Batch Efficiency**:
+    - Type: Time Series
+    - Query: `consumer_process_batch_avg_size`, `consumer_process_batch_last_size`, `consumer_process_batch_buffered_age_seconds`
+    - Insight: 평균 배치 크기 하락과 버퍼 age 상승이 동시에 보이면 batching 정책이 workload와 맞지 않는 경우가 많습니다.
+- **IPC vs Worker Time Split**:
+    - Type: Time Series
+    - Query: `consumer_process_batch_avg_main_to_worker_ipc_seconds`, `consumer_process_batch_avg_worker_exec_seconds`, `consumer_process_batch_avg_worker_to_main_ipc_seconds`
+    - Insight: 세 값을 분리해서 보면 병목이 serialization/IPC인지, 실제 worker 실행인지, completion 회수인지 빠르게 구분할 수 있습니다.
 
 ---
 © 2026 Pyrallel Consumer Project


### PR DESCRIPTION
## Summary
- Adds process-mode metric examples to README monitoring guidance
- Expands operations guide guidance for batch flush reasons, buffer health, IPC timing, and process-mode troubleshooting
- Keeps the completed MQU-219 docs change isolated on top of current `origin/develop`

## Validation
- `git diff --check origin/develop...HEAD`
- `uv run pytest tests/unit/metrics/test_monitoring_assets.py -q` (`4 passed`)

## Notes
- Created from a clean isolated worktree to avoid including unrelated dirty changes from the primary checkout.
- Draft PR opened for remote review/merge per branch-cleanup workflow.