### PR TITLE
chore(ci): pin compose images by immutable versions

### DIFF
--- a/.github/e2e.compose.yml
+++ b/.github/e2e.compose.yml
@@ -25,7 +25,7 @@ services:
       - yamong_network
 
   kafka-exporter:
-    image: danielqsj/kafka-exporter:latest
+    image: danielqsj/kafka-exporter:v1.8.0
     command:
       - "--kafka.server=kafka-1:29092"
     ports:
@@ -37,7 +37,7 @@ services:
       - yamong_network
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.55.1
     volumes:
       - ../monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:

--- a/.github/e2e.compose.yml
+++ b/.github/e2e.compose.yml
@@ -1,6 +1,6 @@
 services:
   kafka-1:
-    image: ${KAFKA_IMAGE:-confluentinc/cp-kafka:7.6.0}
+    image: ${KAFKA_IMAGE:-confluentinc/cp-kafka@sha256:8fc15a671986983b83beecae14e013a91adcd3999f687de8b6b8153fd47e8f67}
     hostname: kafka-1
     ports:
       - "9092:9092"
@@ -25,7 +25,7 @@ services:
       - yamong_network
 
   kafka-exporter:
-    image: danielqsj/kafka-exporter:v1.8.0
+    image: danielqsj/kafka-exporter@sha256:bfae1aa15e873268c75899d02fcb5479418d3cde69d5d0b424511e067caf6f22
     command:
       - "--kafka.server=kafka-1:29092"
     ports:
@@ -37,7 +37,7 @@ services:
       - yamong_network
 
   prometheus:
-    image: prom/prometheus:v2.55.1
+    image: prom/prometheus@sha256:b1935d181b6dd8e9c827705e89438815337e1b10ae35605126f05f44e5c6940f
     volumes:
       - ../monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
@@ -50,7 +50,7 @@ services:
       - yamong_network
 
   grafana:
-    image: grafana/grafana:10.4.2
+    image: grafana/grafana@sha256:3aa2a03d88ad9628485f78e89adcd5b18bcde1aced3e6146bbbd7a718b82b797
     ports:
       - "3000:3000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - yamong_network
 
   kafka-ui:
-    image: provectuslabs/kafka-ui:latest
+    image: provectuslabs/kafka-ui:v0.7.2
     container_name: kafka-ui
     ports:
       - "8080:8080"
@@ -45,7 +45,7 @@ services:
       - yamong_network
 
   kafka-exporter:
-    image: danielqsj/kafka-exporter:latest
+    image: danielqsj/kafka-exporter:v1.8.0
     container_name: kafka-exporter
     command:
       - "--kafka.server=kafka-1:29092"
@@ -57,7 +57,7 @@ services:
       - yamong_network
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.55.1
     container_name: prometheus
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   kafka-1:
-    image: confluentinc/cp-kafka:7.6.0
+    image: confluentinc/cp-kafka@sha256:8fc15a671986983b83beecae14e013a91adcd3999f687de8b6b8153fd47e8f67
     hostname: kafka-1
     container_name: kafka-1
     ports:
@@ -32,7 +32,7 @@ services:
       - yamong_network
 
   kafka-ui:
-    image: provectuslabs/kafka-ui:v0.7.2
+    image: provectuslabs/kafka-ui@sha256:4346a0af1450f52286e671a6b49f701d069d7306a802f7cf6743bd27ac4dbcd1
     container_name: kafka-ui
     ports:
       - "8080:8080"
@@ -45,7 +45,7 @@ services:
       - yamong_network
 
   kafka-exporter:
-    image: danielqsj/kafka-exporter:v1.8.0
+    image: danielqsj/kafka-exporter@sha256:bfae1aa15e873268c75899d02fcb5479418d3cde69d5d0b424511e067caf6f22
     container_name: kafka-exporter
     command:
       - "--kafka.server=kafka-1:29092"
@@ -57,7 +57,7 @@ services:
       - yamong_network
 
   prometheus:
-    image: prom/prometheus:v2.55.1
+    image: prom/prometheus@sha256:b1935d181b6dd8e9c827705e89438815337e1b10ae35605126f05f44e5c6940f
     container_name: prometheus
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
@@ -69,7 +69,7 @@ services:
       - yamong_network
 
   grafana:
-    image: grafana/grafana:10.4.2
+    image: grafana/grafana@sha256:3aa2a03d88ad9628485f78e89adcd5b18bcde1aced3e6146bbbd7a718b82b797
     container_name: grafana
     ports:
       - "3000:3000"

--- a/tests/unit/metrics/test_monitoring_assets.py
+++ b/tests/unit/metrics/test_monitoring_assets.py
@@ -18,6 +18,17 @@ def test_e2e_compose_includes_prometheus_and_grafana_services() -> None:
     assert "../monitoring/grafana/dashboards" in compose_text
 
 
+def test_compose_files_do_not_use_latest_images() -> None:
+    compose_files = [
+        REPO_ROOT / ".github" / "e2e.compose.yml",
+        REPO_ROOT / "docker-compose.yml",
+    ]
+
+    for compose_file in compose_files:
+        compose_text = compose_file.read_text()
+        assert ":latest" not in compose_text, f"found unpinned tag in {compose_file}"
+
+
 def test_grafana_prometheus_datasource_uses_stable_uid() -> None:
     datasource_text = (
         REPO_ROOT

--- a/tests/unit/metrics/test_monitoring_assets.py
+++ b/tests/unit/metrics/test_monitoring_assets.py
@@ -6,6 +6,54 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
+def _extract_compose_image_values(path: Path) -> list[tuple[str, str]]:
+    compose_text = path.read_text(encoding="utf-8")
+    in_services = False
+    current_service = None
+    images: list[tuple[str, str]] = []
+
+    for line in compose_text.splitlines():
+        if not line or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        stripped = line.strip()
+
+        if indent == 0 and stripped == "services:":
+            in_services = True
+            current_service = None
+            continue
+
+        if not in_services:
+            continue
+
+        if indent == 2 and stripped.endswith(":"):
+            current_service = stripped[:-1]
+            continue
+
+        if current_service is None:
+            continue
+
+        if indent == 0 or indent <= 1:
+            current_service = None
+            in_services = False
+            continue
+        if indent == 4 and stripped.startswith("image:"):
+            _, _, value = stripped.partition(":")
+            images.append((current_service, value.strip()))
+
+    return images
+
+
+def _image_value_is_immutable(image_value: str) -> bool:
+    image_value = image_value.strip()
+    if "@sha256:" in image_value:
+        return image_value.split("@sha256:", 1)[1].strip() != ""
+
+    assert image_value.count(":") >= 1, "missing image tag and digest"
+    tag = image_value.rsplit(":", 1)[1]
+    return tag != "" and not tag.startswith("latest") and tag != "latest"
+
+
 def test_e2e_compose_includes_prometheus_and_grafana_services() -> None:
     compose_text = (REPO_ROOT / ".github" / "e2e.compose.yml").read_text()
 
@@ -25,8 +73,10 @@ def test_compose_files_do_not_use_latest_images() -> None:
     ]
 
     for compose_file in compose_files:
-        compose_text = compose_file.read_text()
-        assert ":latest" not in compose_text, f"found unpinned tag in {compose_file}"
+        for service_name, image_value in _extract_compose_image_values(compose_file):
+            assert _image_value_is_immutable(
+                image_value
+            ), f"service {service_name} in {compose_file} uses unsupported image ref {image_value!r}"
 
 
 def test_grafana_prometheus_datasource_uses_stable_uid() -> None:


### PR DESCRIPTION
## Summary
- Pin compose image tags to explicit versions in local/e2e compose files.
- Add tests to prevent :latest usage in compose-related monitoring assets checks.

Refs: #82

## Testing
- ruff check
- pytest tests/unit/metrics/test_monitoring_assets.py