### PR TITLE
chore(MQU-40): reintroduce release governance helpers

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,105 @@
+name: publish-pypi
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        run: |
+          python -m pip install --upgrade pip uv
+      - name: Sync locked dependencies
+        run: |
+          uv sync --frozen --group dev
+      - name: Validate branch/version policy
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          uv run python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          from scripts.release_policy import validate_branch_version
+
+          branch = "${{ github.ref_name }}"
+          data = tomllib.loads(Path("pyproject.toml").read_text())
+          version = data["project"]["version"]
+
+          if branch == "develop":
+              raise SystemExit("publish-pypi is not allowed from develop in V1")
+
+          if not validate_branch_version(branch, version):
+              raise SystemExit(
+                  f"Branch/version policy mismatch: branch={branch!r} version={version!r}"
+              )
+          PY
+      - name: Validate canonical tag when present
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          uv run python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          from scripts.release_policy import validate_tag_version
+
+          ref_type = "${{ github.ref_type }}"
+          ref_name = "${{ github.ref_name }}"
+          if ref_type != "tag":
+              raise SystemExit(0)
+
+          data = tomllib.loads(Path("pyproject.toml").read_text())
+          version = data["project"]["version"]
+
+          if not validate_tag_version(ref_name, version):
+              raise SystemExit(
+                  f"Tag/version policy mismatch: tag={ref_name!r} version={version!r}"
+              )
+          PY
+      - name: Build distributions
+        run: |
+          rm -rf dist
+          uv build
+      - name: Resolve release artifacts (freshness gate)
+        id: release_artifacts
+        run: |
+          uv run python scripts/release_policy.py resolve-artifacts --write-github-output
+      - name: Check distribution metadata
+        run: |
+          uv run twine check \
+            "${{ steps.release_artifacts.outputs.sdist_path }}" \
+            "${{ steps.release_artifacts.outputs.wheel_path }}"
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: |
+            ${{ steps.release_artifacts.outputs.sdist_path }}
+            ${{ steps.release_artifacts.outputs.wheel_path }}
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/scripts/release_policy.py
+++ b/scripts/release_policy.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import tomllib
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+
+_BRANCH_RELEASE_RE = re.compile(r"^release/(?P<major>\d+)\.(?P<minor>\d+)$")
+_BRANCH_HOTFIX_RE = re.compile(
+    r"^hotfix/(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$"
+)
+_LINE_VERSION_RE = re.compile(
+    r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<label>a|b|rc)(?P<num>\d+)$"
+)
+_STABLE_VERSION_RE = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
+
+
+class PolicyError(ValueError):
+    pass
+
+
+def load_project_metadata(pyproject_path: str) -> tuple[str, str]:
+    data = tomllib.loads(Path(pyproject_path).read_text())
+    project = data.get("project")
+    if not isinstance(project, dict):
+        raise PolicyError(f"missing [project] metadata: {pyproject_path}")
+    name = project.get("name")
+    version = project.get("version")
+    if not isinstance(name, str) or not isinstance(version, str):
+        raise PolicyError(f"missing project name/version metadata: {pyproject_path}")
+    return name, version
+
+
+def _normalize_distribution_stem(project_name: str) -> str:
+    normalized = re.sub(r"[-_.]+", "_", project_name).lower()
+    if not normalized:
+        raise PolicyError("project name is empty after normalization")
+    return normalized
+
+
+def _is_distribution_file(path: Path) -> bool:
+    return path.suffix == ".whl" or path.name.endswith(".tar.gz")
+
+
+def resolve_release_artifacts(
+    dist_dir: str, project_name: str, version: str
+) -> tuple[str, str]:
+    dist_path = Path(dist_dir)
+    if not dist_path.is_dir():
+        raise PolicyError(f"distribution directory does not exist: {dist_dir}")
+
+    stem = _normalize_distribution_stem(project_name)
+    prefix = f"{stem}-{version}"
+    sdist_path = dist_path / f"{prefix}.tar.gz"
+    wheel_candidates = sorted(dist_path.glob(f"{prefix}-*.whl"))
+
+    if not sdist_path.is_file():
+        raise PolicyError(f"missing expected sdist artifact: {sdist_path}")
+    if len(wheel_candidates) != 1:
+        raise PolicyError(
+            f"expected exactly one wheel artifact for {prefix}, found {len(wheel_candidates)}"
+        )
+
+    wheel_path = wheel_candidates[0]
+    expected = {sdist_path.resolve(), wheel_path.resolve()}
+    all_dist_files = sorted(
+        candidate
+        for candidate in dist_path.glob(f"{stem}-*")
+        if candidate.is_file() and _is_distribution_file(candidate)
+    )
+    stale = [
+        candidate for candidate in all_dist_files if candidate.resolve() not in expected
+    ]
+    if stale:
+        stale_names = ", ".join(path.name for path in stale)
+        raise PolicyError(
+            f"stale distribution artifacts detected in {dist_dir}: {stale_names}"
+        )
+
+    return str(sdist_path), str(wheel_path)
+
+
+def emit_github_output(sdist_path: str, wheel_path: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        raise PolicyError(
+            "GITHUB_OUTPUT is required when --write-github-output is used"
+        )
+    with Path(output_path).open("a", encoding="utf-8") as handle:
+        handle.write(f"sdist_path={sdist_path}\n")
+        handle.write(f"wheel_path={wheel_path}\n")
+
+
+def classify_branch(branch: str) -> str:
+    if branch == "develop":
+        return "develop"
+    if branch == "main":
+        return "main"
+    if _BRANCH_RELEASE_RE.match(branch):
+        return "release"
+    if _BRANCH_HOTFIX_RE.match(branch):
+        return "hotfix"
+    raise PolicyError(f"unsupported branch: {branch}")
+
+
+def _parse_version(version: str) -> Version:
+    try:
+        return Version(version)
+    except InvalidVersion as exc:
+        raise PolicyError(f"invalid version: {version}") from exc
+
+
+def validate_branch_version(branch: str, version: str) -> bool:
+    kind = classify_branch(branch)
+    parsed = _parse_version(version)
+
+    if kind == "develop":
+        return parsed.is_prerelease and parsed.pre is not None and parsed.pre[0] == "a"
+    if kind == "main":
+        return not parsed.is_prerelease
+    if kind == "release":
+        match = _BRANCH_RELEASE_RE.match(branch)
+        assert match is not None
+        if (parsed.major, parsed.minor) != (
+            int(match.group("major")),
+            int(match.group("minor")),
+        ):
+            return False
+        return (
+            parsed.is_prerelease
+            and parsed.pre is not None
+            and parsed.pre[0] in {"b", "rc"}
+        )
+    if kind == "hotfix":
+        match = _BRANCH_HOTFIX_RE.match(branch)
+        assert match is not None
+        branch_major = int(match.group("major"))
+        branch_minor = int(match.group("minor"))
+        branch_patch = int(match.group("patch"))
+        return (
+            not parsed.is_prerelease
+            and (parsed.major, parsed.minor) == (branch_major, branch_minor)
+            and parsed.micro > branch_patch
+        )
+    return False
+
+
+def validate_tag_version(tag: str, version: str) -> bool:
+    _parse_version(version)
+    return tag == f"v{version}"
+
+
+def validate_pull_request_flow(base_branch: str, head_branch: str) -> bool:
+    """Validate git-flow pull-request routing.
+
+    Current hard gate:
+    - PRs into ``main`` are allowed only from ``release/x.y`` or ``hotfix/x.y.z``.
+    - Other supported base branches are not constrained at this layer.
+    """
+    base_kind = classify_branch(base_branch)
+    if base_kind != "main":
+        return True
+    return bool(_BRANCH_RELEASE_RE.match(head_branch)) or bool(
+        _BRANCH_HOTFIX_RE.match(head_branch)
+    )
+
+
+def _bump_line(version: str, expected_label: str) -> str:
+    match = _LINE_VERSION_RE.match(version)
+    if match is None:
+        raise PolicyError(f"version is not a valid prerelease line: {version}")
+    if match.group("label") != expected_label:
+        raise PolicyError(f"version does not use {expected_label!r}: {version}")
+    return (
+        f"{match.group('major')}.{match.group('minor')}.{match.group('patch')}"
+        f"{expected_label}{int(match.group('num')) + 1}"
+    )
+
+
+def bump_alpha(version: str) -> str:
+    return _bump_line(version, "a")
+
+
+def bump_beta(version: str) -> str:
+    return _bump_line(version, "b")
+
+
+def bump_rc(version: str) -> str:
+    return _bump_line(version, "rc")
+
+
+def bump_patch(version: str) -> str:
+    match = _STABLE_VERSION_RE.match(version)
+    if match is None:
+        raise PolicyError(f"version is not a stable patch line: {version}")
+    return (
+        f"{match.group('major')}.{match.group('minor')}.{int(match.group('patch')) + 1}"
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate release policy branch/tag rules."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    branch_parser = subparsers.add_parser("validate-branch-version")
+    branch_parser.add_argument("--branch", required=True)
+    branch_parser.add_argument("--version", required=True)
+
+    pr_flow_parser = subparsers.add_parser("validate-pr-flow")
+    pr_flow_parser.add_argument("--base-branch", required=True)
+    pr_flow_parser.add_argument("--head-branch", required=True)
+
+    tag_parser = subparsers.add_parser("validate-tag-version")
+    tag_parser.add_argument("--tag", required=True)
+    tag_parser.add_argument("--version", required=True)
+
+    artifacts_parser = subparsers.add_parser("resolve-artifacts")
+    artifacts_parser.add_argument("--dist-dir", default="dist")
+    artifacts_parser.add_argument("--project-file", default="pyproject.toml")
+    artifacts_parser.add_argument(
+        "--write-github-output",
+        action="store_true",
+        help="Write artifact paths to GITHUB_OUTPUT for GitHub Actions.",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "validate-branch-version":
+            is_valid = validate_branch_version(args.branch, args.version)
+            if is_valid:
+                print("OK")
+                return 0
+            print("INVALID")
+            return 1
+        if args.command == "validate-tag-version":
+            is_valid = validate_tag_version(args.tag, args.version)
+            if is_valid:
+                print("OK")
+                return 0
+            print("INVALID")
+            return 1
+        if args.command == "validate-pr-flow":
+            is_valid = validate_pull_request_flow(args.base_branch, args.head_branch)
+            if is_valid:
+                print("OK")
+                return 0
+            print("INVALID")
+            return 1
+
+        project_name, version = load_project_metadata(args.project_file)
+        sdist_path, wheel_path = resolve_release_artifacts(
+            args.dist_dir, project_name, version
+        )
+        print(sdist_path)
+        print(wheel_path)
+        if args.write_github_output:
+            emit_github_output(sdist_path, wheel_path)
+        return 0
+    except PolicyError as exc:
+        print(f"INVALID: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/role_b_preflight.py
+++ b/scripts/role_b_preflight.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import argparse
+import shlex
+
+# Uses subprocess to execute fixed local pytest commands.
+import subprocess  # nosec B404
+import sys
+from collections.abc import Callable, Sequence
+
+DEFAULT_TEST_TARGETS: tuple[str, ...] = (
+    "tests/unit/test_role_b_preflight.py",
+    "tests/unit/benchmarks/test_benchmark_runtime.py",
+    "tests/unit/test_release_policy.py",
+)
+
+
+def build_commands(
+    *,
+    python_executable: str | None = None,
+    test_targets: Sequence[str] = DEFAULT_TEST_TARGETS,
+) -> list[list[str]]:
+    python_cmd = python_executable or sys.executable
+    return [[python_cmd, "-m", "pytest", target, "-q"] for target in test_targets]
+
+
+def format_commands(commands: Sequence[Sequence[str]]) -> str:
+    lines: list[str] = []
+    for index, command in enumerate(commands, start=1):
+        rendered = " ".join(shlex.quote(part) for part in command)
+        lines.append(f"{index}. {rendered}")
+    return "\n".join(lines)
+
+
+def run_commands(
+    commands: Sequence[Sequence[str]],
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    continue_on_failure: bool = False,
+) -> int:
+    exit_code = 0
+    for command in commands:
+        completed = runner(
+            list(command),
+            check=False,
+            text=True,
+        )
+        if completed.returncode != 0:
+            exit_code = completed.returncode
+            if not continue_on_failure:
+                break
+    return exit_code
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Role B lane preflight validation command runner."
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Print the canonical validation command list.",
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Execute canonical validation commands.",
+    )
+    parser.add_argument(
+        "--continue-on-failure",
+        action="store_true",
+        help="Continue running later commands even if an earlier command fails.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    commands = build_commands()
+
+    if args.list or not args.run:
+        print("Role B preflight command set:")
+        print(format_commands(commands))
+
+    if not args.run:
+        return 0
+
+    return run_commands(commands, continue_on_failure=args.continue_on_failure)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_release_policy.py
+++ b/tests/unit/test_release_policy.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+release_policy = importlib.import_module("scripts.release_policy")
+PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish-pypi.yml"
+
+
+def test_classify_branch_kinds() -> None:
+    assert release_policy.classify_branch("develop") == "develop"
+    assert release_policy.classify_branch("release/0.3") == "release"
+    assert release_policy.classify_branch("main") == "main"
+    assert release_policy.classify_branch("hotfix/0.3.1") == "hotfix"
+
+
+@pytest.mark.parametrize(
+    ("branch", "version", "expected"),
+    [
+        ("develop", "0.3.0a8", True),
+        ("develop", "0.3.0b1", False),
+        ("release/0.3", "0.3.0b2", True),
+        ("release/0.3", "0.3.0rc1", True),
+        ("release/0.3", "0.3.0a9", False),
+        ("main", "0.3.0", True),
+        ("main", "0.3.0rc2", False),
+        ("hotfix/0.3.1", "0.3.2", True),
+        ("hotfix/0.3.1", "0.3.2rc1", False),
+    ],
+)
+def test_validate_branch_version(branch: str, version: str, expected: bool) -> None:
+    assert release_policy.validate_branch_version(branch, version) is expected
+
+
+def test_validate_tag_version_exact_match() -> None:
+    assert release_policy.validate_tag_version("v0.3.0rc1", "0.3.0rc1") is True
+    assert release_policy.validate_tag_version("v0.3.0-rc.1", "0.3.0rc1") is False
+
+
+@pytest.mark.parametrize(
+    ("base_branch", "head_branch", "expected"),
+    [
+        ("main", "release/0.3", True),
+        ("main", "hotfix/0.3.1", True),
+        ("main", "feat/parallel-fix", False),
+        ("main", "develop", False),
+        ("develop", "feat/parallel-fix", True),
+        ("release/0.3", "feat/release-fix", True),
+    ],
+)
+def test_validate_pull_request_flow(
+    base_branch: str, head_branch: str, expected: bool
+) -> None:
+    assert (
+        release_policy.validate_pull_request_flow(base_branch, head_branch) is expected
+    )
+
+
+def test_validate_pull_request_flow_unsupported_base_branch() -> None:
+    with pytest.raises(release_policy.PolicyError, match="unsupported branch"):
+        release_policy.validate_pull_request_flow(
+            "feature/not-supported", "feat/example"
+        )
+
+
+def test_resolve_release_artifacts_success(tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    sdist = dist_dir / "pyrallel_consumer-0.3.0rc1.tar.gz"
+    wheel = dist_dir / "pyrallel_consumer-0.3.0rc1-py3-none-any.whl"
+    sdist.write_text("sdist")
+    wheel.write_text("wheel")
+
+    resolved_sdist, resolved_wheel = release_policy.resolve_release_artifacts(
+        str(dist_dir), "pyrallel-consumer", "0.3.0rc1"
+    )
+
+    assert resolved_sdist == str(sdist)
+    assert resolved_wheel == str(wheel)
+
+
+def test_resolve_release_artifacts_rejects_stale_dist_files(tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "pyrallel_consumer-0.3.0rc1.tar.gz").write_text("sdist")
+    (dist_dir / "pyrallel_consumer-0.3.0rc1-py3-none-any.whl").write_text("wheel")
+    stale = dist_dir / "pyrallel_consumer-0.2.9-py3-none-any.whl"
+    stale.write_text("stale-wheel")
+
+    with pytest.raises(
+        release_policy.PolicyError, match="stale distribution artifacts"
+    ):
+        release_policy.resolve_release_artifacts(
+            str(dist_dir), "pyrallel-consumer", "0.3.0rc1"
+        )
+
+
+@pytest.mark.parametrize(
+    ("func_name", "version", "expected"),
+    [
+        ("bump_alpha", "0.3.0a8", "0.3.0a9"),
+        ("bump_beta", "0.3.0b2", "0.3.0b3"),
+        ("bump_rc", "0.3.0rc1", "0.3.0rc2"),
+        ("bump_patch", "0.3.1", "0.3.2"),
+    ],
+)
+def test_bump_helpers(func_name: str, version: str, expected: str) -> None:
+    func = getattr(release_policy, func_name)
+    assert func(version) == expected
+
+
+def test_cli_validate_branch_version_success() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "release_policy.py"),
+            "validate-branch-version",
+            "--branch",
+            "develop",
+            "--version",
+            "0.3.0a8",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "OK" in result.stdout
+
+
+def test_cli_validate_branch_version_failure() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "release_policy.py"),
+            "validate-branch-version",
+            "--branch",
+            "main",
+            "--version",
+            "0.3.0rc2",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "INVALID" in result.stdout
+
+
+def test_cli_validate_tag_version() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "release_policy.py"),
+            "validate-tag-version",
+            "--tag",
+            "v0.3.0rc1",
+            "--version",
+            "0.3.0rc1",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "OK" in result.stdout
+
+
+def test_cli_validate_pr_flow_success() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "release_policy.py"),
+            "validate-pr-flow",
+            "--base-branch",
+            "main",
+            "--head-branch",
+            "release/0.3",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "OK" in result.stdout
+
+
+def test_cli_validate_pr_flow_failure() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "release_policy.py"),
+            "validate-pr-flow",
+            "--base-branch",
+            "main",
+            "--head-branch",
+            "feat/direct-main-pr",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "INVALID" in result.stdout
+
+
+def test_cli_resolve_artifacts(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "pyrallel-consumer"',
+                'version = "0.3.0rc1"',
+                "",
+            ]
+        )
+    )
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    sdist = dist_dir / "pyrallel_consumer-0.3.0rc1.tar.gz"
+    wheel = dist_dir / "pyrallel_consumer-0.3.0rc1-py3-none-any.whl"
+    sdist.write_text("sdist")
+    wheel.write_text("wheel")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "release_policy.py"),
+            "resolve-artifacts",
+            "--dist-dir",
+            str(dist_dir),
+            "--project-file",
+            str(pyproject),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    assert lines == [str(sdist), str(wheel)]
+
+
+def test_publish_workflow_uses_release_policy_and_trusted_publishing() -> None:
+    text = PUBLISH_WORKFLOW.read_text()
+
+    assert "workflow_dispatch:" in text
+    assert "scripts.release_policy" in text
+    assert "validate_branch_version" in text
+    assert "validate_tag_version" in text
+    assert "resolve-artifacts --write-github-output" in text
+    assert "id-token: write" in text
+    assert "pypa/gh-action-pypi-publish@release/v1" in text

--- a/tests/unit/test_role_b_preflight.py
+++ b/tests/unit/test_role_b_preflight.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+role_b_preflight = importlib.import_module("scripts.role_b_preflight")
+
+
+def test_build_commands_uses_expected_default_targets() -> None:
+    commands = role_b_preflight.build_commands(python_executable="python")
+
+    assert commands == [
+        ["python", "-m", "pytest", "tests/unit/test_role_b_preflight.py", "-q"],
+        [
+            "python",
+            "-m",
+            "pytest",
+            "tests/unit/benchmarks/test_benchmark_runtime.py",
+            "-q",
+        ],
+        ["python", "-m", "pytest", "tests/unit/test_release_policy.py", "-q"],
+    ]
+
+
+def test_format_commands_outputs_ordered_shell_lines() -> None:
+    rendered = role_b_preflight.format_commands(
+        [
+            ["python", "-m", "pytest", "tests/unit/a.py", "-q"],
+            ["python", "-m", "pytest", "tests/unit/b.py", "-q"],
+        ]
+    )
+
+    assert rendered == (
+        "1. python -m pytest tests/unit/a.py -q\n"
+        "2. python -m pytest tests/unit/b.py -q"
+    )
+
+
+def test_run_commands_stops_on_first_failure() -> None:
+    calls: list[list[str]] = []
+
+    def _runner(command: list[str], *, check: bool, text: bool) -> SimpleNamespace:
+        del check, text
+        calls.append(command)
+        if len(calls) == 2:
+            return SimpleNamespace(returncode=1)
+        return SimpleNamespace(returncode=0)
+
+    exit_code = role_b_preflight.run_commands(
+        [
+            ["python", "-m", "pytest", "tests/unit/a.py", "-q"],
+            ["python", "-m", "pytest", "tests/unit/b.py", "-q"],
+            ["python", "-m", "pytest", "tests/unit/c.py", "-q"],
+        ],
+        runner=_runner,
+        continue_on_failure=False,
+    )
+
+    assert exit_code == 1
+    assert calls == [
+        ["python", "-m", "pytest", "tests/unit/a.py", "-q"],
+        ["python", "-m", "pytest", "tests/unit/b.py", "-q"],
+    ]
+
+
+def test_run_commands_continues_when_requested() -> None:
+    calls: list[list[str]] = []
+
+    def _runner(command: list[str], *, check: bool, text: bool) -> SimpleNamespace:
+        del check, text
+        calls.append(command)
+        return SimpleNamespace(returncode=2 if len(calls) == 1 else 0)
+
+    exit_code = role_b_preflight.run_commands(
+        [
+            ["python", "-m", "pytest", "tests/unit/a.py", "-q"],
+            ["python", "-m", "pytest", "tests/unit/b.py", "-q"],
+        ],
+        runner=_runner,
+        continue_on_failure=True,
+    )
+
+    assert exit_code == 2
+    assert calls == [
+        ["python", "-m", "pytest", "tests/unit/a.py", "-q"],
+        ["python", "-m", "pytest", "tests/unit/b.py", "-q"],
+    ]
+
+
+def test_main_lists_commands_by_default(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = role_b_preflight.main([])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Role B preflight command set:" in captured.out
+    assert "tests/unit/test_role_b_preflight.py" in captured.out
+
+
+def test_main_run_invokes_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        role_b_preflight,
+        "build_commands",
+        lambda: [["python", "-m", "pytest", "tests/unit/a.py", "-q"]],
+    )
+    monkeypatch.setattr(
+        role_b_preflight,
+        "run_commands",
+        lambda commands, continue_on_failure=False: 0,
+    )
+
+    assert role_b_preflight.main(["--run"]) == 0


### PR DESCRIPTION
## 요약

MQU-40 백업 전용 산출물 중 현재 요구사항에 더 가까운 항목만 선별 재도입했습니다.

재도입:
- protected manual PyPI publish workflow: `.github/workflows/publish-pypi.yml`
- release branch/tag/artifact policy helper: `scripts/release_policy.py`
- release policy tests: `tests/unit/test_release_policy.py`
- Role B preflight helper/tests: `scripts/role_b_preflight.py`, `tests/unit/test_role_b_preflight.py`

제외:
- MQU-167/MQU-168 standalone Korean docs: 현재 `docs/operations/playbooks.md`에 핵심 해석이 이미 있고, unsuffixed English canonical 정책과 충돌합니다.
- backup CI branch-version gate: 현재 `develop`의 `pyproject.toml`은 `1.0.0` stable이라 이전 gate를 그대로 되살리면 현재 develop CI를 깨뜨립니다.

## 검증

- `UV_CACHE_DIR=.uv-cache uv run pytest tests/unit/test_release_policy.py tests/unit/test_role_b_preflight.py -q` -> 37 passed
- `UV_CACHE_DIR=.uv-cache uv run ruff check scripts/release_policy.py scripts/role_b_preflight.py tests/unit/test_release_policy.py tests/unit/test_role_b_preflight.py` -> passed
- `UV_CACHE_DIR=.uv-cache uv run python -m scripts.role_b_preflight --list` -> command list 출력 확인
- `UV_CACHE_DIR=.uv-cache uv run python scripts/release_policy.py validate-branch-version --branch main --version 1.0.0` -> OK
- `UV_CACHE_DIR=.uv-cache uv run pylint --disable=W,C,R,E -j 0 -rn -sn pyrallel_consumer/` -> passed
- `UV_CACHE_DIR=.uv-cache uv run bandit -q -lll -x 'tests/**/*.py,./contrib/,./.venv/,./.worktrees/,./.uv-cache/,./.cache/' -r .` -> passed
- `git diff --check` -> passed

참고: local pre-commit의 `pylint`/`bandit` hooks는 `language: system`이라 worktree PATH에서 바이너리를 찾지 못해 hook만 skip하고, 동일 명령을 `uv run`으로 직접 검증했습니다.