### PR TITLE
feat(metrics): export adaptive control runtime snapshots

### DIFF
--- a/docs/blueprint/features/04-tooling/01-observability-metrics/03-design.ko.md
+++ b/docs/blueprint/features/04-tooling/01-observability-metrics/03-design.ko.md
@@ -27,6 +27,23 @@
 | `consumer_oldest_task_duration_seconds` | Gauge | `topic`, `partition` | blocking duration |
 | `consumer_backpressure_active` | Gauge | 없음 | `1=paused` |
 | `consumer_metadata_size_bytes` | Gauge | `topic` | commit metadata payload 크기 |
+| `consumer_adaptive_backpressure_configured_max_in_flight` | Gauge | 없음 | adaptive backpressure 설정 ceiling |
+| `consumer_adaptive_backpressure_effective_max_in_flight` | Gauge | 없음 | adaptive backpressure 실시간 ceiling |
+| `consumer_adaptive_backpressure_min_in_flight` | Gauge | 없음 | adaptive backpressure 최소 하한 |
+| `consumer_adaptive_backpressure_scale_up_step` | Gauge | 없음 | adaptive backpressure 상승 step |
+| `consumer_adaptive_backpressure_scale_down_step` | Gauge | 없음 | adaptive backpressure 하향 step |
+| `consumer_adaptive_backpressure_cooldown_ms` | Gauge | 없음 | adaptive backpressure 쿨다운(ms) |
+| `consumer_adaptive_backpressure_lag_scale_up_threshold` | Gauge | 없음 | adaptive backpressure scale-up을 유도하는 lag 임계값 |
+| `consumer_adaptive_backpressure_low_latency_threshold_ms` | Gauge | 없음 | adaptive backpressure 저지연 임계값(ms) |
+| `consumer_adaptive_backpressure_high_latency_threshold_ms` | Gauge | 없음 | adaptive backpressure 고지연 임계값(ms) |
+| `consumer_adaptive_backpressure_avg_completion_latency_seconds` | Gauge | 없음 | 현재 adaptive backpressure 의사결정 입력값 |
+| `consumer_adaptive_backpressure_last_decision` | Gauge | `decision` | 마지막 adaptive backpressure decision one-hot |
+| `consumer_adaptive_concurrency_configured_max_in_flight` | Gauge | 없음 | adaptive concurrency 설정 ceiling |
+| `consumer_adaptive_concurrency_effective_max_in_flight` | Gauge | 없음 | adaptive concurrency 실시간 ceiling |
+| `consumer_adaptive_concurrency_min_in_flight` | Gauge | 없음 | adaptive concurrency 최소 하한 |
+| `consumer_adaptive_concurrency_scale_up_step` | Gauge | 없음 | adaptive concurrency 상승 step |
+| `consumer_adaptive_concurrency_scale_down_step` | Gauge | 없음 | adaptive concurrency 하향 step |
+| `consumer_adaptive_concurrency_cooldown_ms` | Gauge | 없음 | adaptive concurrency 쿨다운(ms) |
 
 ## 4. 운영 해석 규칙
 

--- a/docs/blueprint/features/04-tooling/01-observability-metrics/03-design.md
+++ b/docs/blueprint/features/04-tooling/01-observability-metrics/03-design.md
@@ -19,3 +19,34 @@ For the preserved Korean source text, see [03-design.ko.md](./03-design.ko.md).
 - [01-requirements.md](./01-requirements.md)
 - [02-architecture.md](./02-architecture.md)
 - [03-design.md](./03-design.md)
+
+## Canonical metric surface
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `consumer_processed_total` | Counter | `topic`, `partition`, `status` | completion success/failure count |
+| `consumer_processing_latency_seconds` | Histogram | `topic`, `partition` | submit to completion latency |
+| `consumer_in_flight_count` | Gauge | none | total in-flight count |
+| `consumer_parallel_lag` | Gauge | `topic`, `partition` | true lag |
+| `consumer_gap_count` | Gauge | `topic`, `partition` | outstanding gap count |
+| `consumer_internal_queue_depth` | Gauge | `topic`, `partition` | virtual queue backlog |
+| `consumer_oldest_task_duration_seconds` | Gauge | `topic`, `partition` | blocking duration |
+| `consumer_backpressure_active` | Gauge | none | `1=paused` |
+| `consumer_metadata_size_bytes` | Gauge | `topic` | commit metadata payload size |
+| `consumer_adaptive_backpressure_configured_max_in_flight` | Gauge | none | configured adaptive backpressure ceiling |
+| `consumer_adaptive_backpressure_effective_max_in_flight` | Gauge | none | live adaptive backpressure limit |
+| `consumer_adaptive_backpressure_min_in_flight` | Gauge | none | adaptive backpressure minimum floor |
+| `consumer_adaptive_backpressure_scale_up_step` | Gauge | none | adaptive backpressure scale-up step |
+| `consumer_adaptive_backpressure_scale_down_step` | Gauge | none | adaptive backpressure scale-down step |
+| `consumer_adaptive_backpressure_cooldown_ms` | Gauge | none | adaptive backpressure cooldown (ms) |
+| `consumer_adaptive_backpressure_lag_scale_up_threshold` | Gauge | none | lag threshold that triggers backpressure scale-up |
+| `consumer_adaptive_backpressure_low_latency_threshold_ms` | Gauge | none | adaptive backpressure low-latency threshold (ms) |
+| `consumer_adaptive_backpressure_high_latency_threshold_ms` | Gauge | none | adaptive backpressure high-latency threshold (ms) |
+| `consumer_adaptive_backpressure_avg_completion_latency_seconds` | Gauge | none | current adaptive backpressure decision input |
+| `consumer_adaptive_backpressure_last_decision` | Gauge | `decision` | last adaptive backpressure decision one-hot |
+| `consumer_adaptive_concurrency_configured_max_in_flight` | Gauge | none | configured adaptive concurrency ceiling |
+| `consumer_adaptive_concurrency_effective_max_in_flight` | Gauge | none | live adaptive concurrency limit |
+| `consumer_adaptive_concurrency_min_in_flight` | Gauge | none | adaptive concurrency minimum floor |
+| `consumer_adaptive_concurrency_scale_up_step` | Gauge | none | adaptive concurrency scale-up step |
+| `consumer_adaptive_concurrency_scale_down_step` | Gauge | none | adaptive concurrency scale-down step |
+| `consumer_adaptive_concurrency_cooldown_ms` | Gauge | none | adaptive concurrency cooldown (ms) |

--- a/docs/operations/guide.en.md
+++ b/docs/operations/guide.en.md
@@ -92,6 +92,28 @@ Kafka's default Lag (`LogEndOffset - CommittedOffset`) alone cannot accurately r
 - **Meaning**: Process-only safety data such as minimum in-flight offsets should be exposed as an optional engine capability, not by branching on a concrete engine class inside `BrokerPoller`.
 - **Tip**: When validating refactors, run the same control-plane checks against async and process engines (or mocks) to confirm the boundary stays polymorphic.
 
+### 1.10. Adaptive Backpressure / Adaptive Concurrency Runtime Snapshots
+- **Prometheus queries**:
+    - `consumer_adaptive_backpressure_configured_max_in_flight`
+    - `consumer_adaptive_backpressure_effective_max_in_flight`
+    - `consumer_adaptive_backpressure_min_in_flight`
+    - `consumer_adaptive_backpressure_scale_up_step`
+    - `consumer_adaptive_backpressure_scale_down_step`
+    - `consumer_adaptive_backpressure_cooldown_ms`
+    - `consumer_adaptive_backpressure_lag_scale_up_threshold`
+    - `consumer_adaptive_backpressure_low_latency_threshold_ms`
+    - `consumer_adaptive_backpressure_high_latency_threshold_ms`
+    - `consumer_adaptive_backpressure_avg_completion_latency_seconds`
+    - `consumer_adaptive_backpressure_last_decision`
+    - `consumer_adaptive_concurrency_configured_max_in_flight`
+    - `consumer_adaptive_concurrency_effective_max_in_flight`
+    - `consumer_adaptive_concurrency_min_in_flight`
+    - `consumer_adaptive_concurrency_scale_up_step`
+    - `consumer_adaptive_concurrency_scale_down_step`
+    - `consumer_adaptive_concurrency_cooldown_ms`
+- **Meaning**: These gauges expose both current runtime decisions and configured control limits for adaptive backpressure/adaptive concurrency. They are especially useful when tuning `max_in_flight_messages` and diagnosing oscillation.
+- **Tip**: Pair `*_effective_*` with `consumer_backpressure_active` and `consumer_in_flight_count`; if `*_effective_*` is pinned low while in-flight is saturated, reduce aggressive concurrency changes and check batch/processing latency behavior.
+
 ## 2. Tuning Guide
 
 ### 2.1. `max_in_flight_messages` (Control Plane)
@@ -176,6 +198,20 @@ Assuming `get_metrics()` results are collected via Prometheus, the following pan
     - Type: Time Series
     - Query: `consumer_process_batch_avg_main_to_worker_ipc_seconds`, `consumer_process_batch_avg_worker_exec_seconds`, `consumer_process_batch_avg_worker_to_main_ipc_seconds`
     - Insight: Split these three values to quickly decide whether the bottleneck is serialization/IPC, worker execution, or completion draining.
+
+### 4.5. Adaptive Control Runtime (Row)
+- **Adaptive Backpressure Limits**:
+    - Type: Stat
+    - Query: `consumer_adaptive_backpressure_configured_max_in_flight`, `consumer_adaptive_backpressure_effective_max_in_flight`
+- **Adaptive Concurrency Limits**:
+    - Type: Stat
+    - Query: `consumer_adaptive_concurrency_configured_max_in_flight`, `consumer_adaptive_concurrency_effective_max_in_flight`
+- **Adaptive Decision Input**:
+    - Type: Time Series
+    - Query: `consumer_adaptive_backpressure_avg_completion_latency_seconds`, `consumer_adaptive_backpressure_last_decision`
+- **Tuning Reference**:
+    - Type: Table
+    - Query: `consumer_adaptive_backpressure_scale_up_step`, `consumer_adaptive_backpressure_scale_down_step`, `consumer_adaptive_backpressure_cooldown_ms`, `consumer_adaptive_concurrency_scale_up_step`, `consumer_adaptive_concurrency_scale_down_step`, `consumer_adaptive_concurrency_cooldown_ms`
 
 ---
 © 2026 Pyrallel Consumer Project

--- a/docs/operations/guide.ko.md
+++ b/docs/operations/guide.ko.md
@@ -92,6 +92,28 @@ Kafka의 기본 Lag(`LogEndOffset - CommittedOffset`)만으로는 병렬 처리 
 - **의미**: 최소 in-flight offset 같은 Process 전용 안전 정보는 `BrokerPoller` 내부의 구체 클래스 분기 대신, 선택적 엔진 capability로 노출되어야 합니다.
 - **운영 팁**: 리팩터링 검증 시 async/process 엔진(또는 mock) 모두에 동일한 control-plane 검증을 적용해 polymorphic 경계가 유지되는지 확인하십시오.
 
+### 1.10. Adaptive Backpressure / Adaptive Concurrency 런타임 스냅샷
+- **Prometheus 쿼리**:
+    - `consumer_adaptive_backpressure_configured_max_in_flight`
+    - `consumer_adaptive_backpressure_effective_max_in_flight`
+    - `consumer_adaptive_backpressure_min_in_flight`
+    - `consumer_adaptive_backpressure_scale_up_step`
+    - `consumer_adaptive_backpressure_scale_down_step`
+    - `consumer_adaptive_backpressure_cooldown_ms`
+    - `consumer_adaptive_backpressure_lag_scale_up_threshold`
+    - `consumer_adaptive_backpressure_low_latency_threshold_ms`
+    - `consumer_adaptive_backpressure_high_latency_threshold_ms`
+    - `consumer_adaptive_backpressure_avg_completion_latency_seconds`
+    - `consumer_adaptive_backpressure_last_decision`
+    - `consumer_adaptive_concurrency_configured_max_in_flight`
+    - `consumer_adaptive_concurrency_effective_max_in_flight`
+    - `consumer_adaptive_concurrency_min_in_flight`
+    - `consumer_adaptive_concurrency_scale_up_step`
+    - `consumer_adaptive_concurrency_scale_down_step`
+    - `consumer_adaptive_concurrency_cooldown_ms`
+- **의미**: 위 게이지는 adaptive backpressure/adaptive concurrency의 현재 런타임 의사결정값과 설정 값을 함께 보여줍니다. `max_in_flight` 튜닝과 진동(oscillation) 분석에 유용합니다.
+- **운영 팁**: `*_effective_*` 값이 낮은 상태에서 `consumer_backpressure_active == 1`와 `consumer_in_flight_count`가 동시에 높으면, 급격한 동시성 변경이 지속되지 않도록 하여 IPC/워커 처리 지연부터 확인하세요.
+
 ## 2. 튜닝 가이드
 
 ### 2.1. `max_in_flight_messages` (Control Plane)
@@ -176,6 +198,20 @@ Kafka의 기본 Lag(`LogEndOffset - CommittedOffset`)만으로는 병렬 처리 
     - Type: Time Series
     - Query: `consumer_process_batch_avg_main_to_worker_ipc_seconds`, `consumer_process_batch_avg_worker_exec_seconds`, `consumer_process_batch_avg_worker_to_main_ipc_seconds`
     - Insight: 세 값을 분리해서 보면 병목이 serialization/IPC인지, 실제 worker 실행인지, completion 회수인지 빠르게 구분할 수 있습니다.
+
+### 4.5. Adaptive Control Runtime (Row)
+- **Adaptive Backpressure Limits**:
+    - Type: Stat
+    - Query: `consumer_adaptive_backpressure_configured_max_in_flight`, `consumer_adaptive_backpressure_effective_max_in_flight`
+- **Adaptive Concurrency Limits**:
+    - Type: Stat
+    - Query: `consumer_adaptive_concurrency_configured_max_in_flight`, `consumer_adaptive_concurrency_effective_max_in_flight`
+- **Adaptive Decision Input**:
+    - Type: Time Series
+    - Query: `consumer_adaptive_backpressure_avg_completion_latency_seconds`, `consumer_adaptive_backpressure_last_decision`
+- **튜닝 참조값**:
+    - Type: Table
+    - Query: `consumer_adaptive_backpressure_scale_up_step`, `consumer_adaptive_backpressure_scale_down_step`, `consumer_adaptive_backpressure_cooldown_ms`, `consumer_adaptive_concurrency_scale_up_step`, `consumer_adaptive_concurrency_scale_down_step`, `consumer_adaptive_concurrency_cooldown_ms`
 
 ---
 © 2026 Pyrallel Consumer Project

--- a/docs/operations/playbooks.md
+++ b/docs/operations/playbooks.md
@@ -49,6 +49,17 @@ Use this when a new release rollout causes production-impacting regressions.
 ## Observability & Alerts
 - **Backpressure**: `consumer_backpressure_active == 1` for >1 minute -> alert; check `max_in_flight` and queue depth.
 - **Lag/Gap**: `consumer_parallel_lag` or `consumer_gap_count` growing for 5m -> investigate stuck offsets, slow workers.
+- **Adaptive control state**:
+  - Backpressure/Concurrency cap tracking:
+    - `consumer_adaptive_backpressure_configured_max_in_flight`
+    - `consumer_adaptive_backpressure_effective_max_in_flight`
+    - `consumer_adaptive_concurrency_effective_max_in_flight`
+  - Backpressure dynamics:
+    - `consumer_adaptive_backpressure_last_decision`
+    - `consumer_adaptive_backpressure_scale_up_step`
+    - `consumer_adaptive_backpressure_scale_down_step`
+    - `consumer_adaptive_concurrency_scale_up_step`
+    - `consumer_adaptive_concurrency_scale_down_step`
 - **Commit failure counter**: any increase in `consumer_commit_failures_total` -> investigate commit path health and replay risk immediately.
 - **DLQ**: any increase in `consumer_dlq_publish_failures_total`, failure rate >1%, or repeated warning logs -> validate DLQ topic and payload mode.
 - **Oldest task duration**: `consumer_oldest_task_duration_seconds` > timeout -> potential stuck worker; trigger graceful shutdown.

--- a/monitoring/grafana/dashboards/pyrallel-overview.json
+++ b/monitoring/grafana/dashboards/pyrallel-overview.json
@@ -501,6 +501,216 @@
       ],
       "title": "Process batch timing",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "consumer_adaptive_backpressure_configured_max_in_flight",
+          "legendFormat": "adaptive_backpressure_configured_max",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "consumer_adaptive_backpressure_effective_max_in_flight",
+          "legendFormat": "adaptive_backpressure_effective",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "consumer_adaptive_concurrency_effective_max_in_flight",
+          "legendFormat": "adaptive_concurrency_effective",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Adaptive control caps",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "consumer_adaptive_backpressure_last_decision",
+          "legendFormat": "{{decision}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "consumer_adaptive_backpressure_scale_up_step",
+          "legendFormat": "backpressure_scale_up_step",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "consumer_adaptive_backpressure_scale_down_step",
+          "legendFormat": "backpressure_scale_down_step",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "consumer_adaptive_concurrency_scale_up_step",
+          "legendFormat": "concurrency_scale_up_step",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "consumer_adaptive_concurrency_scale_down_step",
+          "legendFormat": "concurrency_scale_down_step",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "consumer_adaptive_concurrency_cooldown_ms",
+          "legendFormat": "concurrency_cooldown_ms",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "consumer_adaptive_backpressure_cooldown_ms",
+          "legendFormat": "backpressure_cooldown_ms",
+          "range": true,
+          "refId": "G"
+        }
+      ],
+      "title": "Adaptive control parameters",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/pyrallel_consumer/control_plane/broker_poller.py
+++ b/pyrallel_consumer/control_plane/broker_poller.py
@@ -188,15 +188,11 @@ class BrokerPoller:
             log_change=False,
         )
 
-        self._message_cache: (
-            "OrderedDict[Tuple[DtoTopicPartition, int], Tuple[Any, Any]]"
-        ) = OrderedDict()
+        self._message_cache: "OrderedDict[Tuple[DtoTopicPartition, int], Tuple[Any, Any]]" = OrderedDict()
         # BrokerPoller owns pending terminal DLQ failures across transient
         # BrokerCompletionSupport instances; support mutates this ledger while
         # retrying DLQ publication before offsets may be marked complete.
-        self._pending_dlq_events: (
-            "OrderedDict[Tuple[DtoTopicPartition, int], CompletionEvent]"
-        ) = OrderedDict()
+        self._pending_dlq_events: "OrderedDict[Tuple[DtoTopicPartition, int], CompletionEvent]" = OrderedDict()
         self._message_cache_size_bytes = 0
         self._idle_consume_timeout_seconds = 0.1
 
@@ -1087,6 +1083,8 @@ class BrokerPoller:
             total_in_flight=metrics.total_in_flight,
             is_paused=metrics.is_paused,
             partitions=metrics.partitions,
+            adaptive_backpressure=metrics.adaptive_backpressure,
+            adaptive_concurrency=metrics.adaptive_concurrency,
             process_batch_metrics=(
                 runtime_metrics
                 if isinstance(runtime_metrics, ProcessBatchMetrics)

--- a/pyrallel_consumer/control_plane/broker_poller.py
+++ b/pyrallel_consumer/control_plane/broker_poller.py
@@ -1112,16 +1112,11 @@ class BrokerPoller:
                     avg_completion_latency_seconds=avg_completion_latency
                 )
             )
-            # Avoid exposing a stale backpressure cap when adaptive concurrency has
-            # tightened MAX_IN_FLIGHT_MESSAGES after the backpressure evaluator ran.
+            # Export the true live runtime cap for the backpressure snapshot too.
+            # Adaptive concurrency can change MAX_IN_FLIGHT_MESSAGES after the
+            # backpressure evaluator runs, in either direction.
             if adaptive_backpressure_snapshot is not None:
-                normalized_backpressure_cap = max(
-                    1,
-                    min(
-                        int(self.MAX_IN_FLIGHT_MESSAGES),
-                        int(adaptive_backpressure_snapshot.effective_max_in_flight),
-                    ),
-                )
+                normalized_backpressure_cap = max(1, int(self.MAX_IN_FLIGHT_MESSAGES))
                 if (
                     normalized_backpressure_cap
                     != adaptive_backpressure_snapshot.effective_max_in_flight

--- a/pyrallel_consumer/control_plane/broker_poller.py
+++ b/pyrallel_consumer/control_plane/broker_poller.py
@@ -6,6 +6,7 @@ import inspect
 import random
 import time
 from collections import OrderedDict
+from dataclasses import replace
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from confluent_kafka import Consumer, KafkaException, Message, Producer
@@ -188,11 +189,15 @@ class BrokerPoller:
             log_change=False,
         )
 
-        self._message_cache: "OrderedDict[Tuple[DtoTopicPartition, int], Tuple[Any, Any]]" = OrderedDict()
+        self._message_cache: (
+            "OrderedDict[Tuple[DtoTopicPartition, int], Tuple[Any, Any]]"
+        ) = OrderedDict()
         # BrokerPoller owns pending terminal DLQ failures across transient
         # BrokerCompletionSupport instances; support mutates this ledger while
         # retrying DLQ publication before offsets may be marked complete.
-        self._pending_dlq_events: "OrderedDict[Tuple[DtoTopicPartition, int], CompletionEvent]" = OrderedDict()
+        self._pending_dlq_events: (
+            "OrderedDict[Tuple[DtoTopicPartition, int], CompletionEvent]"
+        ) = OrderedDict()
         self._message_cache_size_bytes = 0
         self._idle_consume_timeout_seconds = 0.1
 
@@ -1107,6 +1112,24 @@ class BrokerPoller:
                     avg_completion_latency_seconds=avg_completion_latency
                 )
             )
+            # Avoid exposing a stale backpressure cap when adaptive concurrency has
+            # tightened MAX_IN_FLIGHT_MESSAGES after the backpressure evaluator ran.
+            if adaptive_backpressure_snapshot is not None:
+                normalized_backpressure_cap = max(
+                    1,
+                    min(
+                        int(self.MAX_IN_FLIGHT_MESSAGES),
+                        int(adaptive_backpressure_snapshot.effective_max_in_flight),
+                    ),
+                )
+                if (
+                    normalized_backpressure_cap
+                    != adaptive_backpressure_snapshot.effective_max_in_flight
+                ):
+                    adaptive_backpressure_snapshot = replace(
+                        adaptive_backpressure_snapshot,
+                        effective_max_in_flight=normalized_backpressure_cap,
+                    )
         adaptive_concurrency_snapshot = None
         if self._adaptive_concurrency_controller.enabled:
             adaptive_concurrency_snapshot = (

--- a/pyrallel_consumer/control_plane/broker_runtime_support.py
+++ b/pyrallel_consumer/control_plane/broker_runtime_support.py
@@ -188,6 +188,8 @@ class BrokerRuntimeSupport:
             total_in_flight=self._work_manager.get_total_in_flight_count(),
             is_paused=self._is_paused,
             partitions=partition_metrics_list,
+            adaptive_backpressure=self._adaptive_backpressure,
+            adaptive_concurrency=self._adaptive_concurrency,
         )
 
     def build_runtime_snapshot(self) -> RuntimeSnapshot:

--- a/pyrallel_consumer/dto.py
+++ b/pyrallel_consumer/dto.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Optional
@@ -251,6 +253,12 @@ class SystemMetrics:
         total_in_flight (int): 시스템 전체에서 처리 중인 메시지 수
         is_paused (bool): 백프레셔로 인한 컨슈머 일시 정지 여부
         partitions (List[PartitionMetrics]): 각 파티션별 메트릭 목록
+        adaptive_backpressure: Optional[AdaptiveBackpressureSnapshot]: 백프레셔/적응형
+            backpressure 제어 상태 스냅샷
+        adaptive_concurrency: Optional[AdaptiveConcurrencyRuntimeSnapshot]:
+            적응형 동시성 제어 상태 스냅샷
+        process_batch_metrics (Optional[ProcessBatchMetrics]): process 모드 배치 메트릭
+        resource_signal: Optional[ResourceSignalSnapshot]: 리소스 signal 상태
     """
 
     total_in_flight: int
@@ -258,6 +266,8 @@ class SystemMetrics:
     partitions: list[PartitionMetrics]
     process_batch_metrics: Optional[ProcessBatchMetrics] = None
     resource_signal: Optional[ResourceSignalSnapshot] = None
+    adaptive_backpressure: Optional[AdaptiveBackpressureSnapshot] = None
+    adaptive_concurrency: Optional[AdaptiveConcurrencyRuntimeSnapshot] = None
 
 
 @dataclass(frozen=True)

--- a/pyrallel_consumer/metrics_exporter.py
+++ b/pyrallel_consumer/metrics_exporter.py
@@ -12,6 +12,8 @@ from prometheus_client import (
 
 from pyrallel_consumer.config import MetricsConfig
 from pyrallel_consumer.dto import (
+    AdaptiveBackpressureSnapshot,
+    AdaptiveConcurrencyRuntimeSnapshot,
     CompletionStatus,
     ProcessBatchMetrics,
     ResourceSignalSnapshot,
@@ -21,12 +23,18 @@ from pyrallel_consumer.dto import (
 )
 
 _RESOURCE_SIGNAL_STATUSES = tuple(status.value for status in ResourceSignalStatus)
+_ADAPTIVE_BACKPRESSURE_DECISIONS = (
+    "disabled",
+    "hold",
+    "scale_up",
+    "scale_down",
+    "cooldown",
+)
 COMMIT_FAILURE_REASONS = ("kafka_exception",)
 
 
 class _Joinable(Protocol):
-    def join(self, timeout: float | None = None) -> None:
-        ...
+    def join(self, timeout: float | None = None) -> None: ...
 
 
 class PrometheusMetricsExporter:
@@ -120,6 +128,92 @@ class PrometheusMetricsExporter:
             "Latest host memory utilization ratio from resource signals",
             registry=self._registry,
         )
+        self._adaptive_backpressure_configured_max_in_flight_gauge = Gauge(
+            "consumer_adaptive_backpressure_configured_max_in_flight",
+            "Configured adaptive backpressure max_in_flight ceiling",
+            registry=self._registry,
+        )
+        self._adaptive_backpressure_effective_max_in_flight_gauge = Gauge(
+            "consumer_adaptive_backpressure_effective_max_in_flight",
+            "Live adaptive backpressure max_in_flight limit",
+            registry=self._registry,
+        )
+        self._adaptive_backpressure_min_in_flight_gauge = Gauge(
+            "consumer_adaptive_backpressure_min_in_flight",
+            "Minimum adaptive backpressure max_in_flight floor",
+            registry=self._registry,
+        )
+        self._adaptive_backpressure_scale_up_step_gauge = Gauge(
+            "consumer_adaptive_backpressure_scale_up_step",
+            "Adaptive backpressure scale-up step",
+            registry=self._registry,
+        )
+        self._adaptive_backpressure_scale_down_step_gauge = Gauge(
+            "consumer_adaptive_backpressure_scale_down_step",
+            "Adaptive backpressure scale-down step",
+            registry=self._registry,
+        )
+        self._adaptive_backpressure_cooldown_ms_gauge = Gauge(
+            "consumer_adaptive_backpressure_cooldown_ms",
+            "Adaptive backpressure cooldown in milliseconds",
+            registry=self._registry,
+        )
+        self._adaptive_backpressure_lag_scale_up_threshold_gauge = Gauge(
+            "consumer_adaptive_backpressure_lag_scale_up_threshold",
+            "Adaptive backpressure lag threshold that triggers scale-up",
+            registry=self._registry,
+        )
+        self._adaptive_backpressure_low_latency_threshold_ms_gauge = Gauge(
+            "consumer_adaptive_backpressure_low_latency_threshold_ms",
+            "Adaptive backpressure low-latency threshold in milliseconds",
+            registry=self._registry,
+        )
+        self._adaptive_backpressure_high_latency_threshold_ms_gauge = Gauge(
+            "consumer_adaptive_backpressure_high_latency_threshold_ms",
+            "Adaptive backpressure high-latency threshold in milliseconds",
+            registry=self._registry,
+        )
+        self._adaptive_backpressure_avg_completion_latency_seconds_gauge = Gauge(
+            "consumer_adaptive_backpressure_avg_completion_latency_seconds",
+            "Current adaptive backpressure decision input: completion latency seconds",
+            registry=self._registry,
+        )
+        self._adaptive_backpressure_last_decision_gauge = Gauge(
+            "consumer_adaptive_backpressure_last_decision",
+            "One-hot gauge of the latest adaptive backpressure decision",
+            labelnames=("decision",),
+            registry=self._registry,
+        )
+        self._adaptive_concurrency_configured_max_in_flight_gauge = Gauge(
+            "consumer_adaptive_concurrency_configured_max_in_flight",
+            "Configured adaptive concurrency max_in_flight ceiling",
+            registry=self._registry,
+        )
+        self._adaptive_concurrency_effective_max_in_flight_gauge = Gauge(
+            "consumer_adaptive_concurrency_effective_max_in_flight",
+            "Live adaptive concurrency max_in_flight limit",
+            registry=self._registry,
+        )
+        self._adaptive_concurrency_min_in_flight_gauge = Gauge(
+            "consumer_adaptive_concurrency_min_in_flight",
+            "Minimum adaptive concurrency max_in_flight floor",
+            registry=self._registry,
+        )
+        self._adaptive_concurrency_scale_up_step_gauge = Gauge(
+            "consumer_adaptive_concurrency_scale_up_step",
+            "Adaptive concurrency scale-up step",
+            registry=self._registry,
+        )
+        self._adaptive_concurrency_scale_down_step_gauge = Gauge(
+            "consumer_adaptive_concurrency_scale_down_step",
+            "Adaptive concurrency scale-down step",
+            registry=self._registry,
+        )
+        self._adaptive_concurrency_cooldown_ms_gauge = Gauge(
+            "consumer_adaptive_concurrency_cooldown_ms",
+            "Adaptive concurrency cooldown in milliseconds",
+            registry=self._registry,
+        )
         self._process_batch_flush_count = Gauge(
             "consumer_process_batch_flush_count",
             "Cumulative process batch flush count by reason",
@@ -203,6 +297,10 @@ class PrometheusMetricsExporter:
             duration = partition.blocking_duration_sec or 0.0
             self._blocking_duration_gauge.labels(*labels).set(duration)
         self._update_resource_signal(metrics.resource_signal)
+        self._update_adaptive_snapshot_metrics(
+            metrics.adaptive_backpressure,
+            metrics.adaptive_concurrency,
+        )
         self._update_process_batch_metrics(metrics.process_batch_metrics)
 
     def observe_completion(
@@ -277,6 +375,88 @@ class PrometheusMetricsExporter:
             if signal is not None and signal.memory_utilization is not None
             else 0
         )
+
+    def _update_adaptive_snapshot_metrics(
+        self,
+        adaptive_backpressure: Optional[AdaptiveBackpressureSnapshot],
+        adaptive_concurrency: Optional[AdaptiveConcurrencyRuntimeSnapshot],
+    ) -> None:
+        if adaptive_backpressure is None:
+            self._adaptive_backpressure_configured_max_in_flight_gauge.set(0)
+            self._adaptive_backpressure_effective_max_in_flight_gauge.set(0)
+            self._adaptive_backpressure_min_in_flight_gauge.set(0)
+            self._adaptive_backpressure_scale_up_step_gauge.set(0)
+            self._adaptive_backpressure_scale_down_step_gauge.set(0)
+            self._adaptive_backpressure_cooldown_ms_gauge.set(0)
+            self._adaptive_backpressure_lag_scale_up_threshold_gauge.set(0)
+            self._adaptive_backpressure_low_latency_threshold_ms_gauge.set(0)
+            self._adaptive_backpressure_high_latency_threshold_ms_gauge.set(0)
+            self._adaptive_backpressure_avg_completion_latency_seconds_gauge.set(0)
+            last_decision = "disabled"
+        else:
+            self._adaptive_backpressure_configured_max_in_flight_gauge.set(
+                adaptive_backpressure.configured_max_in_flight
+            )
+            self._adaptive_backpressure_effective_max_in_flight_gauge.set(
+                adaptive_backpressure.effective_max_in_flight
+            )
+            self._adaptive_backpressure_min_in_flight_gauge.set(
+                adaptive_backpressure.min_in_flight
+            )
+            self._adaptive_backpressure_scale_up_step_gauge.set(
+                adaptive_backpressure.scale_up_step
+            )
+            self._adaptive_backpressure_scale_down_step_gauge.set(
+                adaptive_backpressure.scale_down_step
+            )
+            self._adaptive_backpressure_cooldown_ms_gauge.set(
+                adaptive_backpressure.cooldown_ms
+            )
+            self._adaptive_backpressure_lag_scale_up_threshold_gauge.set(
+                adaptive_backpressure.lag_scale_up_threshold
+            )
+            self._adaptive_backpressure_low_latency_threshold_ms_gauge.set(
+                adaptive_backpressure.low_latency_threshold_ms
+            )
+            self._adaptive_backpressure_high_latency_threshold_ms_gauge.set(
+                adaptive_backpressure.high_latency_threshold_ms
+            )
+            self._adaptive_backpressure_avg_completion_latency_seconds_gauge.set(
+                adaptive_backpressure.avg_completion_latency_seconds or 0
+            )
+            last_decision = adaptive_backpressure.last_decision
+
+        for decision in _ADAPTIVE_BACKPRESSURE_DECISIONS:
+            self._adaptive_backpressure_last_decision_gauge.labels(
+                decision=decision
+            ).set(1 if decision == last_decision else 0)
+
+        if adaptive_concurrency is None:
+            self._adaptive_concurrency_configured_max_in_flight_gauge.set(0)
+            self._adaptive_concurrency_effective_max_in_flight_gauge.set(0)
+            self._adaptive_concurrency_min_in_flight_gauge.set(0)
+            self._adaptive_concurrency_scale_up_step_gauge.set(0)
+            self._adaptive_concurrency_scale_down_step_gauge.set(0)
+            self._adaptive_concurrency_cooldown_ms_gauge.set(0)
+        else:
+            self._adaptive_concurrency_configured_max_in_flight_gauge.set(
+                adaptive_concurrency.configured_max_in_flight
+            )
+            self._adaptive_concurrency_effective_max_in_flight_gauge.set(
+                adaptive_concurrency.effective_max_in_flight
+            )
+            self._adaptive_concurrency_min_in_flight_gauge.set(
+                adaptive_concurrency.min_in_flight
+            )
+            self._adaptive_concurrency_scale_up_step_gauge.set(
+                adaptive_concurrency.scale_up_step
+            )
+            self._adaptive_concurrency_scale_down_step_gauge.set(
+                adaptive_concurrency.scale_down_step
+            )
+            self._adaptive_concurrency_cooldown_ms_gauge.set(
+                adaptive_concurrency.cooldown_ms
+            )
 
     def _update_process_batch_metrics(
         self, metrics: Optional[ProcessBatchMetrics]

--- a/tests/unit/control_plane/test_broker_poller_metrics.py
+++ b/tests/unit/control_plane/test_broker_poller_metrics.py
@@ -280,6 +280,49 @@ class TestBrokerPollerMetrics:
         assert metrics.adaptive_concurrency.cooldown_ms == 500
 
     @pytest.mark.asyncio
+    async def test_get_metrics_clamps_adaptive_backpressure_effective_max_to_runtime_limit(
+        self, broker_poller_with_mocks
+    ):
+        broker_poller_with_mocks._adaptive_backpressure_controller = (
+            AdaptiveBackpressureController(
+                configured_max_in_flight=100,
+                config=AdaptiveBackpressureConfig(
+                    enabled=True,
+                    min_in_flight=8,
+                    scale_up_step=16,
+                    scale_down_step=16,
+                    cooldown_ms=1000,
+                    lag_scale_up_threshold=2500,
+                    low_latency_threshold_ms=25.0,
+                    high_latency_threshold_ms=125.0,
+                ),
+            )
+        )
+        broker_poller_with_mocks._adaptive_concurrency_controller = (
+            AdaptiveConcurrencyController(
+                AdaptiveConcurrencyConfig(
+                    enabled=True,
+                    min_in_flight=10,
+                    scale_up_step=8,
+                    scale_down_step=16,
+                    cooldown_ms=500,
+                ),
+                configured_max_in_flight=100,
+            )
+        )
+        # Simulate adaptive concurrency having reduced max_in_flight before this poller
+        # emits runtime snapshots.
+        broker_poller_with_mocks._set_runtime_max_in_flight(40, log_change=False)
+
+        metrics = broker_poller_with_mocks.get_metrics()
+
+        assert metrics.adaptive_backpressure is not None
+        assert metrics.adaptive_backpressure.effective_max_in_flight == 40
+        assert metrics.adaptive_backpressure.configured_max_in_flight == 100
+        assert metrics.adaptive_concurrency is not None
+        assert metrics.adaptive_concurrency.effective_max_in_flight == 40
+
+    @pytest.mark.asyncio
     async def test_get_runtime_snapshot_projects_runtime_state(
         self, broker_poller_with_mocks, mock_work_manager, mock_offset_tracker
     ):

--- a/tests/unit/control_plane/test_broker_poller_metrics.py
+++ b/tests/unit/control_plane/test_broker_poller_metrics.py
@@ -2,7 +2,17 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from pyrallel_consumer.config import KafkaConfig
+from pyrallel_consumer.config import (
+    AdaptiveBackpressureConfig,
+    AdaptiveConcurrencyConfig,
+    KafkaConfig,
+)
+from pyrallel_consumer.control_plane.adaptive_backpressure import (
+    AdaptiveBackpressureController,
+)
+from pyrallel_consumer.control_plane.adaptive_concurrency import (
+    AdaptiveConcurrencyController,
+)
 from pyrallel_consumer.control_plane.broker_poller import BrokerPoller
 from pyrallel_consumer.control_plane.offset_tracker import OffsetTracker
 from pyrallel_consumer.control_plane.work_manager import WorkManager
@@ -218,6 +228,56 @@ class TestBrokerPollerMetrics:
         assert metrics.process_batch_metrics is not None
         assert metrics.process_batch_metrics.size_flush_count == 3
         assert metrics.process_batch_metrics.buffered_items == 1
+
+    @pytest.mark.asyncio
+    async def test_get_metrics_includes_adaptive_runtime_snapshots(
+        self, broker_poller_with_mocks
+    ):
+        broker_poller_with_mocks._adaptive_backpressure_controller = (
+            AdaptiveBackpressureController(
+                configured_max_in_flight=100,
+                config=AdaptiveBackpressureConfig(
+                    enabled=True,
+                    min_in_flight=8,
+                    scale_up_step=16,
+                    scale_down_step=16,
+                    cooldown_ms=1000,
+                    lag_scale_up_threshold=2500,
+                    low_latency_threshold_ms=25.0,
+                    high_latency_threshold_ms=125.0,
+                ),
+            )
+        )
+        broker_poller_with_mocks._adaptive_concurrency_controller = (
+            AdaptiveConcurrencyController(
+                AdaptiveConcurrencyConfig(
+                    enabled=True,
+                    min_in_flight=10,
+                    scale_up_step=8,
+                    scale_down_step=16,
+                    cooldown_ms=500,
+                ),
+                configured_max_in_flight=100,
+            )
+        )
+
+        metrics = broker_poller_with_mocks.get_metrics()
+
+        assert metrics.adaptive_backpressure is not None
+        assert metrics.adaptive_backpressure.configured_max_in_flight == 100
+        assert metrics.adaptive_backpressure.min_in_flight == 8
+        assert metrics.adaptive_backpressure.scale_up_step == 16
+        assert metrics.adaptive_backpressure.scale_down_step == 16
+        assert metrics.adaptive_backpressure.cooldown_ms == 1000
+        assert metrics.adaptive_backpressure.lag_scale_up_threshold == 2500
+        assert metrics.adaptive_backpressure.last_decision == "hold"
+
+        assert metrics.adaptive_concurrency is not None
+        assert metrics.adaptive_concurrency.configured_max_in_flight == 100
+        assert metrics.adaptive_concurrency.min_in_flight == 10
+        assert metrics.adaptive_concurrency.scale_up_step == 8
+        assert metrics.adaptive_concurrency.scale_down_step == 16
+        assert metrics.adaptive_concurrency.cooldown_ms == 500
 
     @pytest.mark.asyncio
     async def test_get_runtime_snapshot_projects_runtime_state(

--- a/tests/unit/control_plane/test_broker_poller_metrics.py
+++ b/tests/unit/control_plane/test_broker_poller_metrics.py
@@ -323,6 +323,53 @@ class TestBrokerPollerMetrics:
         assert metrics.adaptive_concurrency.effective_max_in_flight == 40
 
     @pytest.mark.asyncio
+    async def test_get_metrics_aligns_adaptive_backpressure_effective_max_when_runtime_limit_scales_up(
+        self, broker_poller_with_mocks
+    ):
+        broker_poller_with_mocks._adaptive_backpressure_controller = (
+            AdaptiveBackpressureController(
+                configured_max_in_flight=100,
+                config=AdaptiveBackpressureConfig(
+                    enabled=True,
+                    min_in_flight=8,
+                    scale_up_step=16,
+                    scale_down_step=16,
+                    cooldown_ms=1000,
+                    lag_scale_up_threshold=2500,
+                    low_latency_threshold_ms=25.0,
+                    high_latency_threshold_ms=125.0,
+                ),
+            )
+        )
+        broker_poller_with_mocks._adaptive_concurrency_controller = (
+            AdaptiveConcurrencyController(
+                AdaptiveConcurrencyConfig(
+                    enabled=True,
+                    min_in_flight=10,
+                    scale_up_step=8,
+                    scale_down_step=16,
+                    cooldown_ms=500,
+                ),
+                configured_max_in_flight=100,
+            )
+        )
+        broker_poller_with_mocks._adaptive_backpressure_controller.evaluate(
+            total_true_lag=0,
+            total_queued=10,
+            avg_completion_latency_seconds=0.5,
+            is_paused=True,
+            now_monotonic=1.0,
+        )
+        broker_poller_with_mocks._set_runtime_max_in_flight(60, log_change=False)
+
+        metrics = broker_poller_with_mocks.get_metrics()
+
+        assert metrics.adaptive_backpressure is not None
+        assert metrics.adaptive_backpressure.effective_max_in_flight == 60
+        assert metrics.adaptive_concurrency is not None
+        assert metrics.adaptive_concurrency.effective_max_in_flight == 60
+
+    @pytest.mark.asyncio
     async def test_get_runtime_snapshot_projects_runtime_state(
         self, broker_poller_with_mocks, mock_work_manager, mock_offset_tracker
     ):

--- a/tests/unit/metrics/test_monitoring_assets.py
+++ b/tests/unit/metrics/test_monitoring_assets.py
@@ -52,11 +52,16 @@ def test_grafana_dashboard_includes_process_batch_panels() -> None:
     assert "Process batch flushes" in panel_titles
     assert "Process batch sizing" in panel_titles
     assert "Process batch timing" in panel_titles
+    assert "Adaptive control caps" in panel_titles
+    assert "Adaptive control parameters" in panel_titles
     assert 'consumer_process_batch_flush_count{reason="timer"}' in expressions
     assert "consumer_process_batch_avg_size" in expressions
     assert "consumer_process_batch_avg_main_to_worker_ipc_seconds" in expressions
     assert "consumer_process_batch_avg_worker_exec_seconds" in expressions
     assert "consumer_process_batch_avg_worker_to_main_ipc_seconds" in expressions
+    assert "consumer_adaptive_backpressure_effective_max_in_flight" in expressions
+    assert "consumer_adaptive_concurrency_effective_max_in_flight" in expressions
+    assert "consumer_adaptive_backpressure_last_decision" in expressions
 
 
 def test_operations_guides_use_regex_for_process_flush_reason_set() -> None:

--- a/tests/unit/metrics/test_prometheus_exporter.py
+++ b/tests/unit/metrics/test_prometheus_exporter.py
@@ -6,6 +6,8 @@ from prometheus_client import CollectorRegistry  # noqa: E402
 from pyrallel_consumer.config import MetricsConfig  # noqa: E402
 from pyrallel_consumer.dto import (  # noqa: E402
     CompletionStatus,
+    AdaptiveBackpressureSnapshot,
+    AdaptiveConcurrencyRuntimeSnapshot,
     PartitionMetrics,
     ProcessBatchMetrics,
     ResourceSignalSnapshot,
@@ -75,6 +77,27 @@ def test_exporter_updates_metrics_and_observes_completion():
             last_worker_to_main_ipc_seconds=0.004,
             avg_worker_to_main_ipc_seconds=0.003,
         ),
+        adaptive_backpressure=AdaptiveBackpressureSnapshot(
+            configured_max_in_flight=128,
+            effective_max_in_flight=96,
+            min_in_flight=32,
+            scale_up_step=16,
+            scale_down_step=16,
+            cooldown_ms=1000,
+            lag_scale_up_threshold=1000,
+            low_latency_threshold_ms=25.5,
+            high_latency_threshold_ms=125.0,
+            last_decision="scale_down",
+            avg_completion_latency_seconds=0.42,
+        ),
+        adaptive_concurrency=AdaptiveConcurrencyRuntimeSnapshot(
+            configured_max_in_flight=100,
+            effective_max_in_flight=80,
+            min_in_flight=24,
+            scale_up_step=8,
+            scale_down_step=16,
+            cooldown_ms=500,
+        ),
     )
 
     exporter.update_from_system_metrics(metrics)
@@ -125,6 +148,56 @@ def test_exporter_updates_metrics_and_observes_completion():
         exporter._process_batch_avg_worker_to_main_ipc_seconds_gauge._value.get()
         == 0.003
     )
+    assert (
+        exporter._adaptive_backpressure_configured_max_in_flight_gauge._value.get()
+        == 128
+    )
+    assert (
+        exporter._adaptive_backpressure_effective_max_in_flight_gauge._value.get() == 96
+    )
+    assert exporter._adaptive_backpressure_min_in_flight_gauge._value.get() == 32
+    assert exporter._adaptive_backpressure_scale_up_step_gauge._value.get() == 16
+    assert exporter._adaptive_backpressure_scale_down_step_gauge._value.get() == 16
+    assert exporter._adaptive_backpressure_cooldown_ms_gauge._value.get() == 1000
+    assert (
+        exporter._adaptive_backpressure_lag_scale_up_threshold_gauge._value.get()
+        == 1000
+    )
+    assert (
+        exporter._adaptive_backpressure_low_latency_threshold_ms_gauge._value.get()
+        == 25.5
+    )
+    assert (
+        exporter._adaptive_backpressure_high_latency_threshold_ms_gauge._value.get()
+        == 125.0
+    )
+    assert (
+        exporter._adaptive_backpressure_avg_completion_latency_seconds_gauge._value.get()
+        == 0.42
+    )
+    assert (
+        exporter._adaptive_backpressure_last_decision_gauge.labels(
+            decision="scale_down"
+        )._value.get()
+        == 1
+    )
+    assert (
+        exporter._adaptive_backpressure_last_decision_gauge.labels(
+            decision="scale_up"
+        )._value.get()
+        == 0
+    )
+    assert (
+        exporter._adaptive_concurrency_configured_max_in_flight_gauge._value.get()
+        == 100
+    )
+    assert (
+        exporter._adaptive_concurrency_effective_max_in_flight_gauge._value.get() == 80
+    )
+    assert exporter._adaptive_concurrency_min_in_flight_gauge._value.get() == 24
+    assert exporter._adaptive_concurrency_scale_up_step_gauge._value.get() == 8
+    assert exporter._adaptive_concurrency_scale_down_step_gauge._value.get() == 16
+    assert exporter._adaptive_concurrency_cooldown_ms_gauge._value.get() == 500
 
     tp = TopicPartition(topic="topic-a", partition=0)
     exporter.observe_completion(tp, CompletionStatus.SUCCESS, duration_seconds=0.12)
@@ -159,6 +232,18 @@ def test_exporter_treats_missing_resource_signal_as_fail_open_unavailable() -> N
     )
     assert exporter._resource_cpu_utilization_gauge._value.get() == 0
     assert exporter._resource_memory_utilization_gauge._value.get() == 0
+    assert (
+        exporter._adaptive_backpressure_configured_max_in_flight_gauge._value.get() == 0
+    )
+    assert (
+        exporter._adaptive_backpressure_last_decision_gauge.labels(
+            decision="disabled"
+        )._value.get()
+        == 1
+    )
+    assert (
+        exporter._adaptive_concurrency_effective_max_in_flight_gauge._value.get() == 0
+    )
 
 
 def test_exporter_registers_and_increments_failure_counters() -> None:


### PR DESCRIPTION
## Summary
- Include adaptive backpressure and adaptive concurrency runtime snapshots in SystemMetrics.
- Export these runtime snapshots to Prometheus gauges including decision one-hot metric and fallback-zero behavior.
- Add unit coverage for exporter snapshot updates and broker poller metrics passthrough.

Refs: #83

## Testing
- ruff check
- pytest tests/unit/metrics/test_prometheus_exporter.py tests/unit/control_plane/test_broker_poller_metrics.py