### PR TITLE
docs(operations): fix process flush PromQL query

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,9 @@
 # Pyrallel Consumer - 개발 현황 및 인수인계 문서
 
-*최종 업데이트: 2026년 4월 17일 금요일*
+*최종 업데이트: 2026년 4월 20일 월요일*
+
+## 최근 업데이트 (2026-04-20)
+- PR #60 post-merge Codex review 후속 수정 (2026-04-20 KST): PR #60이 merge된 뒤 생성된 Codex review comment를 확인했고, `consumer_process_batch_flush_count{reason="size|timer|close|demand"}`가 PromQL exact-match라 정상 배포에서 빈 결과를 반환한다는 지적이 기술적으로 맞음을 검증했습니다. `docs/operations/guide.en.md`와 `docs/operations/guide.ko.md`의 process batch flush reason set 쿼리를 regex match(`reason=~"size|timer|close|demand"`)로 수정했고, `tests/unit/metrics/test_monitoring_assets.py::test_operations_guides_use_regex_for_process_flush_reason_set`로 영어/한국어 운영 가이드가 같은 계약을 유지하도록 고정했습니다. Copilot follow-up으로 한국어 가이드 파일을 읽는 테스트에는 `encoding="utf-8", errors="strict"`를 명시해 non-UTF-8 locale에서도 deterministic하게 실패/통과하도록 보강했습니다.
 
 ## 최근 업데이트 (2026-04-17)
 - Release gate evidence 문서 보강 (2026-04-17): QA 변경요청에 따라 `docs/operations/release-readiness.md`의 P0 구간에 `P0/E2E Gate (broker-backed release gate)` 라인을 추가했습니다. fresh evidence로 `e2e` run/artifact(`https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725840`, `https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725840/artifacts/6488389048`)와 `release-verify` run/artifact(`https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725833`, `https://github.com/tomorrow9913/Pyrallel-Consumer/actions/runs/24546725833/artifacts/6488394673`)를 고정 집계했고, `Run broker-backed E2E tests (release gate)` step success 확인 근거를 함께 명시했습니다.

--- a/docs/operations/guide.en.md
+++ b/docs/operations/guide.en.md
@@ -27,7 +27,7 @@ Kafka's default Lag (`LogEndOffset - CommittedOffset`) alone cannot accurately r
 - **Tip**: When this value reaches the `max_in_flight` setting, **Backpressure** activates, and Kafka consumption is `Paused`.
 
 ### 1.5. Process Batch Flush Count
-- **Prometheus query**: `consumer_process_batch_flush_count{reason="size|timer|close|demand"}`
+- **Prometheus query**: `consumer_process_batch_flush_count{reason=~"size|timer|close|demand"}`
 - **Meaning**:
     - `size`: batches are reaching the configured batch size and flushing efficiently.
     - `timer`: input is sparse or `max_batch_wait_ms` is expiring before the batch fills.

--- a/docs/operations/guide.ko.md
+++ b/docs/operations/guide.ko.md
@@ -27,7 +27,7 @@ Kafka의 기본 Lag(`LogEndOffset - CommittedOffset`)만으로는 병렬 처리 
 - **운영 팁**: 이 값이 `max_in_flight` 설정값에 도달하면 **Backpressure**가 동작하여 Kafka 소비를 일시 중지(`Pause`)합니다.
 
 ### 1.5. Process Batch Flush Count (process 배치 flush 이유)
-- **Prometheus 쿼리**: `consumer_process_batch_flush_count{reason="size|timer|close|demand"}`
+- **Prometheus 쿼리**: `consumer_process_batch_flush_count{reason=~"size|timer|close|demand"}`
 - **의미**:
     - `size`: 배치 크기가 설정값에 도달해 정상적으로 묶여 전송되었습니다.
     - `timer`: 입력이 느리거나 `max_batch_wait_ms`가 먼저 도달해 작은 배치가 자주 전송되고 있습니다.

--- a/tests/unit/metrics/test_monitoring_assets.py
+++ b/tests/unit/metrics/test_monitoring_assets.py
@@ -59,6 +59,24 @@ def test_grafana_dashboard_includes_process_batch_panels() -> None:
     assert "consumer_process_batch_avg_worker_to_main_ipc_seconds" in expressions
 
 
+def test_operations_guides_use_regex_for_process_flush_reason_set() -> None:
+    guide_paths = [
+        REPO_ROOT / "docs" / "operations" / "guide.en.md",
+        REPO_ROOT / "docs" / "operations" / "guide.ko.md",
+    ]
+
+    for guide_path in guide_paths:
+        guide_text = guide_path.read_text(encoding="utf-8", errors="strict")
+        assert (
+            'consumer_process_batch_flush_count{reason=~"size|timer|close|demand"}'
+            in guide_text
+        )
+        assert (
+            'consumer_process_batch_flush_count{reason="size|timer|close|demand"}'
+            not in guide_text
+        )
+
+
 def test_monitoring_ci_workflow_runs_prometheus_and_grafana_smoke_checks() -> None:
     workflow_text = (
         REPO_ROOT / ".github" / "workflows" / "ci_monitoring.yml"


### PR DESCRIPTION
## Summary
- Fixes the post-merge Codex review finding from PR #60: the process flush reason set query now uses PromQL regex matching with `reason=~"size|timer|close|demand"`.
- Updates both English and Korean operations guides.
- Adds a monitoring asset regression test so the guides do not regress to exact-match syntax.
- Records the follow-up in `GEMINI.md` per project handoff rules.

## Review Context
- PR #60 was merged at `2026-04-20T10:13:53Z`.
- The Codex review comment was created later at `2026-04-20T10:15:33Z`, so it was not visible before the merge.
- The comment is technically valid because `reason="size|timer|close|demand"` matches only a literal label value, not the four emitted flush reasons.

## Validation
- `uv run pytest tests/unit/metrics/test_monitoring_assets.py -q` (`5 passed`)
- `uv run ruff check tests/unit/metrics/test_monitoring_assets.py` (`All checks passed`)
- `git diff --check HEAD~1..HEAD`
- Commit pre-commit hooks passed with `.venv/bin` on `PATH` for `pylint`/`bandit`.