### PR TITLE
fix(release): address PR #90 review follow-ups

### DIFF
--- a/benchmarks/pyrallel_consumer_test.py
+++ b/benchmarks/pyrallel_consumer_test.py
@@ -495,12 +495,6 @@ async def run_pyrallel_consumer_test(
     run_completed = False
     metrics_start = time.perf_counter()
 
-    def _record_release_gate_metrics() -> None:
-        if stats is None:
-            return
-        metrics = broker_poller.get_metrics()
-        _record_release_gate_metrics_from_snapshot(metrics)
-
     def _record_release_gate_metrics_from_snapshot(metrics: SystemMetrics) -> None:
         if stats is None:
             return

--- a/benchmarks/pyrallel_consumer_test.py
+++ b/benchmarks/pyrallel_consumer_test.py
@@ -15,6 +15,7 @@ from pyrallel_consumer.dto import (
     CompletionStatus,
     ExecutionMode,
     OrderingMode,
+    SystemMetrics,
     WorkItem,
 )
 from pyrallel_consumer.execution_plane.async_engine import AsyncExecutionEngine
@@ -498,6 +499,11 @@ async def run_pyrallel_consumer_test(
         if stats is None:
             return
         metrics = broker_poller.get_metrics()
+        _record_release_gate_metrics_from_snapshot(metrics)
+
+    def _record_release_gate_metrics_from_snapshot(metrics: SystemMetrics) -> None:
+        if stats is None:
+            return
         stats.record_release_gate_observation(
             elapsed_sec=time.perf_counter() - metrics_start,
             consumer_parallel_lag=sum(pm.true_lag for pm in metrics.partitions),
@@ -598,10 +604,11 @@ async def run_pyrallel_consumer_test(
                 pass
 
         print("Stopping PyrallelConsumer...")
+        final_metrics = broker_poller.get_metrics()
+        _record_release_gate_metrics_from_snapshot(final_metrics)
         await broker_poller.stop()
         if prometheus_exporter is not None:
-            prometheus_exporter.update_from_system_metrics(broker_poller.get_metrics())
-        _record_release_gate_metrics()
+            prometheus_exporter.update_from_system_metrics(final_metrics)
         await engine.shutdown()
         if stats:
             stats.stop()

--- a/benchmarks/release_gate.py
+++ b/benchmarks/release_gate.py
@@ -167,6 +167,7 @@ def _evaluate_persistent_gap(
         ]
     positive_started_at: float | None = None
     longest_positive_gap_sec = 0.0
+    current_run_name: str | None = None
     for observation in observations:
         if not isinstance(observation, Mapping):
             return [
@@ -177,6 +178,16 @@ def _evaluate_persistent_gap(
                     path=str(path),
                 )
             ]
+        run_name_value = observation.get("run_name")
+        run_name = (
+            str(run_name_value)
+            if isinstance(run_name_value, str) and run_name_value
+            else None
+        )
+        if current_run_name != run_name:
+            current_run_name = run_name
+            positive_started_at = None
+
         elapsed_sec = _as_number(
             observation.get("elapsed_sec"), "elapsed_sec", path=path
         )

--- a/pyrallel_consumer/config.py
+++ b/pyrallel_consumer/config.py
@@ -445,6 +445,14 @@ class KafkaConfig(BaseSettings):
         )
 
     def dump_to_rdkafka(self) -> dict[str, object]:
+        """Return a redacted librdkafka-style snapshot safe for logging/tests."""
+        return self._build_rdkafka_config(include_secrets=False)
+
+    def get_rdkafka_config(self) -> dict[str, object]:
+        """Return a full librdkafka-style config for live client construction."""
+        return self._build_rdkafka_config(include_secrets=True)
+
+    def _build_rdkafka_config(self, *, include_secrets: bool) -> dict[str, object]:
         data: dict[str, object] = self.model_dump(exclude_none=True)
 
         _exclude = {
@@ -457,16 +465,22 @@ class KafkaConfig(BaseSettings):
             "auto_offset_reset",
             "enable_auto_commit",
             "session_timeout_ms",
-            "sasl_password",
-            "ssl_key_password",
             "rebalance_protocol",
             "metrics",
             "parallel_consumer",
         }
+        if not include_secrets:
+            _exclude.update({"sasl_password", "ssl_key_password"})
 
         conf: dict[str, object] = {}
+        if include_secrets:
+            conf["bootstrap.servers"] = self._bootstrap_servers_csv()
+
         for k, v in data.items():
             if k in _exclude:
+                continue
+            if isinstance(v, SecretStr):
+                conf[k.replace("_", ".")] = v.get_secret_value()
                 continue
             conf[k.replace("_", ".")] = v
 

--- a/pyrallel_consumer/config.py
+++ b/pyrallel_consumer/config.py
@@ -472,9 +472,7 @@ class KafkaConfig(BaseSettings):
         if not include_secrets:
             _exclude.update({"sasl_password", "ssl_key_password"})
 
-        conf: dict[str, object] = {}
-        if include_secrets:
-            conf["bootstrap.servers"] = self._bootstrap_servers_csv()
+        conf: dict[str, object] = {"bootstrap.servers": self._bootstrap_servers_csv()}
 
         for k, v in data.items():
             if k in _exclude:

--- a/tests/unit/benchmarks/test_release_gate.py
+++ b/tests/unit/benchmarks/test_release_gate.py
@@ -137,6 +137,31 @@ def test_evaluate_release_gate_reports_no_go_for_persistent_gap_observations(
     assert "persistent_gap" in failed_codes
 
 
+def test_evaluate_release_gate_resets_persistent_gap_timer_per_run_name(
+    tmp_path: Path,
+) -> None:
+    good = _passing_summary()
+    good["metrics_observations"] = [
+        {"run_name": "run-a", "elapsed_sec": 10, "consumer_gap_count": 1},
+        {"run_name": "run-a", "elapsed_sec": 50, "consumer_gap_count": 1},
+        {"run_name": "run-b", "elapsed_sec": 5, "consumer_gap_count": 1},
+        {"run_name": "run-b", "elapsed_sec": 45, "consumer_gap_count": 1},
+    ]
+    paths = []
+    for index in range(2):
+        path = tmp_path / ("release-gate-grouped-gap-%d.json" % index)
+        path.write_text(json.dumps(good), encoding="utf-8")
+        paths.append(path)
+
+    report = release_gate.evaluate_release_gate(paths)
+
+    assert report["verdict"] == "PASS"
+    assert all(
+        check["code"] != "persistent_gap" or check["status"] == "PASS"
+        for check in report["checks"]
+    )
+
+
 def test_evaluate_release_gate_requires_repeated_full_release_matrix(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -358,6 +358,25 @@ def test_kafka_config_masks_secret_security_fields_in_snapshots() -> None:
     assert "key-secret" not in rdkafka_snapshot
 
 
+def test_kafka_config_get_rdkafka_config_includes_secret_security_fields() -> None:
+    config = KafkaConfig(
+        _env_file=None,
+        bootstrap_servers=["secure-1:9093", "secure-2:9093"],
+        security_protocol="SASL_SSL",
+        sasl_username="pyrallel-user",
+        sasl_password="super-secret",
+        ssl_key_password="key-secret",
+    )
+
+    rdkafka_config = config.get_rdkafka_config()
+
+    assert rdkafka_config["bootstrap.servers"] == "secure-1:9093,secure-2:9093"
+    assert rdkafka_config["security.protocol"] == "SASL_SSL"
+    assert rdkafka_config["sasl.username"] == "pyrallel-user"
+    assert rdkafka_config["sasl.password"] == "super-secret"
+    assert rdkafka_config["ssl.key.password"] == "key-secret"
+
+
 def test_kafka_config_omits_blank_security_fields_from_client_configs() -> None:
     config = KafkaConfig(
         _env_file=None,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -343,6 +343,7 @@ def test_kafka_config_includes_allowlisted_security_fields_in_client_configs() -
 def test_kafka_config_masks_secret_security_fields_in_snapshots() -> None:
     config = KafkaConfig(
         _env_file=None,
+        bootstrap_servers=["secure-1:9093", "secure-2:9093"],
         security_protocol="SASL_SSL",
         sasl_username="pyrallel-user",
         sasl_password="super-secret",
@@ -350,12 +351,14 @@ def test_kafka_config_masks_secret_security_fields_in_snapshots() -> None:
     )
 
     dumped_json = config.model_dump_json()
-    rdkafka_snapshot = repr(config.dump_to_rdkafka())
+    redacted_snapshot = config.dump_to_rdkafka()
+    rdkafka_snapshot = repr(redacted_snapshot)
 
     assert "super-secret" not in dumped_json
     assert "key-secret" not in dumped_json
     assert "super-secret" not in rdkafka_snapshot
     assert "key-secret" not in rdkafka_snapshot
+    assert redacted_snapshot["bootstrap.servers"] == "secure-1:9093,secure-2:9093"
 
 
 def test_kafka_config_get_rdkafka_config_includes_secret_security_fields() -> None:


### PR DESCRIPTION
## Summary
- record final release-gate lag/gap before `broker_poller.stop()` so terminal evidence cannot be zeroed by shutdown
- evaluate persistent gap per benchmark `run_name` instead of across merged elapsed timelines
- keep `dump_to_rdkafka()` redacted and add `get_rdkafka_config()` as the full live librdkafka helper

## Tests
- `./.venv/bin/python -m pytest tests/unit/benchmarks/test_release_gate.py tests/unit/test_config.py tests/unit/benchmarks/test_stats.py`
- `./.venv/bin/ruff check benchmarks/release_gate.py benchmarks/pyrallel_consumer_test.py pyrallel_consumer/config.py tests/unit/benchmarks/test_release_gate.py tests/unit/test_config.py tests/unit/benchmarks/test_stats.py`
- `./.venv/bin/python -m mypy benchmarks/release_gate.py benchmarks/pyrallel_consumer_test.py pyrallel_consumer/config.py`

Refs: #90