### PR TITLE
fix(process): preserve worker-pipe shutdown completions

### DIFF
--- a/docs/blueprint/features/03-execution/02-process-execution-engine/04-worker-pipe-transport-experiment.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/04-worker-pipe-transport-experiment.md
@@ -277,6 +277,23 @@ process engine.
 - preserve `wait_for_completion()` expectations around prefetched completions
   and already-queued completions.
 
+#### Shutdown completion-preservation contract
+
+Shutdown completion preservation is a control-plane boundary contract, not a
+transport-specific retry policy. During graceful shutdown, the process engine
+may preserve already-visible real completions by moving them into the same
+prefetched completion path that backs `wait_for_completion()` and
+`poll_completed_events()`. `WorkManager` and `BrokerPoller` must consume those
+events as normal completion events, including epoch/rebalance fencing, offset
+commit advancement, and DLQ handling for failure completions.
+
+Residual work without an already-visible real completion remains
+diagnostic-only in this experiment. Shutdown cleanup must not synthesize failure
+completion events, must not publish DLQ records, and must not make commit
+decisions based only on teardown timing. Any future policy that turns shutdown
+residuals into terminal outcomes must be designed as an explicit control-plane
+contract change, not as a worker-pipe transport side effect.
+
 ### Crash, restart, and recycle guardrails
 
 - the first slice may preserve current dead-worker recovery only when it is

--- a/docs/blueprint/features/03-execution/02-process-execution-engine/04-worker-pipe-transport-experiment.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/04-worker-pipe-transport-experiment.md
@@ -294,6 +294,14 @@ decisions based only on teardown timing. Any future policy that turns shutdown
 residuals into terminal outcomes must be designed as an explicit control-plane
 contract change, not as a worker-pipe transport side effect.
 
+Shutdown drain logs and metrics should be interpreted as diagnostic evidence
+only. Pre-join and post-join drain counts explain how many registry and
+completion events were reconciled before local cleanup; stable-empty post-join
+passes explain that no immediately visible IPC remained within the bounded
+window. They are not a retry ledger, an audit log for commit safety, or evidence
+that residual work failed. Commit, DLQ, and rebalance outcomes continue to be
+derived only from normal completion handling in the control plane.
+
 ### Crash, restart, and recycle guardrails
 
 - the first slice may preserve current dead-worker recovery only when it is

--- a/docs/operations/guide.en.md
+++ b/docs/operations/guide.en.md
@@ -92,7 +92,15 @@ Kafka's default Lag (`LogEndOffset - CommittedOffset`) alone cannot accurately r
 - **Meaning**: Commit clamping is computed from the control-plane `WorkManager` dispatch ledger. This commit clamping rule belongs to the control plane, while process-private registries remain recovery/diagnostics state rather than a required engine capability.
 - **Tip**: Keep `process_batch_metrics` documented as a v1 compatibility projection while generic engine diagnostics evolve internally. When validating refactors, run the same control-plane checks against async and process engines (or mocks) to confirm the boundary stays polymorphic.
 
-### 1.10. Adaptive Backpressure / Adaptive Concurrency Runtime Snapshots
+### 1.10. Shutdown Drain Diagnostics
+- **Log lines**:
+    - `ProcessExecutionEngine shutdown pre-join drain: registry_events=... completion_events=... residual_in_flight_registry=...`
+    - `ProcessExecutionEngine shutdown post-join drain: registry_events=... completion_events=... passes=... residual_in_flight_registry=...`
+    - `Residual in-flight registry after shutdown drain: ...`
+- **Meaning**: These entries describe visible IPC reconciliation during shutdown and remaining process-private diagnostic state. They are not Prometheus counters, a retry ledger, a DLQ trigger, or commit-safety evidence.
+- **Tip**: Treat non-zero `completion_events` as evidence that already-visible real completions were moved into the normal prefetched completion path. Treat `passes` as a bounded stable-empty observation only; it is not proof that no hidden worker outcome can still exist outside the shutdown boundary. Commit advancement, DLQ publish, and epoch fencing remain control-plane decisions driven by normal completion handling.
+
+### 1.11. Adaptive Backpressure / Adaptive Concurrency Runtime Snapshots
 - **Prometheus queries**:
     - `consumer_adaptive_backpressure_configured_max_in_flight`
     - `consumer_adaptive_backpressure_effective_max_in_flight`

--- a/docs/operations/guide.ko.md
+++ b/docs/operations/guide.ko.md
@@ -92,7 +92,15 @@ Kafka의 기본 Lag(`LogEndOffset - CommittedOffset`)만으로는 병렬 처리 
 - **의미**: commit clamping / commit clamp용 최소 in-flight offset은 control-plane `WorkManager` dispatch ledger에서 계산한다. 따라서 process 전용 registry는 canonical commit safety 규칙이 아니라 recovery/diagnostics 상태로 남아야 합니다.
 - **운영 팁**: `process_batch_metrics`는 v1 compatibility projection으로 계속 문서화하고, generic engine diagnostics는 내부 진화 방향으로 취급하십시오. 리팩터링 검증 시 async/process 엔진(또는 mock) 모두에 동일한 control-plane 검증을 적용해 polymorphic 경계가 유지되는지 확인하십시오.
 
-### 1.10. Adaptive Backpressure / Adaptive Concurrency 런타임 스냅샷
+### 1.10. Shutdown Drain Diagnostics (종료 drain 진단)
+- **로그 라인**:
+    - `ProcessExecutionEngine shutdown pre-join drain: registry_events=... completion_events=... residual_in_flight_registry=...`
+    - `ProcessExecutionEngine shutdown post-join drain: registry_events=... completion_events=... passes=... residual_in_flight_registry=...`
+    - `Residual in-flight registry after shutdown drain: ...`
+- **의미**: 이 로그는 shutdown 중 main process에서 보이는 IPC를 얼마나 reconcile했는지와 남은 process-private 진단 상태를 설명합니다. Prometheus counter, retry ledger, DLQ trigger, commit-safety 근거가 아닙니다.
+- **운영 팁**: `completion_events`가 0보다 크면 이미 보이던 real completion이 일반 prefetched completion 경로로 이동했다는 증거로만 해석하십시오. `passes`는 bounded stable-empty 관찰 횟수이며, shutdown 경계 밖의 숨은 worker outcome이 절대 없다는 증명이 아닙니다. Commit advancement, DLQ publish, epoch fencing은 계속 control-plane의 normal completion handling에서만 결정됩니다.
+
+### 1.11. Adaptive Backpressure / Adaptive Concurrency 런타임 스냅샷
 - **Prometheus 쿼리**:
     - `consumer_adaptive_backpressure_configured_max_in_flight`
     - `consumer_adaptive_backpressure_effective_max_in_flight`

--- a/docs/operations/public-contract-v1.md
+++ b/docs/operations/public-contract-v1.md
@@ -95,6 +95,12 @@ Generic engine diagnostics remain an additive internal direction for future runt
 observability, but the documented v1 `RuntimeSnapshot` field boundary above stays
 frozen until a future major-version contract change.
 
+Process-engine shutdown drain log lines are diagnostic-only reconciliation evidence.
+They may report pre-join/post-join `registry_events`, `completion_events`,
+post-join `passes`, and `residual_in_flight_registry`, but those values are not
+part of the frozen `RuntimeSnapshot` contract, are not a retry ledger, and must
+not be interpreted as commit-safety or DLQ-publish authority.
+
 ## 3) Contract Regression Tests
 
 The v1 frozen contract is guarded by the following regression tests.

--- a/docs/plans/2026-04-27-process-worker-pipes-target-algorithm.md
+++ b/docs/plans/2026-04-27-process-worker-pipes-target-algorithm.md
@@ -258,6 +258,21 @@ A work item can be in exactly one canonical phase per execution identity:
   - add/strengthen the residual-log test before changing code;
   - include full logical identity (`id/epoch`) in the residual diagnostic string so same-offset redeliveries remain distinguishable in shutdown logs.
 
+### V2.6: Post-join shutdown diagnostic drain
+- Keep the V2.5 diagnostic-only shutdown policy.
+- Add one final best-effort post-join IPC drain before local shutdown cleanup so registry/completion events that become visible while workers are joining are reconciled, counted, and preserved when they are real worker completions.
+- This final drain is diagnostic/reconciliation only:
+  - it must not start worker recovery;
+  - it must not requeue pending dispatches;
+  - it must not synthesize terminal failure completions;
+  - it must happen before clearing residual in-flight registry and transport pending-dispatch state.
+- Real completions drained during shutdown remain prefetched so the control plane can poll already-produced outcomes; residual work without completions remains diagnostic-only.
+- Tests:
+  - shutdown calls the post-join drain after worker joins and before local cleanup;
+  - late completions drained post-join clear only matching registry entries and remain available to `poll_completed_events`;
+  - post-join drain counts are logged;
+  - existing diagnostic-only shutdown tests continue to prove no synthetic shutdown completion/requeue is emitted.
+
 ## Recommended next instruction for agents
 
 Use this prompt for the next implementation pass:

--- a/docs/plans/2026-04-27-process-worker-pipes-target-algorithm.md
+++ b/docs/plans/2026-04-27-process-worker-pipes-target-algorithm.md
@@ -242,8 +242,21 @@ A work item can be in exactly one canonical phase per execution identity:
   - cross-thread lock contention is side-effect free and retries later.
 
 ### V2.5: Shutdown policy decision
-- Decide whether shutdown residual work should remain diagnostic or become terminal synthetic completions.
-- If terminal completions are emitted, document control-plane implications and DLQ behavior.
+- Decision: keep shutdown residual work diagnostic-only for V2.5; do not emit new terminal synthetic completions from shutdown.
+- Rationale:
+  - Shutdown is an operator/application lifecycle boundary, not evidence that a work item failed in the worker execution model.
+  - Emitting synthetic failures during shutdown would make commit/DLQ behavior depend on teardown timing and could publish DLQ records after the caller has already decided to stop consuming.
+  - Current shutdown already drains visible registry/completion IPC before join, logs residual in-flight work with worker/topic/partition/offset/timeout/attempt diagnostics, then clears local state.
+  - Worker-pipes transport shutdown is mechanical: it sends sentinels and ignores broken senders, while pending dispatch cleanup remains local transport state cleanup.
+- Minimal contract tests:
+  - shutdown drains queued registry and completion events before cleanup, preserving any already-visible completion for the control plane;
+  - shutdown logs residual in-flight registry diagnostics when work remains after the bounded drain;
+  - shutdown delegates sentinel/close behavior through the transport seam and clears pending dispatches after joins;
+  - worker-pipes shutdown ignores broken senders without converting that condition into synthetic failures.
+- Minimal implementation, if needed:
+  - keep existing diagnostic-only semantics;
+  - add/strengthen the residual-log test before changing code;
+  - include full logical identity (`id/epoch`) in the residual diagnostic string so same-offset redeliveries remain distinguishable in shutdown logs.
 
 ## Recommended next instruction for agents
 

--- a/docs/plans/2026-04-27-process-worker-pipes-target-algorithm.md
+++ b/docs/plans/2026-04-27-process-worker-pipes-target-algorithm.md
@@ -286,6 +286,23 @@ A work item can be in exactly one canonical phase per execution identity:
   - keep the transitional `(worker_index, topic, partition, offset)` in-flight key for now because V2.1 centralized full logical identity matching at mutation boundaries;
   - defer full worker-scoped key migration until all registry, timeout, recovery, residual logging, and tests can move together in one explicit migration slice.
 
+### V2.8: Registry key full identity migration review
+- Decision for the current PR: do not widen the in-flight registry key yet.
+- Rationale:
+  - mutation boundaries now compare full logical identity (`id/epoch`) before discarding registry or pending-dispatch state;
+  - widening keys independently would touch registry start/done/timeout paths, pending-dispatch recovery, residual logging, and tests in one cross-cutting migration;
+  - keeping the transitional key avoids mixing a mechanical key migration with shutdown/control-plane boundary hardening.
+- Next explicit migration slice, if chosen, must move these together:
+  - registry key construction and worker `start/done` event payloads;
+  - timeout scan and completion-driven registry discard;
+  - pending-dispatch recovery and slot-release matching;
+  - residual diagnostics and same-offset redelivery tests.
+
+### V2.9: Timeout policy convergence / e2e boundary
+- Keep timeout policy convergence out of the shutdown-preservation PR unless CI proves a direct regression from these changes.
+- Future PR scope should decide whether worker timeout, blocking timeout, shutdown residual diagnostics, and retry/DLQ outcomes need a single operator-facing policy model.
+- E2E failures should be triaged in that separate PR only when they exercise timeout/recovery semantics; otherwise treat them as environment or harness issues first.
+
 ## Recommended next instruction for agents
 
 Use this prompt for the next implementation pass:

--- a/docs/plans/2026-04-27-process-worker-pipes-target-algorithm.md
+++ b/docs/plans/2026-04-27-process-worker-pipes-target-algorithm.md
@@ -274,6 +274,18 @@ A work item can be in exactly one canonical phase per execution identity:
   - post-join drain counts are logged;
   - existing diagnostic-only shutdown tests continue to prove no synthetic shutdown completion/requeue is emitted.
 
+### V2.7: Shutdown diagnostics interpretation and boundary hardening
+- Keep shutdown drain observability diagnostic-only:
+  - pre-join and post-join `registry_events` / `completion_events` counts report visible IPC reconciled before local cleanup;
+  - post-join `passes` reports bounded stable-empty observation, not proof that no hidden worker outcome exists;
+  - residual in-flight registry logs are operator diagnostics, not a retry ledger, DLQ trigger, or commit-safety source.
+- Preserve the control-plane boundary:
+  - real shutdown-preserved completions continue through normal `WorkManager`, `BrokerPoller`, commit, DLQ, and rebalance/epoch fencing;
+  - stale-epoch shutdown-preserved completions must remain fenced before DLQ publish, commit advancement, or cache cleanup.
+- Registry key migration review:
+  - keep the transitional `(worker_index, topic, partition, offset)` in-flight key for now because V2.1 centralized full logical identity matching at mutation boundaries;
+  - defer full worker-scoped key migration until all registry, timeout, recovery, residual logging, and tests can move together in one explicit migration slice.
+
 ## Recommended next instruction for agents
 
 Use this prompt for the next implementation pass:

--- a/docs/plans/2026-04-27-process-worker-pipes-target-algorithm.md
+++ b/docs/plans/2026-04-27-process-worker-pipes-target-algorithm.md
@@ -260,8 +260,8 @@ A work item can be in exactly one canonical phase per execution identity:
 
 ### V2.6: Post-join shutdown diagnostic drain
 - Keep the V2.5 diagnostic-only shutdown policy.
-- Add one final best-effort post-join IPC drain before local shutdown cleanup so registry/completion events that become visible while workers are joining are reconciled, counted, and preserved when they are real worker completions.
-- This final drain is diagnostic/reconciliation only:
+- Add a short bounded stable-empty post-join IPC drain before local shutdown cleanup so registry/completion events that become visible while workers are joining or immediately after the first empty post-join pass are reconciled, counted, and preserved when they are real worker completions.
+- This post-join drain is diagnostic/reconciliation only:
   - it must not start worker recovery;
   - it must not requeue pending dispatches;
   - it must not synthesize terminal failure completions;
@@ -269,6 +269,7 @@ A work item can be in exactly one canonical phase per execution identity:
 - Real completions drained during shutdown remain prefetched so the control plane can poll already-produced outcomes; residual work without completions remains diagnostic-only.
 - Tests:
   - shutdown calls the post-join drain after worker joins and before local cleanup;
+  - post-join draining exits after a bounded stable-empty observation rather than waiting on residual in-flight registry state;
   - late completions drained post-join clear only matching registry entries and remain available to `poll_completed_events`;
   - post-join drain counts are logged;
   - existing diagnostic-only shutdown tests continue to prove no synthetic shutdown completion/requeue is emitted.

--- a/docs/plans/2026-04-27-process-worker-pipes-target-algorithm.md
+++ b/docs/plans/2026-04-27-process-worker-pipes-target-algorithm.md
@@ -1,0 +1,265 @@
+# Target Algorithm: Process Worker-Pipes
+
+## Purpose
+This is the canonical direction document for moving PR #115 beyond the v1 review-fix milestone. v1 made worker-pipes safe enough to review by fixing specific edge cases; v2 should make the algorithm explicit, ownership-bounded, and mechanically verifiable.
+
+The target is not “make every current e2e green” in this phase. The target is an implementation-ready state model that future code changes can follow without rediscovering concurrency/recovery invariants through review comments.
+
+## Current v1 baseline
+
+### Main code touchpoints
+- `pyrallel_consumer/execution_plane/process_engine.py`
+  - owns process lifecycle, liveness scanning, registry/completion draining, worker restart, recovered-payload requeue/failure emission, and shutdown drains.
+- `pyrallel_consumer/execution_plane/process_transport_worker_pipes.py`
+  - owns per-worker pipe dispatch, pending dispatch tracking, worker-pipe slot semaphore, and slot-wait liveness callback.
+- `pyrallel_consumer/execution_plane/process_registry_support.py`
+  - owns pure-ish registry transitions for `start`, `timeout`, `done`, runtime metrics events, and dead-worker recovery extraction.
+- `pyrallel_consumer/execution_plane/process_transport.py`
+  - defines the transport seam and route identity.
+- `pyrallel_consumer/execution_plane/process_transport_shared_queue.py`
+  - remains the shared-queue compatibility transport.
+
+### v1 review fixes that must be preserved
+- Worker-pipe backpressure blocks normally; there is no fixed slot-acquire deadline for healthy long-running work.
+- Slot waiting is decoupled from `task_timeout_ms`.
+- Pending dispatch identity includes `worker/topic/partition/offset/id/epoch`.
+- Dead worker recovery restarts the worker before requeueing recovered worker-pipe payloads.
+- If restart throws after payload recovery, each recovered payload gets a terminal failure completion instead of being dropped.
+- Slot-wait liveness does not recursively run recovery across unrelated threads.
+- Same-thread recovery reentry is allowed through an `RLock`; cross-thread lock contention is side-effect free.
+- Registry/completion mutations are serialized behind registry state locking.
+- Completion prefetch discards in-flight registry rows only when `topic/partition/offset/id/epoch` match.
+
+## Target ownership model
+
+### 1. Engine owns lifecycle and canonical recovery decisions
+`ProcessExecutionEngine` is the only component allowed to decide that a worker is dead, restart a worker, retry recovered work, emit terminal synthetic failures, or abandon work during shutdown.
+
+The engine owns:
+- worker liveness checks and restart ordering;
+- registry queue draining;
+- completion queue prefetch;
+- in-flight registry reconciliation;
+- retry/DLQ-visible synthetic completion emission;
+- shutdown drain and residual diagnostics.
+
+### 2. Transport owns local dispatch capacity, not recovery policy
+`WorkerPipesProcessTransport` owns only the mechanics of delivering bytes to worker pipes and accounting for “sent but not yet accepted by worker loop” items.
+
+The transport owns:
+- route-to-worker dispatch selection;
+- serialization and pipe send;
+- pending dispatch entries until worker `start` acknowledgement;
+- worker-pipe slot acquisition and release;
+- returning pending dispatch payloads for engine-led recovery.
+
+The transport must not:
+- decide retry/DLQ outcome;
+- mutate engine in-flight registry;
+- recursively recover workers;
+- drop payloads silently.
+
+### 3. Registry support owns deterministic state transitions
+`ProcessRegistrySupport` should remain the deterministic transition module for engine-owned registry state. It should not know about pipe semaphores, processes, or transport implementations.
+
+### 4. Control-plane completion handling owns commits/DLQ publishing
+Completion events, including synthetic terminal failures from engine recovery, are the bridge to control-plane commit/DLQ behavior. Engine recovery must surface failures in the same event language as normal worker failures.
+
+## Canonical work identity
+
+The logical work identity is:
+
+```text
+(topic, partition, offset, id, epoch)
+```
+
+The worker-scoped execution identity is:
+
+```text
+(worker_index, topic, partition, offset, id, epoch)
+```
+
+v1 still uses `(worker_index, topic, partition, offset)` for the in-flight registry key and stores `id/epoch` in payload. This is acceptable as a transitional implementation only if all operations that can confuse redelivery/epoch overlap compare payload identity before removing or recovering entries.
+
+### Target invariant
+Any operation that deletes, completes, times out, requeues, or emits failure for work must act on a full logical work identity, not offset alone.
+
+### Future v2 preference
+Consider widening in-flight registry keys to full worker-scoped execution identity once all callsites are ready. This would reduce identity checks hidden in payload comparisons, but it is a larger migration than the current review-fix scope.
+
+## Target state model
+
+A work item can be in exactly one canonical phase per execution identity:
+
+1. `submitted_to_engine`
+   - WorkManager calls engine submit.
+2. `pending_dispatch`
+   - Worker-pipes transport acquired a worker slot and recorded payload before sending bytes.
+   - Slot is held.
+3. `in_flight`
+   - Worker emitted `start`; engine registry has the payload.
+   - Pending dispatch entry is removed and slot is released.
+4. `completed_prefetched`
+   - Engine pulled completion into prefetched completion queue and removed the exact matching in-flight entry.
+5. `completed_delivered`
+   - `poll_completed_events` or `wait_for_completion` surfaces completion to the control plane and decrements in-flight count.
+6. `recovered_pending_or_inflight`
+   - Engine detected a dead worker and recovered entries from pending dispatch and/or in-flight registry.
+7. `requeued`
+   - Engine restarted worker and re-dispatched recovered payloads with incremented recovery attempts.
+8. `terminal_failure_emitted`
+   - Max retries, timeout, or restart failure surfaced a failure completion.
+9. `shutdown_drained_or_abandoned_with_diagnostics`
+   - Shutdown path drained visible events and reported residual state.
+
+## Target event flow
+
+### Submit / dispatch
+1. Engine drains registry/completion opportunistically before submit when in worker-pipes mode.
+2. Engine resolves route identity once from `WorkItem`.
+3. Transport computes stable worker index.
+4. Transport waits for the target worker slot.
+   - If a liveness callback is configured, it may call engine liveness periodically.
+   - The callback must be side-effect free when another thread owns the liveness lock.
+5. After slot acquisition, transport writes pending dispatch entry keyed by full dispatch identity.
+6. Transport serializes and sends bytes to the worker pipe.
+7. If serialization/send fails, transport removes pending entry, releases slot, and raises.
+8. If dispatch succeeds and this is original submission, engine in-flight count is incremented through the transport callback.
+
+### Worker start acknowledgement
+1. Worker decodes payload and emits `start` with worker-scoped offset key and full payload.
+2. Engine drains registry event.
+3. Engine first lets transport handle the event.
+4. Worker-pipes transport removes the matching pending dispatch entry using full payload identity and releases the slot.
+5. Registry support records payload in in-flight registry.
+
+### Completion
+1. Worker emits completion with `id/topic/partition/offset/epoch/status/error/attempt`.
+2. Worker emits `done` for the registry key after completion enqueue when non-timeout.
+3. Engine prefetch or poll decodes completion.
+4. Engine discards only the in-flight entry whose topic/partition/offset plus id/epoch match the completion.
+5. Control plane later processes the completion and applies commit/DLQ behavior.
+
+### Timeout
+1. Worker emits `timeout` registry event and exits fatally.
+2. Engine registry marks the exact in-flight entry timed out.
+3. Worker liveness recovery emits a timeout failure completion for timed-out entries and removes them from registry.
+4. Timeout failures are terminal for that worker execution and should not be requeued by dead-worker recovery.
+
+### Worker death recovery
+1. Engine drains registry/completion before scanning workers.
+2. For each dead worker:
+   1. Recover in-flight entries owned by that worker.
+   2. Recover pending dispatches owned by that worker from transport.
+   3. Apply retry eligibility/max retry rules once.
+   4. Restart the worker.
+   5. If restart fails, emit terminal failure completions for recovered payloads.
+   6. If restart succeeds, requeue recovered payloads through the transport.
+3. Requeue must not recursively trigger cross-thread recovery mutation.
+4. Same-thread liveness reentry may drain/reconcile only through controlled reentrant lock paths.
+
+### Shutdown
+1. Signal transport shutdown for all workers.
+2. Drain registry and completion queues for a bounded period.
+3. Join/terminate workers as needed.
+4. Log residual in-flight registry with enough identity to diagnose unrecovered work.
+5. Clear transport pending dispatch and local diagnostic state only after drains/joins complete.
+
+## Core invariants
+
+1. **No silent drop**: every accepted payload must eventually be in pending, in-flight, prefetched completion, delivered completion, requeued, terminal failure emitted, or explicitly logged during shutdown residual diagnostics.
+2. **Identity preservation**: same topic/partition/offset with different id/epoch must remain distinct across pending dispatch, in-flight registry, completion prefetch, and recovery.
+3. **Slot ownership**: worker-pipe slot is held from successful pre-send pending dispatch record until a matching worker `start` event, send failure, pending recovery, or shutdown cleanup.
+4. **Single recovery owner**: only one thread may perform full liveness/recovery at a time; other slot waiters must either no-op or same-thread reenter safely.
+5. **Transport is mechanical**: transport returns recoverable pending payloads but does not choose retry/DLQ semantics.
+6. **Completion is authoritative for control plane**: terminal recovery outcomes must be expressed as completion events, not only logs.
+7. **Drains are serialized**: registry/completion mutation paths must not run concurrently with dead-worker registry iteration.
+8. **Retry count monotonicity**: recovery retries increment exactly once per recovery decision, not once per nested callback or slot wait loop.
+9. **Backpressure is not failure**: full worker-pipe slots mean wait/reconcile, not timeout/fail under normal healthy workers.
+10. **Shutdown is explicit**: shutdown cleanup may clear local state only after giving visible events a bounded chance to surface and after logging leftovers.
+
+## V1 gaps versus target
+
+1. **In-flight registry key shape is transitional**
+   - Current key omits id/epoch and depends on payload checks for identity-sensitive removal.
+   - V2 should evaluate widening the key or centralizing identity match helpers.
+
+2. **State transitions are distributed**
+   - Slot release occurs in transport `handle_registry_event` while registry mutation occurs in engine support.
+   - V2 should make event application order and failure behavior explicit in tests and docs.
+
+3. **Recovery and completion prefetch share mutable state**
+   - v1 now serializes, but the model is still implicit.
+   - V2 should centralize registry mutation APIs so all state changes pass through one small surface.
+
+4. **Retry/DLQ semantics are split across engine and control plane**
+   - Engine chooses terminal synthetic failure attempts; control plane interprets attempts for DLQ.
+   - V2 should document or encode this contract more directly.
+
+5. **Pending dispatch recovery is transport-specific**
+   - Shared queue has no pending dispatch recovery; worker-pipes does.
+   - V2 should define transport capability contracts explicitly.
+
+6. **Shutdown residual handling is diagnostic-heavy**
+   - Shutdown logs leftovers but does not model them as terminal events.
+   - Future work should decide if shutdown should emit terminal synthetic completions or remain diagnostic-only.
+
+## V2 implementation roadmap
+
+### V2.1: Identity and registry API consolidation
+- Add helper functions for work identity comparison and registry matching.
+- Replace ad hoc `topic/partition/offset/id/epoch` comparisons with helper use.
+- Consider a typed alias/dataclass for logical and execution identity.
+- Tests:
+  - same offset/different id/epoch cannot be removed by stale completion;
+  - timeout/done/start target only intended identity where payload identity is available.
+
+### V2.2: Explicit transport capability contract
+- Document/encode whether a transport has pending dispatch recovery.
+- Make `recover_pending_dispatches` return payloads plus enough identity metadata for diagnostics.
+- Tests:
+  - worker-pipes pending dispatch recovery releases slots exactly once;
+  - shared queue returns no pending dispatches and recovery is entirely registry-based.
+
+### V2.3: Recovery transaction shape
+- Refactor `_ensure_workers_alive` into a small sequence of named operations:
+  1. drain visible events;
+  2. collect worker recovery candidates;
+  3. restart worker;
+  4. publish terminal failures or requeue;
+  5. log outcome.
+- Preserve restart-before-requeue ordering for worker-pipes.
+- Tests:
+  - restart failure emits terminal completion for in-flight and pending entries;
+  - requeue happens once per recovered payload;
+  - max retry entries do not requeue.
+
+### V2.4: Backpressure/liveness contract tests
+- Promote the slot-wait/liveness edge cases into clear behavioral tests.
+- Tests:
+  - healthy long-running worker causes blocking, not failure;
+  - same-thread recovery reentry can free slots;
+  - cross-thread lock contention is side-effect free and retries later.
+
+### V2.5: Shutdown policy decision
+- Decide whether shutdown residual work should remain diagnostic or become terminal synthetic completions.
+- If terminal completions are emitted, document control-plane implications and DLQ behavior.
+
+## Recommended next instruction for agents
+
+Use this prompt for the next implementation pass:
+
+> Read `.omx/plans/target-algorithm-process-worker-pipes.md`, `.omx/plans/prd-process-worker-pipes-target-algorithm.md`, and `.omx/plans/test-spec-process-worker-pipes-target-algorithm.md`. Treat PR #115 v1 review fixes as complete. Do not chase e2e CI failures unless a proposed v2 change directly affects them. Implement V2.1 only: centralize work identity matching for process worker-pipes registry/completion handling with minimal diff and regression tests. Do not commit `AGENTS.md`.
+
+## Completion criteria for this document phase
+- This document exists and names state owners, identities, event flows, invariants, v1 gaps, and v2 tasks.
+- Team/subagent review is incorporated before committing.
+- Verification: `test -s .omx/plans/target-algorithm-process-worker-pipes.md` and `git diff --check`.
+
+## Team/Ralph review notes
+
+- `$team ralph 3:architect` was launched as `process-worker-pipes-target-al` to parallelize review of ownership, invariants, and migration risks.
+- Startup evidence: workers `%149`, `%150`, `%151` were created; `omx team status` reported `workers: total=3 dead=0 non_reporting=0` at startup.
+- Worker-2 completed PRD review; worker-3 completed test-spec/doc existence review; worker-1 inspected process engine/transport/registry code and ran targeted verification commands before the team panes stopped.
+- The team runtime split the task prompt too broadly into small task fragments and later reported dead workers with pending fragments, so the leader integrated the usable findings and finalized this document directly.
+- Verification performed for this document phase: `test -s .omx/plans/target-algorithm-process-worker-pipes.md` and `git diff --check`.

--- a/pyrallel_consumer/control_plane/broker_completion_support.py
+++ b/pyrallel_consumer/control_plane/broker_completion_support.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional, Protocol
 
 from pyrallel_consumer.config import KafkaConfig
@@ -13,6 +14,12 @@ from pyrallel_consumer.dto import TopicPartition as DtoTopicPartition
 class DlqFailureMetricsExporter(Protocol):
     def record_dlq_publish_failure(self, tp: DtoTopicPartition) -> None:
         ...
+
+
+@dataclass(frozen=True)
+class CompletionProcessingResult:
+    processed_count: int
+    completed_partitions: frozenset[DtoTopicPartition]
 
 
 class BrokerCompletionSupport:
@@ -87,11 +94,13 @@ class BrokerCompletionSupport:
     async def process_completed_events(
         self,
         completed_events: list[CompletionEvent],
-    ) -> int:
+    ) -> CompletionProcessingResult:
         pending_events = [(event, True) for event in self._pending_dlq_events.values()]
         fresh_events = [(event, False) for event in completed_events]
         events_to_process = pending_events + fresh_events
         resolved_pending_keys: set[tuple[DtoTopicPartition, int]] = set()
+        completed_count = 0
+        completed_partitions: set[DtoTopicPartition] = set()
 
         for event, from_pending_ledger in events_to_process:
             pending_key = (event.tp, event.offset)
@@ -182,9 +191,14 @@ class BrokerCompletionSupport:
                     continue
 
             tracker.mark_complete(event.offset)
+            completed_count += 1
+            completed_partitions.add(event.tp)
             if from_pending_ledger:
                 resolved_pending_keys.add(pending_key)
             self._pending_dlq_events.pop(pending_key, None)
             self._pop_cached_message((event.tp, event.offset))
 
-        return len(events_to_process)
+        return CompletionProcessingResult(
+            processed_count=completed_count,
+            completed_partitions=frozenset(completed_partitions),
+        )

--- a/pyrallel_consumer/control_plane/broker_poller.py
+++ b/pyrallel_consumer/control_plane/broker_poller.py
@@ -712,16 +712,15 @@ class BrokerPoller:
         pending_retry_partitions = {
             tp for tp, _ in self._pending_dlq_events.keys() if tp in managed_partitions
         }
-        processed_count = (
+        processing_result = (
             await self._make_completion_support().process_completed_events(
                 completed_events
             )
         )
+        processed_count = processing_result.processed_count
+        completed_partitions = set(processing_result.completed_partitions)
 
         if processed_count > 0:
-            completed_partitions = {
-                event.tp for event in completed_events if event.tp in managed_partitions
-            }
             dirty_partitions = completed_partitions | pending_retry_partitions
             self._dirty_commit_partitions.update(dirty_partitions)
             self._completions_since_last_commit += processed_count

--- a/pyrallel_consumer/control_plane/work_manager.py
+++ b/pyrallel_consumer/control_plane/work_manager.py
@@ -180,14 +180,24 @@ class WorkManager:
         dispatch_time = self._dispatch_timestamps.pop(work_item_id, None)
         if completed_item is None:
             return False, dispatch_time
-        self._work_item_ids_by_tp_offset.pop(
-            (completed_item.tp, completed_item.offset), None
-        )
+        tp_offset_key = (completed_item.tp, completed_item.offset)
+        if self._work_item_ids_by_tp_offset.get(tp_offset_key) == work_item_id:
+            self._work_item_ids_by_tp_offset.pop(tp_offset_key, None)
 
         if self._ordering_mode == OrderingMode.KEY_HASH:
-            self._keys_in_flight.discard((completed_item.tp, completed_item.key))
+            if not any(
+                item.tp == completed_item.tp and item.key == completed_item.key
+                for item_id, item in self._in_flight_work_items.items()
+                if item_id in self._dispatch_timestamps
+            ):
+                self._keys_in_flight.discard((completed_item.tp, completed_item.key))
         elif self._ordering_mode == OrderingMode.PARTITION:
-            self._partitions_in_flight.discard(completed_item.tp)
+            if not any(
+                item.tp == completed_item.tp
+                for item_id, item in self._in_flight_work_items.items()
+                if item_id in self._dispatch_timestamps
+            ):
+                self._partitions_in_flight.discard(completed_item.tp)
 
         self._cleanup_empty_queue(completed_item.tp, completed_item.key)
         if dispatch_time is not None:

--- a/pyrallel_consumer/control_plane/work_manager.py
+++ b/pyrallel_consumer/control_plane/work_manager.py
@@ -71,6 +71,8 @@ class WorkManager:
         self._max_revoke_grace_ms = max_revoke_grace_ms
         self._keys_in_flight: set[tuple[DtoTopicPartition, Any]] = set()
         self._partitions_in_flight: set[DtoTopicPartition] = set()
+        self._key_in_flight_counts: Dict[tuple[DtoTopicPartition, Any], int] = {}
+        self._partition_in_flight_counts: Dict[DtoTopicPartition, int] = {}
         self._blocking_cache: Dict[DtoTopicPartition, Optional[OffsetRange]] = {}
         self._blocking_cache_ttl = blocking_cache_ttl
         self._blocking_cache_counter = 0
@@ -184,20 +186,8 @@ class WorkManager:
         if self._work_item_ids_by_tp_offset.get(tp_offset_key) == work_item_id:
             self._work_item_ids_by_tp_offset.pop(tp_offset_key, None)
 
-        if self._ordering_mode == OrderingMode.KEY_HASH:
-            if not any(
-                item.tp == completed_item.tp and item.key == completed_item.key
-                for item_id, item in self._in_flight_work_items.items()
-                if item_id in self._dispatch_timestamps
-            ):
-                self._keys_in_flight.discard((completed_item.tp, completed_item.key))
-        elif self._ordering_mode == OrderingMode.PARTITION:
-            if not any(
-                item.tp == completed_item.tp
-                for item_id, item in self._in_flight_work_items.items()
-                if item_id in self._dispatch_timestamps
-            ):
-                self._partitions_in_flight.discard(completed_item.tp)
+        if dispatch_time is not None:
+            self._release_ordering_lock(completed_item)
 
         self._cleanup_empty_queue(completed_item.tp, completed_item.key)
         if dispatch_time is not None:
@@ -221,6 +211,34 @@ class WorkManager:
         if self._ordering_mode == OrderingMode.PARTITION:
             return tp not in self._partitions_in_flight
         return True
+
+    def _record_ordering_lock(self, item: WorkItem) -> None:
+        if self._ordering_mode == OrderingMode.KEY_HASH:
+            key = (item.tp, item.key)
+            self._key_in_flight_counts[key] = self._key_in_flight_counts.get(key, 0) + 1
+            self._keys_in_flight.add(key)
+        elif self._ordering_mode == OrderingMode.PARTITION:
+            self._partition_in_flight_counts[item.tp] = (
+                self._partition_in_flight_counts.get(item.tp, 0) + 1
+            )
+            self._partitions_in_flight.add(item.tp)
+
+    def _release_ordering_lock(self, item: WorkItem) -> None:
+        if self._ordering_mode == OrderingMode.KEY_HASH:
+            key = (item.tp, item.key)
+            remaining = self._key_in_flight_counts.get(key, 1) - 1
+            if remaining > 0:
+                self._key_in_flight_counts[key] = remaining
+            else:
+                self._key_in_flight_counts.pop(key, None)
+                self._keys_in_flight.discard(key)
+        elif self._ordering_mode == OrderingMode.PARTITION:
+            remaining = self._partition_in_flight_counts.get(item.tp, 1) - 1
+            if remaining > 0:
+                self._partition_in_flight_counts[item.tp] = remaining
+            else:
+                self._partition_in_flight_counts.pop(item.tp, None)
+                self._partitions_in_flight.discard(item.tp)
 
     def _pick_blocking_queue_key(
         self, blocking_offsets: Dict[DtoTopicPartition, Optional[OffsetRange]]
@@ -335,6 +353,16 @@ class WorkManager:
                 }
             elif self._ordering_mode == OrderingMode.PARTITION:
                 self._partitions_in_flight -= revoked_tp_set
+            self._key_in_flight_counts = {
+                key: count
+                for key, count in self._key_in_flight_counts.items()
+                if key[0] not in revoked_tp_set
+            }
+            self._partition_in_flight_counts = {
+                tp: count
+                for tp, count in self._partition_in_flight_counts.items()
+                if tp not in revoked_tp_set
+            }
         self._rebalancing = True  # Rebalancing starts when partitions are revoked
         self._invalidate_blocking_cache()
 
@@ -464,12 +492,7 @@ class WorkManager:
                     )
                     self._current_in_flight_count += 1
                     self._dispatch_timestamps[item_to_submit.id] = time.perf_counter()
-                    if self._ordering_mode == OrderingMode.KEY_HASH:
-                        self._keys_in_flight.add(
-                            (item_to_submit.tp, item_to_submit.key)
-                        )
-                    elif self._ordering_mode == OrderingMode.PARTITION:
-                        self._partitions_in_flight.add(item_to_submit.tp)
+                    self._record_ordering_lock(item_to_submit)
                 except Exception:
                     self._logger.exception(
                         "Error submitting work item %s", item_to_submit.id

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -87,6 +87,16 @@ def _work_item_from_dict(payload: SerializedWorkItem) -> WorkItem:
     )
 
 
+def _work_item_identity_payload(payload: SerializedWorkItem) -> SerializedWorkItem:
+    return {
+        "id": payload["id"],
+        "topic": payload["topic"],
+        "partition": payload["partition"],
+        "offset": payload["offset"],
+        "epoch": payload["epoch"],
+    }
+
+
 def _completion_event_to_dict(
     event: CompletionEvent,
     extra_fields: Optional[dict[str, Any]] = None,
@@ -640,7 +650,7 @@ def _worker_loop(
                         {
                             "kind": "done",
                             "key": in_flight_key,
-                            "payload": dict(payload),
+                            "payload": _work_item_identity_payload(payload),
                         }
                     )
 

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -1232,12 +1232,11 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             # became empty before local cleanup closes the shutdown boundary.
             if remaining_seconds <= 0 and not drained_any_events:
                 break
-            await asyncio.sleep(
-                min(
-                    _SHUTDOWN_DRAIN_SLEEP_SECONDS,
-                    max(0.0, remaining_seconds),
-                )
-            )
+            if remaining_seconds > 0:
+                sleep_seconds = min(_SHUTDOWN_DRAIN_SLEEP_SECONDS, remaining_seconds)
+            else:
+                sleep_seconds = _SHUTDOWN_DRAIN_SLEEP_SECONDS
+            await asyncio.sleep(sleep_seconds)
 
         return total_registry_drained, total_completion_drained, total_passes
 

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -550,6 +550,7 @@ def _worker_loop(
                         {
                             "kind": "timeout",
                             "key": in_flight_key,
+                            "payload": dict(payload),
                             "attempt": attempt,
                             "timeout_error": error,
                         }
@@ -632,7 +633,13 @@ def _worker_loop(
                         put_exc,
                     )
                 finally:
-                    registry_event_queue.put({"kind": "done", "key": in_flight_key})
+                    registry_event_queue.put(
+                        {
+                            "kind": "done",
+                            "key": in_flight_key,
+                            "payload": dict(payload),
+                        }
+                    )
 
             # Check worker recycling after task completion
             if recycle_limit is not None:
@@ -1087,22 +1094,22 @@ class ProcessExecutionEngine(BaseExecutionEngine):
                 except queue.Empty:
                     return prefetched
                 event = self._decode_completion_queue_item(raw_event)
-                prefetched_events.append(event)
+                self._prefetch_completion_event(event)
                 prefetched += 1
-                self._discard_registry_entry_for_completion(event)
+
+    def _prefetch_completion_event(self, event: CompletionEvent) -> None:
+        self._prefetched_completion_events.append(event)
+        self._discard_registry_entry_for_completion(event)
 
     def _discard_registry_entry_for_completion(self, event: CompletionEvent) -> None:
         with self._get_registry_state_lock():
-            for key, payload in list(self._in_flight_registry.items()):
-                _worker_index, topic, partition, offset = key
-                if (
-                    topic == event.tp.topic
-                    and partition == event.tp.partition
-                    and offset == event.offset
-                    and payload.get("epoch", 0) == event.epoch
-                    and payload.get("id", "") == event.id
-                ):
-                    self._in_flight_registry.pop(key, None)
+            in_flight_registry = getattr(self, "_in_flight_registry", None)
+            if in_flight_registry is None:
+                return
+            ProcessRegistrySupport.discard_completion_from_registry(
+                in_flight_registry=in_flight_registry,
+                event=event,
+            )
 
     def _drain_shutdown_ipc_once(self) -> tuple[int, int]:
         drained_registry = self._drain_registry_event_queue()
@@ -1114,7 +1121,7 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             except queue.Empty:
                 break
             drained_completion += 1
-            self._prefetched_completion_events.append(
+            self._prefetch_completion_event(
                 self._decode_completion_queue_item(raw_event)
             )
 
@@ -1221,6 +1228,7 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             try:
                 raw_event = self._completion_queue.get_nowait()
                 event = self._decode_completion_queue_item(raw_event)
+                self._discard_registry_entry_for_completion(event)
                 completed_events.append(event)
                 with self._in_flight_lock:
                     self._in_flight_count -= 1
@@ -1248,7 +1256,7 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             raw_event = None
 
         if raw_event is not None:
-            self._prefetched_completion_events.append(
+            self._prefetch_completion_event(
                 self._decode_completion_queue_item(raw_event)
             )
             return True
@@ -1265,9 +1273,7 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         except queue.Empty:
             return False
 
-        self._prefetched_completion_events.append(
-            self._decode_completion_queue_item(raw_event)
-        )
+        self._prefetch_completion_event(self._decode_completion_queue_item(raw_event))
         return True
 
     def _initialize_runtime_timing_state(self) -> None:

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -14,7 +14,7 @@ import time
 from collections import deque
 from collections.abc import Callable
 from multiprocessing import Process, Queue
-from typing import Any, Deque, List, Optional
+from typing import Any, Deque, List, Optional, cast
 
 import msgpack  # type: ignore[import-untyped]
 
@@ -1272,8 +1272,10 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         """
         완료 큐에서 완료 이벤트를 가져와 리스트로 반환합니다.
         """
-        await asyncio.to_thread(self._ensure_workers_alive)
-        self._drain_registry_events()
+        if not getattr(self, "_is_shutdown", False):
+            await asyncio.to_thread(self._ensure_workers_alive)
+            self._drain_registry_events()
+
         completed_events: List[CompletionEvent] = []
         while (
             len(completed_events) < batch_limit and self._prefetched_completion_events
@@ -1281,6 +1283,8 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             completed_events.append(self._prefetched_completion_events.popleft())
             with self._in_flight_lock:
                 self._in_flight_count -= 1
+        if getattr(self, "_is_shutdown", False):
+            return completed_events
         while len(completed_events) < batch_limit:
             try:
                 raw_event = self._completion_queue.get_nowait()
@@ -1301,6 +1305,9 @@ class ProcessExecutionEngine(BaseExecutionEngine):
     async def wait_for_completion(
         self, timeout_seconds: Optional[float] = None
     ) -> bool:
+        if getattr(self, "_is_shutdown", False):
+            return bool(self._prefetched_completion_events)
+
         await asyncio.to_thread(self._ensure_workers_alive)
         self._drain_registry_events()
 
@@ -1466,6 +1473,21 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             total_completion_drained,
             len(self._in_flight_registry),
         )
+
+        # Wait for all workers to finish
+        for worker in self._workers:
+            self._join_worker_with_escalation(worker)
+
+        (
+            post_join_registry_drained,
+            post_join_completion_drained,
+        ) = self._drain_shutdown_ipc_once()
+        _logger.debug(
+            "ProcessExecutionEngine shutdown post-join drain: registry_events=%d completion_events=%d residual_in_flight_registry=%d",
+            post_join_registry_drained,
+            post_join_completion_drained,
+            len(self._in_flight_registry),
+        )
         if self._in_flight_registry:
             registry_summary = []
             for (worker_idx, topic, partition, offset), payload in sorted(
@@ -1491,15 +1513,16 @@ class ProcessExecutionEngine(BaseExecutionEngine):
                 "; ".join(registry_summary),
             )
 
-        # Wait for all workers to finish
-        for worker in self._workers:
-            self._join_worker_with_escalation(worker)
-
-        self._prefetched_completion_events.clear()
+        for _ in range(min(prefetched_count, len(self._prefetched_completion_events))):
+            popleft = getattr(self._prefetched_completion_events, "popleft", None)
+            if callable(popleft):
+                popleft()
+            else:
+                cast(Any, self._prefetched_completion_events).pop(0)
         self._in_flight_registry.clear()
         self._transport.clear_pending_dispatches()
         with self._in_flight_lock:
-            self._in_flight_count = 0
+            self._in_flight_count = len(self._prefetched_completion_events)
 
         _logger.debug("ProcessExecutionEngine shutdown complete.")
         self._log_listener.stop()

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -1473,13 +1473,15 @@ class ProcessExecutionEngine(BaseExecutionEngine):
                 key=lambda item: item[0],
             ):
                 registry_summary.append(
-                    "%d(pid=%s):%s-%d@%d timed_out=%s attempts=%s"
+                    "%d(pid=%s):%s-%d@%d id=%s epoch=%s timed_out=%s attempts=%s"
                     % (
                         worker_idx,
                         self._worker_pid_by_index.get(worker_idx),
                         topic,
                         partition,
                         offset,
+                        payload.get("id", ""),
+                        payload.get("epoch", 0),
                         payload.get("timed_out", False),
                         payload.get("requeue_attempts", 0),
                     )

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -1204,11 +1204,13 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         stable_empty_passes: int,
     ) -> tuple[int, int, int]:
         deadline = time.monotonic() + max(0.0, max_seconds)
+        hard_deadline = deadline + (
+            _SHUTDOWN_DRAIN_SLEEP_SECONDS * max(1, stable_empty_passes + 2)
+        )
         total_registry_drained = 0
         total_completion_drained = 0
         total_passes = 0
         empty_passes = 0
-        drained_any_events = False
 
         while True:
             drained_registry, drained_completion = self._drain_shutdown_ipc_once()
@@ -1220,22 +1222,28 @@ class ProcessExecutionEngine(BaseExecutionEngine):
                 empty_passes += 1
             else:
                 empty_passes = 0
-                drained_any_events = True
 
             if empty_passes >= stable_empty_passes:
                 break
-            remaining_seconds = deadline - time.monotonic()
-            # Once shutdown has observed post-join IPC, the safety boundary is
-            # stable-empty observation after that event rather than the original
-            # time budget. Otherwise a completion that arrives on the last
-            # budgeted pass could be prefetched without proving the queue then
-            # became empty before local cleanup closes the shutdown boundary.
-            if remaining_seconds <= 0 and not drained_any_events:
-                break
+            now = time.monotonic()
+            remaining_seconds = deadline - now
+            # The shutdown safety boundary is stable-empty observation, not
+            # merely the original time budget.  A multiprocessing.Queue feeder
+            # can make the first late IPC event visible just after the budget,
+            # so still perform non-zero post-deadline waits until the queue has
+            # been observed empty for the configured consecutive passes.  Keep
+            # that post-deadline grace bounded so shutdown cannot hang forever
+            # if a buggy or hostile queue source never reaches stable-empty.
             if remaining_seconds > 0:
                 sleep_seconds = min(_SHUTDOWN_DRAIN_SLEEP_SECONDS, remaining_seconds)
             else:
-                sleep_seconds = _SHUTDOWN_DRAIN_SLEEP_SECONDS
+                remaining_grace_seconds = hard_deadline - now
+                if remaining_grace_seconds <= 0:
+                    break
+                sleep_seconds = min(
+                    _SHUTDOWN_DRAIN_SLEEP_SECONDS,
+                    remaining_grace_seconds,
+                )
             await asyncio.sleep(sleep_seconds)
 
         return total_registry_drained, total_completion_drained, total_passes

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -961,8 +961,25 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             )
 
     def _ensure_workers_alive(self, *, force: bool = False) -> None:
+        self._drain_visible_worker_events()
+        if not self._should_run_worker_liveness_scan(force=force):
+            return
+
+        for idx, exitcode in self._collect_dead_worker_recovery_candidates():
+            to_requeue = self._collect_recoverable_worker_payloads(idx)
+            self._logger.error(
+                "ProcessWorker[%d] died (exitcode=%s). Restarting worker.",
+                idx,
+                exitcode,
+            )
+            if self._restart_dead_worker(idx, exitcode, to_requeue):
+                self._publish_recovered_worker_payloads(idx, to_requeue)
+
+    def _drain_visible_worker_events(self) -> None:
         self._drain_registry_events()
         self._prefetch_completed_events_from_queue()
+
+    def _should_run_worker_liveness_scan(self, *, force: bool) -> bool:
         liveness_interval = getattr(
             self,
             "_worker_liveness_check_interval_seconds",
@@ -972,60 +989,90 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             now = time.monotonic()
             last_check = getattr(self, "_last_worker_liveness_check", 0.0)
             if now - last_check < liveness_interval:
-                return
+                return False
             self._last_worker_liveness_check = now
-        elif force:
+            return True
+        if force:
             self._last_worker_liveness_check = time.monotonic()
+        return True
 
+    def _collect_dead_worker_recovery_candidates(self) -> list[tuple[int, Any]]:
+        candidates: list[tuple[int, Any]] = []
         for idx, worker in enumerate(self._workers):
-            if worker.is_alive():
-                continue
-            exitcode = worker.exitcode
-            to_requeue: list[SerializedWorkItem] = []
-            try:
-                to_requeue = self._recover_dead_worker_items(idx)
-                to_requeue.extend(self._recover_pending_pipe_dispatches(idx))
-            except Exception as recovery_exc:
-                self._logger.error(
-                    "Failed to recover work from worker %d: %s", idx, recovery_exc
-                )
+            if not worker.is_alive():
+                candidates.append((idx, worker.exitcode))
+        return candidates
+
+    def _collect_recoverable_worker_payloads(
+        self,
+        idx: int,
+    ) -> list[SerializedWorkItem]:
+        to_requeue: list[SerializedWorkItem] = []
+        try:
+            to_requeue.extend(self._recover_dead_worker_items(idx))
+        except Exception as recovery_exc:
             self._logger.error(
-                "ProcessWorker[%d] died (exitcode=%s). Restarting worker.",
+                "Failed to recover in-flight work from worker %d: %s",
+                idx,
+                recovery_exc,
+            )
+        try:
+            to_requeue.extend(self._recover_pending_pipe_dispatches(idx))
+        except Exception as recovery_exc:
+            self._logger.error(
+                "Failed to recover pending dispatches from worker %d: %s",
+                idx,
+                recovery_exc,
+            )
+        return to_requeue
+
+    def _restart_dead_worker(
+        self,
+        idx: int,
+        exitcode: Any,
+        recovered_payloads: list[SerializedWorkItem],
+    ) -> bool:
+        try:
+            new_worker = self._start_worker(idx)
+        except Exception as restart_exc:
+            self._logger.error(
+                "Failed to restart worker %d after exitcode=%s: %s",
                 idx,
                 exitcode,
+                restart_exc,
             )
-            try:
-                new_worker = self._start_worker(idx)
-            except Exception as restart_exc:
-                self._logger.error(
-                    "Failed to restart worker %d after exitcode=%s: %s",
-                    idx,
-                    exitcode,
-                    restart_exc,
-                )
-                self._emit_worker_restart_failures(idx, to_requeue, restart_exc)
-                continue
-            self._workers[idx] = new_worker
-            try:
-                if to_requeue:
-                    self._requeue_recovered_payloads(to_requeue)
-                    offsets = [entry.get("offset") for entry in to_requeue]
-                    self._logger.warning(
-                        "Requeued %d lost work item(s) offsets=%s from dead worker %d",
-                        len(to_requeue),
-                        offsets,
-                        idx,
-                    )
-            except Exception as requeue_exc:
-                self._logger.error(
-                    "Failed to requeue work from worker %d: %s", idx, requeue_exc
-                )
+            self._emit_worker_restart_failures(idx, recovered_payloads, restart_exc)
+            return False
+        self._workers[idx] = new_worker
+        return True
+
+    def _publish_recovered_worker_payloads(
+        self,
+        idx: int,
+        payloads: list[SerializedWorkItem],
+    ) -> None:
+        if not payloads:
+            return
+        try:
+            self._requeue_recovered_payloads(payloads)
+            offsets = [entry.get("offset") for entry in payloads]
+            self._logger.warning(
+                "Requeued %d lost work item(s) offsets=%s from dead worker %d",
+                len(payloads),
+                offsets,
+                idx,
+            )
+        except Exception as requeue_exc:
+            self._logger.error(
+                "Failed to requeue work from worker %d: %s", idx, requeue_exc
+            )
 
     def _recover_pending_pipe_dispatches(self, idx: int) -> list[SerializedWorkItem]:
         transport = getattr(self, "_transport", None)
         if transport is None:
             return []
-        if not transport.capabilities.pending_dispatch_recovery:
+        capabilities = getattr(transport, "capabilities", None)
+        if capabilities is None or not capabilities.pending_dispatch_recovery:
             return []
         recovered_dispatches = transport.recover_pending_dispatches(idx)
         if recovered_dispatches:

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -1198,6 +1198,7 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         total_completion_drained = 0
         total_passes = 0
         empty_passes = 0
+        drained_any_events = False
 
         while True:
             drained_registry, drained_completion = self._drain_shutdown_ipc_once()
@@ -1209,13 +1210,24 @@ class ProcessExecutionEngine(BaseExecutionEngine):
                 empty_passes += 1
             else:
                 empty_passes = 0
+                drained_any_events = True
 
             if empty_passes >= stable_empty_passes:
                 break
             remaining_seconds = deadline - time.monotonic()
-            if remaining_seconds <= 0:
+            # Once shutdown has observed post-join IPC, the safety boundary is
+            # stable-empty observation after that event rather than the original
+            # time budget. Otherwise a completion that arrives on the last
+            # budgeted pass could be prefetched without proving the queue then
+            # became empty before local cleanup closes the shutdown boundary.
+            if remaining_seconds <= 0 and not drained_any_events:
                 break
-            await asyncio.sleep(min(_SHUTDOWN_DRAIN_SLEEP_SECONDS, remaining_seconds))
+            await asyncio.sleep(
+                min(
+                    _SHUTDOWN_DRAIN_SLEEP_SECONDS,
+                    max(0.0, remaining_seconds),
+                )
+            )
 
         return total_registry_drained, total_completion_drained, total_passes
 

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -14,7 +14,7 @@ import time
 from collections import deque
 from collections.abc import Callable
 from multiprocessing import Process, Queue
-from typing import Any, Deque, List, Optional, cast
+from typing import Any, Deque, List, Optional
 
 import msgpack  # type: ignore[import-untyped]
 
@@ -52,6 +52,9 @@ SerializedBatchEnvelope = dict[str, Any]
 
 _SENTINEL = None
 _PIPE_SENTINEL = b"__pyrallel_consumer_pipe_sentinel__"
+_SHUTDOWN_DRAIN_SLEEP_SECONDS = 0.01
+_POST_JOIN_SHUTDOWN_DRAIN_SECONDS = 0.05
+_POST_JOIN_SHUTDOWN_STABLE_EMPTY_PASSES = 2
 _logger = logging.getLogger(__name__)
 
 
@@ -1184,6 +1187,38 @@ class ProcessExecutionEngine(BaseExecutionEngine):
 
         return drained_registry, drained_completion
 
+    async def _drain_shutdown_ipc_until_stable_empty(
+        self,
+        *,
+        max_seconds: float,
+        stable_empty_passes: int,
+    ) -> tuple[int, int, int]:
+        deadline = time.monotonic() + max(0.0, max_seconds)
+        total_registry_drained = 0
+        total_completion_drained = 0
+        total_passes = 0
+        empty_passes = 0
+
+        while True:
+            drained_registry, drained_completion = self._drain_shutdown_ipc_once()
+            total_registry_drained += drained_registry
+            total_completion_drained += drained_completion
+            total_passes += 1
+
+            if drained_registry == 0 and drained_completion == 0:
+                empty_passes += 1
+            else:
+                empty_passes = 0
+
+            if empty_passes >= stable_empty_passes:
+                break
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                break
+            await asyncio.sleep(min(_SHUTDOWN_DRAIN_SLEEP_SECONDS, remaining_seconds))
+
+        return total_registry_drained, total_completion_drained, total_passes
+
     def get_min_inflight_offset(self, tp: TopicPartition) -> Optional[int]:
         """
         Deprecated compatibility hook.
@@ -1466,7 +1501,7 @@ class ProcessExecutionEngine(BaseExecutionEngine):
                 and not self._in_flight_registry
             ):
                 break
-            await asyncio.sleep(0.01)
+            await asyncio.sleep(_SHUTDOWN_DRAIN_SLEEP_SECONDS)
         _logger.debug(
             "ProcessExecutionEngine shutdown pre-join drain: registry_events=%d completion_events=%d residual_in_flight_registry=%d",
             total_registry_drained,
@@ -1481,11 +1516,16 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         (
             post_join_registry_drained,
             post_join_completion_drained,
-        ) = self._drain_shutdown_ipc_once()
+            post_join_drain_passes,
+        ) = await self._drain_shutdown_ipc_until_stable_empty(
+            max_seconds=_POST_JOIN_SHUTDOWN_DRAIN_SECONDS,
+            stable_empty_passes=_POST_JOIN_SHUTDOWN_STABLE_EMPTY_PASSES,
+        )
         _logger.debug(
-            "ProcessExecutionEngine shutdown post-join drain: registry_events=%d completion_events=%d residual_in_flight_registry=%d",
+            "ProcessExecutionEngine shutdown post-join drain: registry_events=%d completion_events=%d passes=%d residual_in_flight_registry=%d",
             post_join_registry_drained,
             post_join_completion_drained,
+            post_join_drain_passes,
             len(self._in_flight_registry),
         )
         if self._in_flight_registry:
@@ -1513,12 +1553,6 @@ class ProcessExecutionEngine(BaseExecutionEngine):
                 "; ".join(registry_summary),
             )
 
-        for _ in range(min(prefetched_count, len(self._prefetched_completion_events))):
-            popleft = getattr(self._prefetched_completion_events, "popleft", None)
-            if callable(popleft):
-                popleft()
-            else:
-                cast(Any, self._prefetched_completion_events).pop(0)
         self._in_flight_registry.clear()
         self._transport.clear_pending_dispatches()
         with self._in_flight_lock:

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -1025,8 +1025,18 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         transport = getattr(self, "_transport", None)
         if transport is None:
             return []
+        if not transport.capabilities.pending_dispatch_recovery:
+            return []
+        recovered_dispatches = transport.recover_pending_dispatches(idx)
+        if recovered_dispatches:
+            identities = [entry.identity for entry in recovered_dispatches]
+            self._logger.warning(
+                "Recovered %d pending worker-pipe dispatch(es) identities=%s",
+                len(recovered_dispatches),
+                identities,
+            )
         return self._filter_recoverable_pending_pipe_dispatches(
-            idx, transport.recover_pending_dispatches(idx)
+            idx, [entry.payload for entry in recovered_dispatches]
         )
 
     def _signal_worker_pipe_slot_wait(self) -> None:

--- a/pyrallel_consumer/execution_plane/process_registry_support.py
+++ b/pyrallel_consumer/execution_plane/process_registry_support.py
@@ -4,7 +4,12 @@ import queue
 from collections.abc import Callable
 from typing import Any, Optional
 
-from pyrallel_consumer.dto import TopicPartition
+from pyrallel_consumer.dto import CompletionEvent, TopicPartition
+from pyrallel_consumer.execution_plane.process_transport import (
+    logical_work_identity_from_completion_event,
+    logical_work_identity_from_registry_entry,
+    registry_entry_matches_payload,
+)
 
 SerializedWorkItem = dict[str, Any]
 InFlightRegistryKey = tuple[int, str, int, int]
@@ -69,11 +74,23 @@ class ProcessRegistrySupport:
         key = event.get("key")
         if kind == "start" and key is not None:
             payload = dict(event.get("payload", {}))
+            registry_payload = in_flight_registry.get(key)
+            if (
+                registry_payload is not None
+                and not ProcessRegistrySupport._event_matches_registry_entry(
+                    event, key, registry_payload
+                )
+            ):
+                return
             payload["requeue_attempts"] = payload.get("requeue_attempts", 0)
             in_flight_registry[key] = payload
             return
 
         if kind == "timeout" and key in in_flight_registry:
+            if not ProcessRegistrySupport._event_matches_registry_entry(
+                event, key, in_flight_registry[key]
+            ):
+                return
             payload = dict(in_flight_registry.get(key, {}))
             payload["timed_out"] = True
             payload["timeout_error"] = event.get("timeout_error", "task_timeout")
@@ -82,6 +99,14 @@ class ProcessRegistrySupport:
             return
 
         if kind == "done" and key is not None:
+            registry_payload = in_flight_registry.get(key)
+            if (
+                registry_payload is not None
+                and not ProcessRegistrySupport._event_matches_registry_entry(
+                    event, key, registry_payload
+                )
+            ):
+                return
             in_flight_registry.pop(key, None)
             return
 
@@ -111,18 +136,49 @@ class ProcessRegistrySupport:
             apply_event(event)
 
     @staticmethod
+    def discard_completion_from_registry(
+        *,
+        in_flight_registry: InFlightRegistry,
+        event: CompletionEvent,
+    ) -> None:
+        expected_identity = logical_work_identity_from_completion_event(event)
+        for key, payload in list(in_flight_registry.items()):
+            if (
+                logical_work_identity_from_registry_entry(key, payload)
+                == expected_identity
+            ):
+                in_flight_registry.pop(key, None)
+
+    @staticmethod
     def get_min_inflight_offset(
         *,
         in_flight_registry: InFlightRegistry,
         tp: TopicPartition,
     ) -> Optional[int]:
         min_offset = None
-        for (_worker_index, topic, partition, _offset), payload in (
-            in_flight_registry.items()
-        ):
+        for (
+            _worker_index,
+            topic,
+            partition,
+            _offset,
+        ), payload in in_flight_registry.items():
             if topic == tp.topic and partition == tp.partition:
                 value = payload.get("offset")
                 if isinstance(value, int):
                     if min_offset is None or value < min_offset:
                         min_offset = value
         return min_offset
+
+    @staticmethod
+    def _event_matches_registry_entry(
+        event: dict[str, Any],
+        key: InFlightRegistryKey,
+        registry_payload: SerializedWorkItem,
+    ) -> bool:
+        event_payload = event.get("payload")
+        if not isinstance(event_payload, dict):
+            return True
+        try:
+            return registry_entry_matches_payload(key, registry_payload, event_payload)
+        except (KeyError, TypeError, ValueError):
+            return True

--- a/pyrallel_consumer/execution_plane/process_registry_support.py
+++ b/pyrallel_consumer/execution_plane/process_registry_support.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 from pyrallel_consumer.dto import CompletionEvent, TopicPartition
 from pyrallel_consumer.execution_plane.process_transport import (
     logical_work_identity_from_completion_event,
+    logical_work_identity_from_payload,
     logical_work_identity_from_registry_entry,
     registry_entry_matches_payload,
 )
@@ -78,6 +79,9 @@ class ProcessRegistrySupport:
             if (
                 registry_payload is not None
                 and not ProcessRegistrySupport._event_matches_registry_entry(
+                    event, key, registry_payload
+                )
+                and not ProcessRegistrySupport._start_event_supersedes_registry_entry(
                     event, key, registry_payload
                 )
             ):
@@ -182,3 +186,24 @@ class ProcessRegistrySupport:
             return registry_entry_matches_payload(key, registry_payload, event_payload)
         except (KeyError, TypeError, ValueError):
             return True
+
+    @staticmethod
+    def _start_event_supersedes_registry_entry(
+        event: dict[str, Any],
+        key: InFlightRegistryKey,
+        registry_payload: SerializedWorkItem,
+    ) -> bool:
+        event_payload = event.get("payload")
+        if not isinstance(event_payload, dict):
+            return True
+        try:
+            existing_identity = logical_work_identity_from_registry_entry(
+                key,
+                registry_payload,
+            )
+            incoming_identity = logical_work_identity_from_payload(event_payload)
+        except (KeyError, TypeError, ValueError):
+            return True
+        if incoming_identity[:3] != existing_identity[:3]:
+            return False
+        return incoming_identity.epoch >= existing_identity.epoch

--- a/pyrallel_consumer/execution_plane/process_registry_support.py
+++ b/pyrallel_consumer/execution_plane/process_registry_support.py
@@ -206,4 +206,4 @@ class ProcessRegistrySupport:
             return True
         if incoming_identity[:3] != existing_identity[:3]:
             return False
-        return incoming_identity.epoch >= existing_identity.epoch
+        return incoming_identity.epoch > existing_identity.epoch

--- a/pyrallel_consumer/execution_plane/process_transport.py
+++ b/pyrallel_consumer/execution_plane/process_transport.py
@@ -4,13 +4,14 @@ import asyncio
 import hashlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, NamedTuple
 
 import msgpack  # type: ignore[import-untyped]
 
-from pyrallel_consumer.dto import WorkItem
+from pyrallel_consumer.dto import CompletionEvent, WorkItem
 
 SerializedWorkItem = dict[str, Any]
+InFlightRegistryKey = tuple[int, str, int, int]
 
 
 @dataclass(frozen=True)
@@ -20,12 +21,93 @@ class RouteIdentity:
     key: Any
 
 
+class LogicalWorkIdentity(NamedTuple):
+    topic: str
+    partition: int
+    offset: int
+    id: str
+    epoch: int
+
+
+class WorkerExecutionIdentity(NamedTuple):
+    worker_index: int
+    work: LogicalWorkIdentity
+
+
 def resolve_route_identity(work_item: WorkItem) -> RouteIdentity:
     return RouteIdentity(
         topic=work_item.tp.topic,
         partition=work_item.tp.partition,
         key=work_item.key,
     )
+
+
+def logical_work_identity_from_payload(
+    payload: SerializedWorkItem,
+) -> LogicalWorkIdentity:
+    return LogicalWorkIdentity(
+        topic=str(payload["topic"]),
+        partition=int(payload["partition"]),
+        offset=int(payload["offset"]),
+        id=str(payload.get("id", "")),
+        epoch=int(payload.get("epoch", 0)),
+    )
+
+
+def logical_work_identity_from_completion_event(
+    event: CompletionEvent,
+) -> LogicalWorkIdentity:
+    return LogicalWorkIdentity(
+        topic=event.tp.topic,
+        partition=event.tp.partition,
+        offset=event.offset,
+        id=event.id,
+        epoch=event.epoch,
+    )
+
+
+def logical_work_identity_from_registry_entry(
+    key: InFlightRegistryKey,
+    payload: SerializedWorkItem,
+) -> LogicalWorkIdentity:
+    _worker_index, topic, partition, offset = key
+    return LogicalWorkIdentity(
+        topic=topic,
+        partition=partition,
+        offset=offset,
+        id=str(payload.get("id", "")),
+        epoch=int(payload.get("epoch", 0)),
+    )
+
+
+def worker_execution_identity_from_payload(
+    worker_index: int,
+    payload: SerializedWorkItem,
+) -> WorkerExecutionIdentity:
+    return WorkerExecutionIdentity(
+        worker_index=worker_index,
+        work=logical_work_identity_from_payload(payload),
+    )
+
+
+def worker_execution_identity_from_registry_entry(
+    key: InFlightRegistryKey,
+    payload: SerializedWorkItem,
+) -> WorkerExecutionIdentity:
+    return WorkerExecutionIdentity(
+        worker_index=key[0],
+        work=logical_work_identity_from_registry_entry(key, payload),
+    )
+
+
+def registry_entry_matches_payload(
+    key: InFlightRegistryKey,
+    registry_payload: SerializedWorkItem,
+    expected_payload: SerializedWorkItem,
+) -> bool:
+    return logical_work_identity_from_registry_entry(
+        key, registry_payload
+    ) == logical_work_identity_from_payload(expected_payload)
 
 
 def stable_worker_index_for_route(

--- a/pyrallel_consumer/execution_plane/process_transport.py
+++ b/pyrallel_consumer/execution_plane/process_transport.py
@@ -34,6 +34,17 @@ class WorkerExecutionIdentity(NamedTuple):
     work: LogicalWorkIdentity
 
 
+@dataclass(frozen=True)
+class ProcessTransportCapabilities:
+    pending_dispatch_recovery: bool = False
+
+
+@dataclass(frozen=True)
+class PendingDispatchRecovery:
+    identity: WorkerExecutionIdentity
+    payload: SerializedWorkItem
+
+
 def resolve_route_identity(work_item: WorkItem) -> RouteIdentity:
     return RouteIdentity(
         topic=work_item.tp.topic,
@@ -129,6 +140,10 @@ def stable_worker_index_for_route(
 
 
 class ProcessTransport(ABC):
+    @property
+    def capabilities(self) -> ProcessTransportCapabilities:
+        return ProcessTransportCapabilities()
+
     @abstractmethod
     async def submit_work_item(
         self,
@@ -158,7 +173,7 @@ class ProcessTransport(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def recover_pending_dispatches(self, idx: int) -> list[SerializedWorkItem]:
+    def recover_pending_dispatches(self, idx: int) -> list[PendingDispatchRecovery]:
         raise NotImplementedError
 
     @abstractmethod

--- a/pyrallel_consumer/execution_plane/process_transport_shared_queue.py
+++ b/pyrallel_consumer/execution_plane/process_transport_shared_queue.py
@@ -9,6 +9,7 @@ import msgpack  # type: ignore[import-untyped]
 
 from pyrallel_consumer.dto import WorkItem
 from pyrallel_consumer.execution_plane.process_transport import (
+    PendingDispatchRecovery,
     ProcessTransport,
     RouteIdentity,
     SerializedWorkItem,
@@ -67,7 +68,7 @@ class SharedQueueProcessTransport(ProcessTransport):
     def handle_registry_event(self, event: dict[str, Any]) -> None:
         del event
 
-    def recover_pending_dispatches(self, idx: int) -> list[SerializedWorkItem]:
+    def recover_pending_dispatches(self, idx: int) -> list[PendingDispatchRecovery]:
         del idx
         return []
 

--- a/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
+++ b/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
@@ -109,8 +109,6 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
         with self._pending_dispatch_lock:
             if pending_key in self._pending_dispatch:
                 self._pending_dispatch.pop(pending_key, None)
-            elif key in self._pending_dispatch:
-                self._pending_dispatch.pop(key, None)
             else:
                 return
         self._release_worker_pipe_queue_slot()

--- a/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
+++ b/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
@@ -190,7 +190,13 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
         key: Any,
         payload: Any,
     ) -> PendingDispatchKey | None:
-        if not isinstance(key, tuple) or not key or not isinstance(payload, dict):
+        if not isinstance(key, tuple) or len(key) < 4 or not isinstance(payload, dict):
+            return None
+        if (
+            payload.get("topic") != key[1]
+            or payload.get("partition") != key[2]
+            or payload.get("offset") != key[3]
+        ):
             return None
         return WorkerPipesProcessTransport._pending_dispatch_key(key[0], payload)
 

--- a/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
+++ b/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
@@ -10,7 +10,9 @@ import msgpack  # type: ignore[import-untyped]
 from pyrallel_consumer.dto import WorkItem
 from pyrallel_consumer.execution_plane.process_transport import (
     AsyncToThreadSubmitMixin,
+    PendingDispatchRecovery,
     ProcessTransport,
+    ProcessTransportCapabilities,
     RouteIdentity,
     SerializedWorkItem,
     stable_worker_index_for_route,
@@ -93,6 +95,10 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
             senders.append(parent_sender)
         return worker_receiver, True
 
+    @property
+    def capabilities(self) -> ProcessTransportCapabilities:
+        return ProcessTransportCapabilities(pending_dispatch_recovery=True)
+
     def handle_registry_event(self, event: dict[str, Any]) -> None:
         if event.get("kind") != "start":
             return
@@ -109,8 +115,8 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
                 return
         self._release_worker_pipe_queue_slot()
 
-    def recover_pending_dispatches(self, idx: int) -> list[SerializedWorkItem]:
-        to_requeue: list[SerializedWorkItem] = []
+    def recover_pending_dispatches(self, idx: int) -> list[PendingDispatchRecovery]:
+        recovered: list[PendingDispatchRecovery] = []
         with self._pending_dispatch_lock:
             for key, payload in list(self._pending_dispatch.items()):
                 if key[0] != idx:
@@ -119,10 +125,18 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
                 recovered_payload["requeue_attempts"] = (
                     recovered_payload.get("requeue_attempts", 0) + 1
                 )
-                to_requeue.append(recovered_payload)
+                recovered.append(
+                    PendingDispatchRecovery(
+                        identity=worker_execution_identity_from_payload(
+                            idx,
+                            recovered_payload,
+                        ),
+                        payload=recovered_payload,
+                    )
+                )
                 self._pending_dispatch.pop(key, None)
                 self._release_worker_pipe_queue_slot()
-        return to_requeue
+        return recovered
 
     def requeue_payloads(self, payloads: list[SerializedWorkItem]) -> None:
         for payload in payloads:

--- a/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
+++ b/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
@@ -14,7 +14,10 @@ from pyrallel_consumer.execution_plane.process_transport import (
     RouteIdentity,
     SerializedWorkItem,
     stable_worker_index_for_route,
+    worker_execution_identity_from_payload,
 )
+
+PendingDispatchKey = tuple[int, str, int, int, str, int]
 
 
 class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
@@ -45,9 +48,7 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
         self._slot_wait_timeout_seconds = slot_wait_timeout_seconds
         self._worker_pipe_queue_slots = threading.BoundedSemaphore(value=queue_size)
         self._pending_dispatch_lock = threading.Lock()
-        self._pending_dispatch: dict[
-            tuple[int, str, int, int, str, int], SerializedWorkItem
-        ] = {}
+        self._pending_dispatch: dict[PendingDispatchKey, SerializedWorkItem] = {}
 
     def dispatch_payload(
         self,
@@ -97,9 +98,7 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
             return
         key = event.get("key")
         payload = event.get("payload")
-        pending_key = None
-        if isinstance(key, tuple) and key and isinstance(payload, dict):
-            pending_key = self._pending_dispatch_key(key[0], payload)
+        pending_key = self._pending_dispatch_key_for_registry_start(key, payload)
 
         with self._pending_dispatch_lock:
             if pending_key in self._pending_dispatch:
@@ -161,15 +160,25 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
     def _pending_dispatch_key(
         worker_idx: int,
         payload: SerializedWorkItem,
-    ) -> tuple[int, str, int, int, str, int]:
+    ) -> PendingDispatchKey:
+        identity = worker_execution_identity_from_payload(worker_idx, payload)
         return (
-            worker_idx,
-            payload["topic"],
-            payload["partition"],
-            payload["offset"],
-            str(payload.get("id", "")),
-            int(payload.get("epoch", 0)),
+            identity.worker_index,
+            identity.work.topic,
+            identity.work.partition,
+            identity.work.offset,
+            identity.work.id,
+            identity.work.epoch,
         )
+
+    @staticmethod
+    def _pending_dispatch_key_for_registry_start(
+        key: Any,
+        payload: Any,
+    ) -> PendingDispatchKey | None:
+        if not isinstance(key, tuple) or not key or not isinstance(payload, dict):
+            return None
+        return WorkerPipesProcessTransport._pending_dispatch_key(key[0], payload)
 
     def _release_worker_pipe_queue_slot(self) -> None:
         try:

--- a/tests/unit/control_plane/test_broker_completion_support.py
+++ b/tests/unit/control_plane/test_broker_completion_support.py
@@ -163,6 +163,64 @@ async def test_process_completed_events_falls_back_to_metadata_only_dlq() -> Non
 
 
 @pytest.mark.asyncio
+async def test_shutdown_preserved_failure_completion_uses_normal_dlq_boundary() -> None:
+    from pyrallel_consumer.control_plane.broker_completion_support import (
+        BrokerCompletionSupport,
+    )
+
+    tp = DtoTopicPartition(topic="demo", partition=0)
+    tracker = OffsetTracker(
+        topic_partition=tp,
+        starting_offset=100,
+        max_revoke_grace_ms=0,
+        initial_completed_offsets=set(),
+    )
+    tracker.increment_epoch()
+    kafka_config = KafkaConfig()
+    kafka_config.dlq_enabled = True
+    kafka_config.parallel_consumer.execution.max_retries = 3
+    publish_to_dlq = AsyncMock(return_value=True)
+    popped_cache_keys: list[tuple[DtoTopicPartition, int]] = []
+
+    support = BrokerCompletionSupport(
+        kafka_config=kafka_config,
+        work_manager=MagicMock(),
+        offset_trackers={tp: tracker},
+        message_cache=OrderedDict({(tp, 100): (b"k", b"v")}),
+        should_cache_message_payloads=lambda: True,
+        pop_cached_message=lambda cache_key: popped_cache_keys.append(cache_key),
+        publish_to_dlq=publish_to_dlq,
+        logger=MagicMock(),
+    )
+
+    await support.process_completed_events(
+        [
+            CompletionEvent(
+                id="shutdown-preserved-failure",
+                tp=tp,
+                offset=100,
+                epoch=tracker.get_current_epoch(),
+                status=CompletionStatus.FAILURE,
+                error="boom",
+                attempt=3,
+            )
+        ]
+    )
+
+    publish_to_dlq.assert_awaited_once_with(
+        tp=tp,
+        offset=100,
+        epoch=tracker.get_current_epoch(),
+        key=b"k",
+        value=b"v",
+        error="boom",
+        attempt=3,
+    )
+    assert 100 in tracker.completed_offsets
+    assert popped_cache_keys == [(tp, 100)]
+
+
+@pytest.mark.asyncio
 async def test_process_completed_events_retries_pending_dlq_failure_and_marks_complete() -> (
     None
 ):

--- a/tests/unit/control_plane/test_broker_completion_support.py
+++ b/tests/unit/control_plane/test_broker_completion_support.py
@@ -272,6 +272,55 @@ async def test_shutdown_preserved_stale_failure_completion_is_epoch_fenced() -> 
 
 
 @pytest.mark.asyncio
+async def test_shutdown_preserved_stale_success_completion_does_not_mark_complete() -> (
+    None
+):
+    from pyrallel_consumer.control_plane.broker_completion_support import (
+        BrokerCompletionSupport,
+    )
+
+    tp = DtoTopicPartition(topic="demo", partition=0)
+    tracker = OffsetTracker(
+        topic_partition=tp,
+        starting_offset=100,
+        max_revoke_grace_ms=0,
+        initial_completed_offsets=set(),
+    )
+    tracker.increment_epoch()
+    tracker.increment_epoch()
+    popped_cache_keys: list[tuple[DtoTopicPartition, int]] = []
+
+    support = BrokerCompletionSupport(
+        kafka_config=KafkaConfig(),
+        work_manager=MagicMock(),
+        offset_trackers={tp: tracker},
+        message_cache=OrderedDict({(tp, 100): (b"k", b"v")}),
+        should_cache_message_payloads=lambda: True,
+        pop_cached_message=lambda cache_key: popped_cache_keys.append(cache_key),
+        publish_to_dlq=AsyncMock(return_value=True),
+        logger=MagicMock(),
+    )
+
+    await support.process_completed_events(
+        [
+            CompletionEvent(
+                id="shutdown-preserved-stale-success",
+                tp=tp,
+                offset=100,
+                epoch=tracker.get_current_epoch() - 1,
+                status=CompletionStatus.SUCCESS,
+                error=None,
+                attempt=1,
+            )
+        ]
+    )
+
+    assert 100 not in tracker.completed_offsets
+    assert tracker.last_committed_offset == 99
+    assert popped_cache_keys == []
+
+
+@pytest.mark.asyncio
 async def test_process_completed_events_retries_pending_dlq_failure_and_marks_complete() -> (
     None
 ):

--- a/tests/unit/control_plane/test_broker_completion_support.py
+++ b/tests/unit/control_plane/test_broker_completion_support.py
@@ -221,6 +221,57 @@ async def test_shutdown_preserved_failure_completion_uses_normal_dlq_boundary() 
 
 
 @pytest.mark.asyncio
+async def test_shutdown_preserved_stale_failure_completion_is_epoch_fenced() -> None:
+    from pyrallel_consumer.control_plane.broker_completion_support import (
+        BrokerCompletionSupport,
+    )
+
+    tp = DtoTopicPartition(topic="demo", partition=0)
+    tracker = OffsetTracker(
+        topic_partition=tp,
+        starting_offset=100,
+        max_revoke_grace_ms=0,
+        initial_completed_offsets=set(),
+    )
+    tracker.increment_epoch()
+    tracker.increment_epoch()
+    kafka_config = KafkaConfig()
+    kafka_config.dlq_enabled = True
+    kafka_config.parallel_consumer.execution.max_retries = 3
+    publish_to_dlq = AsyncMock(return_value=True)
+    popped_cache_keys: list[tuple[DtoTopicPartition, int]] = []
+
+    support = BrokerCompletionSupport(
+        kafka_config=kafka_config,
+        work_manager=MagicMock(),
+        offset_trackers={tp: tracker},
+        message_cache=OrderedDict({(tp, 100): (b"k", b"v")}),
+        should_cache_message_payloads=lambda: True,
+        pop_cached_message=lambda cache_key: popped_cache_keys.append(cache_key),
+        publish_to_dlq=publish_to_dlq,
+        logger=MagicMock(),
+    )
+
+    await support.process_completed_events(
+        [
+            CompletionEvent(
+                id="shutdown-preserved-stale-failure",
+                tp=tp,
+                offset=100,
+                epoch=tracker.get_current_epoch() - 1,
+                status=CompletionStatus.FAILURE,
+                error="boom",
+                attempt=3,
+            )
+        ]
+    )
+
+    publish_to_dlq.assert_not_awaited()
+    assert 100 not in tracker.completed_offsets
+    assert popped_cache_keys == []
+
+
+@pytest.mark.asyncio
 async def test_process_completed_events_retries_pending_dlq_failure_and_marks_complete() -> (
     None
 ):

--- a/tests/unit/control_plane/test_broker_poller_completion_driven.py
+++ b/tests/unit/control_plane/test_broker_poller_completion_driven.py
@@ -8,6 +8,9 @@ from confluent_kafka import Consumer
 from confluent_kafka import TopicPartition as KafkaTopicPartition
 
 from pyrallel_consumer.config import KafkaConfig
+from pyrallel_consumer.control_plane.broker_completion_support import (
+    CompletionProcessingResult,
+)
 from pyrallel_consumer.control_plane.broker_poller import BrokerPoller
 from pyrallel_consumer.control_plane.offset_tracker import OffsetTracker
 from pyrallel_consumer.dto import CompletionEvent, CompletionStatus
@@ -367,7 +370,12 @@ async def test_commit_ready_offsets_waits_for_completion_cadence_before_commit(
     broker_poller._make_dispatch_support = MagicMock(return_value=dispatch_support)
 
     completion_support = MagicMock()
-    completion_support.process_completed_events = AsyncMock(side_effect=[1, 2])
+    completion_support.process_completed_events = AsyncMock(
+        side_effect=[
+            CompletionProcessingResult(1, frozenset({topic_partition})),
+            CompletionProcessingResult(2, frozenset({topic_partition})),
+        ]
+    )
     broker_poller._make_completion_support = MagicMock(return_value=completion_support)
 
     await broker_poller._process_completed_events([completion_event])
@@ -416,7 +424,9 @@ async def test_commit_ready_offsets_force_flushes_dirty_partitions(
     broker_poller._make_dispatch_support = MagicMock(return_value=dispatch_support)
 
     completion_support = MagicMock()
-    completion_support.process_completed_events = AsyncMock(return_value=1)
+    completion_support.process_completed_events = AsyncMock(
+        return_value=CompletionProcessingResult(1, frozenset({topic_partition}))
+    )
     broker_poller._make_completion_support = MagicMock(return_value=completion_support)
 
     await broker_poller._process_completed_events([completion_event])
@@ -433,7 +443,9 @@ async def test_process_completed_events_marks_only_managed_partitions_dirty(
     untracked_partition = DtoTopicPartition(topic="stale-topic", partition=1)
 
     completion_support = MagicMock()
-    completion_support.process_completed_events = AsyncMock(return_value=1)
+    completion_support.process_completed_events = AsyncMock(
+        return_value=CompletionProcessingResult(1, frozenset({topic_partition}))
+    )
     broker_poller._make_completion_support = MagicMock(return_value=completion_support)
 
     await broker_poller._process_completed_events(
@@ -464,7 +476,9 @@ async def test_process_completed_events_unions_retry_and_completion_partitions(
     broker_poller._pending_dlq_events[(retry_partition, 7)] = completion_event
 
     completion_support = MagicMock()
-    completion_support.process_completed_events = AsyncMock(return_value=1)
+    completion_support.process_completed_events = AsyncMock(
+        return_value=CompletionProcessingResult(1, frozenset({topic_partition}))
+    )
     broker_poller._make_completion_support = MagicMock(return_value=completion_support)
 
     await broker_poller._process_completed_events([completion_event])
@@ -483,7 +497,9 @@ async def test_process_completed_events_does_not_mark_everything_dirty_for_untra
     untracked_partition = DtoTopicPartition(topic="stale-topic", partition=1)
 
     completion_support = MagicMock()
-    completion_support.process_completed_events = AsyncMock(return_value=1)
+    completion_support.process_completed_events = AsyncMock(
+        return_value=CompletionProcessingResult(0, frozenset())
+    )
     broker_poller._make_completion_support = MagicMock(return_value=completion_support)
 
     await broker_poller._process_completed_events(
@@ -501,6 +517,39 @@ async def test_process_completed_events_does_not_mark_everything_dirty_for_untra
     )
 
     assert broker_poller._dirty_commit_partitions == set()
+
+
+@pytest.mark.asyncio
+async def test_process_completed_events_dirties_only_accepted_mixed_batch_partitions(
+    broker_poller, topic_partition, completion_event
+):
+    broker_poller._offset_trackers[topic_partition] = _make_tracker(topic_partition)
+    stale_partition = DtoTopicPartition(topic="stale-topic", partition=1)
+    broker_poller._offset_trackers[stale_partition] = _make_tracker(stale_partition)
+
+    completion_support = MagicMock()
+    completion_support.process_completed_events = AsyncMock(
+        return_value=CompletionProcessingResult(1, frozenset({topic_partition}))
+    )
+    broker_poller._make_completion_support = MagicMock(return_value=completion_support)
+
+    await broker_poller._process_completed_events(
+        [
+            completion_event,
+            CompletionEvent(
+                id="stale-work",
+                tp=stale_partition,
+                offset=99,
+                epoch=0,
+                status=CompletionStatus.SUCCESS,
+                error=None,
+                attempt=1,
+            ),
+        ]
+    )
+
+    assert broker_poller._dirty_commit_partitions == {topic_partition}
+    assert broker_poller._completions_since_last_commit == 1
 
 
 @pytest.mark.asyncio
@@ -950,6 +999,58 @@ async def test_stale_completion_does_not_resubmit_next_same_key_work(
         await broker_poller._process_completed_events(completed_events)
 
     assert broker_poller._execution_engine.submit.await_count == 1
+    assert "Discarding zombie completion" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_shutdown_preserved_stale_success_releases_state_without_dirty_commit(
+    broker_poller, topic_partition, caplog
+):
+    tracker = OffsetTracker(
+        topic_partition=topic_partition,
+        starting_offset=0,
+        max_revoke_grace_ms=0,
+        initial_completed_offsets=set(),
+    )
+    tracker.increment_epoch()
+    broker_poller._offset_trackers[topic_partition] = tracker
+    broker_poller._work_manager.on_assign({topic_partition: tracker})
+
+    await broker_poller._work_manager.submit_message(
+        tp=topic_partition,
+        offset=0,
+        epoch=tracker.get_current_epoch(),
+        key=b"key-A",
+        payload=b"payload-0",
+    )
+    await broker_poller._work_manager.schedule()
+
+    first_item = broker_poller._execution_engine.submit.await_args_list[0].args[0]
+    tracker.increment_epoch()
+    stale_completion = CompletionEvent(
+        id=first_item.id,
+        tp=topic_partition,
+        offset=first_item.offset,
+        epoch=first_item.epoch,
+        status=CompletionStatus.SUCCESS,
+        error=None,
+        attempt=1,
+    )
+    broker_poller._execution_engine.poll_completed_events.return_value = [
+        stale_completion
+    ]
+
+    with caplog.at_level("WARNING"):
+        completed_events = await broker_poller._work_manager.poll_completed_events()
+        await broker_poller._process_completed_events(completed_events)
+
+    assert first_item.id not in broker_poller._work_manager._in_flight_work_items
+    assert first_item.id not in broker_poller._work_manager._dispatch_timestamps
+    assert broker_poller._work_manager.get_total_in_flight_count() == 0
+    assert first_item.offset not in tracker.completed_offsets
+    assert tracker.last_committed_offset == -1
+    assert broker_poller._dirty_commit_partitions == set()
+    assert broker_poller._completions_since_last_commit == 0
     assert "Discarding zombie completion" in caplog.text
 
 

--- a/tests/unit/control_plane/test_broker_poller_completion_driven.py
+++ b/tests/unit/control_plane/test_broker_poller_completion_driven.py
@@ -1055,6 +1055,68 @@ async def test_shutdown_preserved_stale_success_releases_state_without_dirty_com
 
 
 @pytest.mark.asyncio
+async def test_shutdown_preserved_stale_failure_skips_dlq_commit_and_cache_cleanup(
+    broker_poller, topic_partition, caplog
+):
+    tracker = OffsetTracker(
+        topic_partition=topic_partition,
+        starting_offset=0,
+        max_revoke_grace_ms=0,
+        initial_completed_offsets=set(),
+    )
+    tracker.increment_epoch()
+    broker_poller._offset_trackers[topic_partition] = tracker
+    broker_poller._work_manager.on_assign({topic_partition: tracker})
+    broker_poller._kafka_config.dlq_enabled = True
+    broker_poller._kafka_config.parallel_consumer.execution.max_retries = 1
+    broker_poller._publish_to_dlq = AsyncMock(return_value=True)
+
+    await broker_poller._work_manager.submit_message(
+        tp=topic_partition,
+        offset=0,
+        epoch=tracker.get_current_epoch(),
+        key=b"key-A",
+        payload=b"payload-0",
+    )
+    await broker_poller._work_manager.schedule()
+
+    first_item = broker_poller._execution_engine.submit.await_args_list[0].args[0]
+    broker_poller._message_cache[(topic_partition, first_item.offset)] = (
+        b"key-A",
+        b"payload-0",
+    )
+    tracker.increment_epoch()
+    stale_completion = CompletionEvent(
+        id=first_item.id,
+        tp=topic_partition,
+        offset=first_item.offset,
+        epoch=first_item.epoch,
+        status=CompletionStatus.FAILURE,
+        error="worker failed before shutdown boundary",
+        attempt=1,
+    )
+    broker_poller._execution_engine.poll_completed_events.return_value = [
+        stale_completion
+    ]
+
+    with caplog.at_level("WARNING"):
+        completed_events = await broker_poller._work_manager.poll_completed_events()
+        await broker_poller._process_completed_events(completed_events)
+
+    assert first_item.id not in broker_poller._work_manager._in_flight_work_items
+    assert first_item.id not in broker_poller._work_manager._dispatch_timestamps
+    assert broker_poller._work_manager.get_total_in_flight_count() == 0
+    assert first_item.offset not in tracker.completed_offsets
+    assert tracker.last_committed_offset == -1
+    assert broker_poller._dirty_commit_partitions == set()
+    assert broker_poller._completions_since_last_commit == 0
+    assert broker_poller._pending_dlq_events == {}
+    assert (topic_partition, first_item.offset) in broker_poller._message_cache
+    broker_poller._publish_to_dlq.assert_not_awaited()
+    assert "Discarding zombie completion" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_on_assign_shared_tracker_allows_key_hash_backlog_to_resume(
     broker_poller, topic_partition
 ):

--- a/tests/unit/control_plane/test_transport_invariants.py
+++ b/tests/unit/control_plane/test_transport_invariants.py
@@ -105,3 +105,25 @@ def test_worker_pipe_blueprint_documents_shutdown_completion_boundary() -> None:
     ]
 
     assert [phrase for phrase in required_phrases if phrase not in blueprint] == []
+
+
+def test_worker_pipe_blueprint_documents_shutdown_diagnostic_interpretation() -> None:
+    blueprint = (
+        REPO_ROOT
+        / "docs"
+        / "blueprint"
+        / "features"
+        / "03-execution"
+        / "02-process-execution-engine"
+        / "04-worker-pipe-transport-experiment.md"
+    ).read_text(encoding="utf-8")
+
+    required_phrases = [
+        "diagnostic evidence",
+        "Pre-join and post-join drain counts",
+        "stable-empty post-join",
+        "not a retry ledger",
+        "audit log for commit safety",
+    ]
+
+    assert [phrase for phrase in required_phrases if phrase not in blueprint] == []

--- a/tests/unit/control_plane/test_transport_invariants.py
+++ b/tests/unit/control_plane/test_transport_invariants.py
@@ -127,3 +127,21 @@ def test_worker_pipe_blueprint_documents_shutdown_diagnostic_interpretation() ->
     ]
 
     assert [phrase for phrase in required_phrases if phrase not in blueprint] == []
+
+
+def test_worker_pipe_target_doc_defers_registry_key_and_timeout_migrations() -> None:
+    target_doc = (
+        REPO_ROOT
+        / "docs"
+        / "plans"
+        / "2026-04-27-process-worker-pipes-target-algorithm.md"
+    ).read_text(encoding="utf-8")
+
+    required_phrases = [
+        "V2.8: Registry key full identity migration review",
+        "do not widen the in-flight registry key yet",
+        "V2.9: Timeout policy convergence / e2e boundary",
+        "separate PR",
+    ]
+
+    assert [phrase for phrase in required_phrases if phrase not in target_doc] == []

--- a/tests/unit/control_plane/test_transport_invariants.py
+++ b/tests/unit/control_plane/test_transport_invariants.py
@@ -81,3 +81,27 @@ def test_control_plane_only_uses_base_execution_engine_contract_methods() -> Non
         "wait_for_completion",
         "get_runtime_metrics",
     }
+
+
+def test_worker_pipe_blueprint_documents_shutdown_completion_boundary() -> None:
+    blueprint = (
+        REPO_ROOT
+        / "docs"
+        / "blueprint"
+        / "features"
+        / "03-execution"
+        / "02-process-execution-engine"
+        / "04-worker-pipe-transport-experiment.md"
+    ).read_text(encoding="utf-8")
+
+    required_phrases = [
+        "Shutdown completion-preservation contract",
+        "already-visible real completions",
+        "diagnostic-only",
+        "must not synthesize",
+        "DLQ",
+        "commit",
+        "rebalance",
+    ]
+
+    assert [phrase for phrase in required_phrases if phrase not in blueprint] == []

--- a/tests/unit/control_plane/test_work_manager.py
+++ b/tests/unit/control_plane/test_work_manager.py
@@ -1928,6 +1928,7 @@ async def test_stale_completion_same_offset_keeps_new_identity_mapping(
         (mock_dto_topic_partition, 10)
     ] = new_item.id
     work_manager._keys_in_flight.add((mock_dto_topic_partition, b"key-A"))
+    work_manager._key_in_flight_counts[(mock_dto_topic_partition, b"key-A")] = 2
 
     stale_completion = CompletionEvent(
         id=old_item.id,
@@ -1953,4 +1954,5 @@ async def test_stale_completion_same_offset_keeps_new_identity_mapping(
     )
     assert work_manager._current_in_flight_count == 1
     assert (mock_dto_topic_partition, b"key-A") in work_manager._keys_in_flight
+    assert work_manager._key_in_flight_counts[(mock_dto_topic_partition, b"key-A")] == 1
     assert tracker.last_committed_offset == -1

--- a/tests/unit/control_plane/test_work_manager.py
+++ b/tests/unit/control_plane/test_work_manager.py
@@ -1884,3 +1884,73 @@ async def test_stale_completion_after_reassign_does_not_touch_new_epoch_state(
     assert work_manager._current_in_flight_count == 1
     assert (mock_dto_topic_partition, b"key-A") in work_manager._keys_in_flight
     assert new_tracker.last_committed_offset == -1
+
+
+@pytest.mark.asyncio
+async def test_stale_completion_same_offset_keeps_new_identity_mapping(
+    mock_execution_engine, mock_dto_topic_partition
+):
+    work_manager = WorkManager(
+        execution_engine=mock_execution_engine,
+        ordering_mode=OrderingMode.KEY_HASH,
+    )
+    tracker = OffsetTracker(
+        topic_partition=mock_dto_topic_partition,
+        starting_offset=0,
+        max_revoke_grace_ms=500,
+    )
+    tracker.increment_epoch()
+    tracker.increment_epoch()
+    work_manager.on_assign({mock_dto_topic_partition: tracker})
+
+    old_item = WorkItem(
+        id="old-work",
+        tp=mock_dto_topic_partition,
+        offset=10,
+        epoch=tracker.get_current_epoch() - 1,
+        key=b"key-A",
+        payload=b"old",
+    )
+    new_item = WorkItem(
+        id="new-work",
+        tp=mock_dto_topic_partition,
+        offset=10,
+        epoch=tracker.get_current_epoch(),
+        key=b"key-A",
+        payload=b"new",
+    )
+    work_manager._current_in_flight_count = 2
+    work_manager._in_flight_work_items[old_item.id] = old_item
+    work_manager._in_flight_work_items[new_item.id] = new_item
+    work_manager._dispatch_timestamps[old_item.id] = 1.0
+    work_manager._dispatch_timestamps[new_item.id] = 2.0
+    work_manager._work_item_ids_by_tp_offset[
+        (mock_dto_topic_partition, 10)
+    ] = new_item.id
+    work_manager._keys_in_flight.add((mock_dto_topic_partition, b"key-A"))
+
+    stale_completion = CompletionEvent(
+        id=old_item.id,
+        tp=mock_dto_topic_partition,
+        offset=old_item.offset,
+        epoch=old_item.epoch,
+        status=CompletionStatus.SUCCESS,
+        error=None,
+        attempt=1,
+    )
+    mock_execution_engine.poll_completed_events.return_value = [stale_completion]
+
+    completed_events = await work_manager.poll_completed_events()
+
+    assert completed_events == [stale_completion]
+    assert old_item.id not in work_manager._in_flight_work_items
+    assert old_item.id not in work_manager._dispatch_timestamps
+    assert new_item.id in work_manager._in_flight_work_items
+    assert new_item.id in work_manager._dispatch_timestamps
+    assert (
+        work_manager._work_item_ids_by_tp_offset[(mock_dto_topic_partition, 10)]
+        == new_item.id
+    )
+    assert work_manager._current_in_flight_count == 1
+    assert (mock_dto_topic_partition, b"key-A") in work_manager._keys_in_flight
+    assert tracker.last_committed_offset == -1

--- a/tests/unit/control_plane/test_work_manager.py
+++ b/tests/unit/control_plane/test_work_manager.py
@@ -250,6 +250,49 @@ async def test_poll_completed_events_does_not_mark_complete_for_shared_trackers(
 
 
 @pytest.mark.asyncio
+async def test_poll_completed_events_processes_shutdown_preserved_completion_normally(
+    mock_execution_engine, mock_dto_topic_partition
+):
+    work_manager = WorkManager(
+        execution_engine=mock_execution_engine,
+        ordering_mode=OrderingMode.KEY_HASH,
+    )
+    work_manager.on_assign([mock_dto_topic_partition])
+
+    work_item_id = str(uuid.uuid4())
+    work_manager._current_in_flight_count = 1
+    work_manager._in_flight_work_items[work_item_id] = WorkItem(
+        id=work_item_id,
+        tp=mock_dto_topic_partition,
+        offset=10,
+        epoch=0,
+        key=b"key",
+        payload=b"payload",
+    )
+    work_manager._dispatch_timestamps[work_item_id] = 0.0
+    work_manager._keys_in_flight.add((mock_dto_topic_partition, b"key"))
+
+    preserved_completion = CompletionEvent(
+        id=work_item_id,
+        tp=mock_dto_topic_partition,
+        offset=10,
+        epoch=0,
+        status=CompletionStatus.SUCCESS,
+        error=None,
+        attempt=1,
+    )
+    mock_execution_engine.poll_completed_events.return_value = [preserved_completion]
+
+    completed_events = await work_manager.poll_completed_events()
+
+    assert completed_events == [preserved_completion]
+    assert work_manager._current_in_flight_count == 0
+    assert work_item_id not in work_manager._in_flight_work_items
+    assert work_item_id not in work_manager._dispatch_timestamps
+    assert (mock_dto_topic_partition, b"key") not in work_manager._keys_in_flight
+
+
+@pytest.mark.asyncio
 async def test_poll_completed_events_uses_work_completion_observer_hook(
     mock_execution_engine, mock_dto_topic_partition
 ):

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -3243,6 +3243,46 @@ async def test_shutdown_post_join_drain_waits_for_stable_empty_before_cleanup(
 
 
 @pytest.mark.asyncio
+async def test_shutdown_post_join_drain_observes_stable_empty_after_deadline_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    drain_results = [
+        (0, 1),
+        (0, 0),
+        (0, 0),
+    ]
+    drain_calls: list[tuple[int, int]] = []
+    sleep_calls: list[float] = []
+
+    def drain_once() -> tuple[int, int]:
+        result = drain_results.pop(0) if drain_results else (0, 0)
+        drain_calls.append(result)
+        return result
+
+    async def record_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    monotonic_values = iter([0.0, 1.0, 1.0, 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(monotonic_values, 1.0))
+    monkeypatch.setattr(
+        "pyrallel_consumer.execution_plane.process_engine.asyncio.sleep",
+        record_sleep,
+    )
+    engine_any._drain_shutdown_ipc_once = Mock(side_effect=drain_once)
+
+    result = await engine._drain_shutdown_ipc_until_stable_empty(
+        max_seconds=0.05,
+        stable_empty_passes=2,
+    )
+
+    assert result == (0, 1, 3)
+    assert drain_calls == [(0, 1), (0, 0), (0, 0)]
+    assert sleep_calls == [0.0, 0.0]
+
+
+@pytest.mark.asyncio
 async def test_shutdown_post_join_stable_empty_prefetches_real_late_completion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -750,6 +750,206 @@ def test_prefetch_completion_keeps_in_flight_when_identity_differs() -> None:
     }
 
 
+def test_registry_done_event_keeps_in_flight_when_identity_differs() -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    current_payload = {
+        "id": "work-redelivered",
+        "topic": "topic",
+        "partition": 1,
+        "offset": 42,
+        "epoch": 8,
+        "requeue_attempts": 0,
+    }
+    engine_any._in_flight_registry = {(0, "topic", 1, 42): current_payload}
+    engine_any._transport = Mock()
+    engine_any._initialize_runtime_timing_state = lambda: None  # type: ignore[method-assign]
+    engine_any._record_main_to_worker_ipc = lambda *_args: None  # type: ignore[method-assign]
+    engine_any._record_worker_exec = lambda *_args: None  # type: ignore[method-assign]
+
+    engine._apply_registry_event(
+        {
+            "kind": "done",
+            "key": (0, "topic", 1, 42),
+            "payload": {
+                "id": "work-first",
+                "topic": "topic",
+                "partition": 1,
+                "offset": 42,
+                "epoch": 7,
+            },
+        }
+    )
+
+    assert engine_any._in_flight_registry == {(0, "topic", 1, 42): current_payload}
+
+
+def test_registry_start_event_keeps_in_flight_when_identity_differs() -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    current_payload = {
+        "id": "work-redelivered",
+        "topic": "topic",
+        "partition": 1,
+        "offset": 42,
+        "epoch": 8,
+        "requeue_attempts": 0,
+    }
+    engine_any._in_flight_registry = {(0, "topic", 1, 42): current_payload}
+    engine_any._transport = Mock()
+    engine_any._initialize_runtime_timing_state = lambda: None  # type: ignore[method-assign]
+    engine_any._record_main_to_worker_ipc = lambda *_args: None  # type: ignore[method-assign]
+    engine_any._record_worker_exec = lambda *_args: None  # type: ignore[method-assign]
+
+    engine._apply_registry_event(
+        {
+            "kind": "start",
+            "key": (0, "topic", 1, 42),
+            "payload": {
+                "id": "work-first",
+                "topic": "topic",
+                "partition": 1,
+                "offset": 42,
+                "epoch": 7,
+            },
+        }
+    )
+
+    assert engine_any._in_flight_registry == {(0, "topic", 1, 42): current_payload}
+
+
+def test_registry_done_event_removes_only_matching_identity() -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    redelivered_payload = {
+        "id": "work-redelivered",
+        "topic": "topic",
+        "partition": 1,
+        "offset": 42,
+        "epoch": 8,
+        "requeue_attempts": 0,
+    }
+    engine_any._in_flight_registry = {
+        (0, "topic", 1, 42): {
+            "id": "work-first",
+            "topic": "topic",
+            "partition": 1,
+            "offset": 42,
+            "epoch": 7,
+            "requeue_attempts": 0,
+        },
+        (1, "topic", 1, 42): redelivered_payload,
+    }
+    engine_any._transport = Mock()
+    engine_any._initialize_runtime_timing_state = lambda: None  # type: ignore[method-assign]
+    engine_any._record_main_to_worker_ipc = lambda *_args: None  # type: ignore[method-assign]
+    engine_any._record_worker_exec = lambda *_args: None  # type: ignore[method-assign]
+
+    engine._apply_registry_event(
+        {
+            "kind": "done",
+            "key": (0, "topic", 1, 42),
+            "payload": {
+                "id": "work-first",
+                "topic": "topic",
+                "partition": 1,
+                "offset": 42,
+                "epoch": 7,
+            },
+        }
+    )
+
+    assert engine_any._in_flight_registry == {(1, "topic", 1, 42): redelivered_payload}
+
+
+def test_registry_timeout_event_keeps_in_flight_when_identity_differs() -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    engine_any._in_flight_registry = {
+        (0, "topic", 1, 42): {
+            "id": "work-redelivered",
+            "topic": "topic",
+            "partition": 1,
+            "offset": 42,
+            "epoch": 8,
+            "requeue_attempts": 0,
+        }
+    }
+    engine_any._transport = Mock()
+    engine_any._initialize_runtime_timing_state = lambda: None  # type: ignore[method-assign]
+    engine_any._record_main_to_worker_ipc = lambda *_args: None  # type: ignore[method-assign]
+    engine_any._record_worker_exec = lambda *_args: None  # type: ignore[method-assign]
+
+    engine._apply_registry_event(
+        {
+            "kind": "timeout",
+            "key": (0, "topic", 1, 42),
+            "payload": {
+                "id": "work-first",
+                "topic": "topic",
+                "partition": 1,
+                "offset": 42,
+                "epoch": 7,
+            },
+            "attempt": 2,
+            "timeout_error": "task_timeout",
+        }
+    )
+
+    assert "timed_out" not in engine_any._in_flight_registry[(0, "topic", 1, 42)]
+    assert engine_any._in_flight_registry[(0, "topic", 1, 42)]["id"] == (
+        "work-redelivered"
+    )
+    assert engine_any._in_flight_registry[(0, "topic", 1, 42)]["epoch"] == 8
+
+
+def test_registry_timeout_event_marks_only_matching_identity() -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    engine_any._in_flight_registry = {
+        (0, "topic", 1, 42): {
+            "id": "work-first",
+            "topic": "topic",
+            "partition": 1,
+            "offset": 42,
+            "epoch": 7,
+            "requeue_attempts": 0,
+        },
+        (1, "topic", 1, 42): {
+            "id": "work-redelivered",
+            "topic": "topic",
+            "partition": 1,
+            "offset": 42,
+            "epoch": 8,
+            "requeue_attempts": 0,
+        },
+    }
+    engine_any._transport = Mock()
+    engine_any._initialize_runtime_timing_state = lambda: None  # type: ignore[method-assign]
+    engine_any._record_main_to_worker_ipc = lambda *_args: None  # type: ignore[method-assign]
+    engine_any._record_worker_exec = lambda *_args: None  # type: ignore[method-assign]
+
+    engine._apply_registry_event(
+        {
+            "kind": "timeout",
+            "key": (0, "topic", 1, 42),
+            "payload": {
+                "id": "work-first",
+                "topic": "topic",
+                "partition": 1,
+                "offset": 42,
+                "epoch": 7,
+            },
+            "attempt": 2,
+            "timeout_error": "task_timeout",
+        }
+    )
+
+    assert engine_any._in_flight_registry[(0, "topic", 1, 42)]["timed_out"] is True
+    assert engine_any._in_flight_registry[(0, "topic", 1, 42)]["attempt"] == 2
+    assert "timed_out" not in engine_any._in_flight_registry[(1, "topic", 1, 42)]
+
+
 def test_worker_pipe_pending_dispatch_key_preserves_redelivered_same_offset() -> None:
     senders = [_PipeSender()]
     transport = WorkerPipesProcessTransport(
@@ -803,6 +1003,58 @@ def test_worker_pipe_pending_dispatch_key_preserves_redelivered_same_offset() ->
 
     assert list(transport._pending_dispatch.values()) == [redelivered_payload]
     assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
+
+
+def test_worker_pipe_start_event_keeps_pending_dispatch_when_identity_differs() -> None:
+    senders = [_PipeSender()]
+    transport = WorkerPipesProcessTransport(
+        process_count=1,
+        queue_size=1,
+        max_payload_bytes=1024,
+        serialize_work_item=_work_item_to_dict,
+        serialize_batch_payload=lambda _batch, _flush_enqueued_at: b"packed",
+        work_item_from_dict=_work_item_from_dict,
+        get_worker_pipe_senders=lambda: senders,
+        increment_in_flight=lambda: None,
+        pipe_sentinel=b"sentinel",
+    )
+    first_payload = _work_item_to_dict(
+        WorkItem(
+            id="work-first",
+            tp=TopicPartition("topic", 1),
+            offset=42,
+            epoch=7,
+            key=b"same-key",
+            payload=b"payload",
+        )
+    )
+    redelivered_payload = _work_item_to_dict(
+        WorkItem(
+            id="work-redelivered",
+            tp=TopicPartition("topic", 1),
+            offset=42,
+            epoch=8,
+            key=b"same-key",
+            payload=b"payload",
+        )
+    )
+    cast(Any, transport._pending_dispatch)[
+        (0, "topic", 1, 42, "work-redelivered", 8)
+    ] = redelivered_payload
+    assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
+
+    transport.handle_registry_event(
+        {
+            "kind": "start",
+            "key": (0, "topic", 1, 42),
+            "payload": first_payload,
+        }
+    )
+
+    assert transport._pending_dispatch == {
+        (0, "topic", 1, 42, "work-redelivered", 8): redelivered_payload
+    }
+    assert transport._worker_pipe_queue_slots.acquire(blocking=False) is False
 
 
 def test_worker_pipe_transport_blocks_for_slot_without_reentrant_recovery() -> None:

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -997,7 +997,7 @@ def test_registry_done_event_keeps_in_flight_when_identity_differs() -> None:
     assert engine_any._in_flight_registry == {(0, "topic", 1, 42): current_payload}
 
 
-def test_registry_start_event_keeps_in_flight_when_identity_differs() -> None:
+def test_registry_start_event_ignores_older_identity_when_identity_differs() -> None:
     engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
     engine_any = cast(Any, engine)
     current_payload = {
@@ -1029,6 +1029,97 @@ def test_registry_start_event_keeps_in_flight_when_identity_differs() -> None:
     )
 
     assert engine_any._in_flight_registry == {(0, "topic", 1, 42): current_payload}
+
+
+def test_registry_start_event_overwrites_stale_identity_when_epoch_advances() -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    stale_payload = {
+        "id": "work-first",
+        "topic": "topic",
+        "partition": 1,
+        "offset": 42,
+        "epoch": 7,
+        "requeue_attempts": 0,
+    }
+    engine_any._in_flight_registry = {(0, "topic", 1, 42): stale_payload}
+    engine_any._transport = Mock()
+    engine_any._initialize_runtime_timing_state = lambda: None  # type: ignore[method-assign]
+    engine_any._record_main_to_worker_ipc = lambda *_args: None  # type: ignore[method-assign]
+    engine_any._record_worker_exec = lambda *_args: None  # type: ignore[method-assign]
+
+    engine._apply_registry_event(
+        {
+            "kind": "start",
+            "key": (0, "topic", 1, 42),
+            "payload": {
+                "id": "work-redelivered",
+                "topic": "topic",
+                "partition": 1,
+                "offset": 42,
+                "epoch": 8,
+            },
+        }
+    )
+
+    assert engine_any._in_flight_registry == {
+        (0, "topic", 1, 42): {
+            "id": "work-redelivered",
+            "topic": "topic",
+            "partition": 1,
+            "offset": 42,
+            "epoch": 8,
+            "requeue_attempts": 0,
+        }
+    }
+
+
+def test_dead_worker_recovery_uses_superseding_start_identity() -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    engine_any._config = ExecutionConfig(
+        mode=ExecutionMode.PROCESS,
+        max_retries=3,
+        process_config=ProcessConfig(process_count=1),
+    )
+    engine_any._completion_queue = queue.Queue()
+    engine_any._logger = logging.getLogger(__name__)
+    engine_any._in_flight_registry = {
+        (0, "topic", 1, 42): {
+            "id": "work-first",
+            "topic": "topic",
+            "partition": 1,
+            "offset": 42,
+            "epoch": 7,
+            "requeue_attempts": 0,
+        }
+    }
+    engine_any._transport = Mock()
+    engine_any._initialize_runtime_timing_state = lambda: None  # type: ignore[method-assign]
+    engine_any._record_main_to_worker_ipc = lambda *_args: None  # type: ignore[method-assign]
+    engine_any._record_worker_exec = lambda *_args: None  # type: ignore[method-assign]
+
+    engine._apply_registry_event(
+        {
+            "kind": "start",
+            "key": (0, "topic", 1, 42),
+            "payload": {
+                "id": "work-redelivered",
+                "topic": "topic",
+                "partition": 1,
+                "offset": 42,
+                "epoch": 8,
+            },
+        }
+    )
+
+    to_requeue = engine._recover_dead_worker_items(0)
+
+    assert len(to_requeue) == 1
+    assert to_requeue[0]["id"] == "work-redelivered"
+    assert to_requeue[0]["epoch"] == 8
+    assert to_requeue[0]["requeue_attempts"] == 1
+    assert engine_any._in_flight_registry == {}
 
 
 def test_registry_done_event_removes_only_matching_identity() -> None:

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -664,7 +664,14 @@ def test_worker_pipe_start_event_releases_pending_dispatch_capacity() -> None:
         pipe_sentinel=b"sentinel",
     )
     engine_any._transport = transport
-    cast(Any, transport._pending_dispatch)[(0, "topic", 1, 42)] = {"offset": 42}
+    pending_key = (0, "topic", 1, 42, "work-42", 1)
+    cast(Any, transport._pending_dispatch)[pending_key] = {
+        "id": "work-42",
+        "topic": "topic",
+        "partition": 1,
+        "offset": 42,
+        "epoch": 1,
+    }
 
     acquired = transport._worker_pipe_queue_slots.acquire(blocking=False)
     assert acquired is True
@@ -685,7 +692,7 @@ def test_worker_pipe_start_event_releases_pending_dispatch_capacity() -> None:
         }
     )
 
-    assert (0, "topic", 1, 42) not in transport._pending_dispatch
+    assert pending_key not in transport._pending_dispatch
     assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
 
 

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -3435,7 +3435,7 @@ async def test_shutdown_post_join_drain_observes_stable_empty_after_deadline_eve
     async def record_sleep(delay: float) -> None:
         sleep_calls.append(delay)
 
-    monotonic_values = iter([0.0, 1.0, 1.0, 1.0])
+    monotonic_values = iter([0.0, 0.06, 0.07])
     monkeypatch.setattr(time, "monotonic", lambda: next(monotonic_values, 1.0))
     monkeypatch.setattr(
         "pyrallel_consumer.execution_plane.process_engine.asyncio.sleep",
@@ -3451,6 +3451,82 @@ async def test_shutdown_post_join_drain_observes_stable_empty_after_deadline_eve
     assert result == (0, 1, 3)
     assert drain_calls == [(0, 1), (0, 0), (0, 0)]
     assert sleep_calls == [0.01, 0.01]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_post_join_drain_waits_for_first_late_event_after_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    drain_results = [
+        (0, 0),
+        (0, 1),
+        (0, 0),
+        (0, 0),
+    ]
+    drain_calls: list[tuple[int, int]] = []
+    sleep_calls: list[float] = []
+
+    def drain_once() -> tuple[int, int]:
+        result = drain_results.pop(0) if drain_results else (0, 0)
+        drain_calls.append(result)
+        return result
+
+    async def record_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    monotonic_values = iter([0.0, 0.055, 0.065, 0.075])
+    monkeypatch.setattr(time, "monotonic", lambda: next(monotonic_values, 1.0))
+    monkeypatch.setattr(
+        "pyrallel_consumer.execution_plane.process_engine.asyncio.sleep",
+        record_sleep,
+    )
+    engine_any._drain_shutdown_ipc_once = Mock(side_effect=drain_once)
+
+    result = await engine._drain_shutdown_ipc_until_stable_empty(
+        max_seconds=0.05,
+        stable_empty_passes=2,
+    )
+
+    assert result == (0, 1, 4)
+    assert drain_calls == [(0, 0), (0, 1), (0, 0), (0, 0)]
+    assert sleep_calls == [0.01, 0.01, 0.01]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_post_join_drain_has_bounded_post_deadline_grace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    drain_calls: list[tuple[int, int]] = []
+    sleep_calls: list[float] = []
+
+    def drain_once() -> tuple[int, int]:
+        result = (0, 1)
+        drain_calls.append(result)
+        return result
+
+    async def record_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    monotonic_values = iter([0.0, 0.055, 0.065, 0.075, 0.095])
+    monkeypatch.setattr(time, "monotonic", lambda: next(monotonic_values, 0.095))
+    monkeypatch.setattr(
+        "pyrallel_consumer.execution_plane.process_engine.asyncio.sleep",
+        record_sleep,
+    )
+    engine_any._drain_shutdown_ipc_once = Mock(side_effect=drain_once)
+
+    result = await engine._drain_shutdown_ipc_until_stable_empty(
+        max_seconds=0.05,
+        stable_empty_passes=2,
+    )
+
+    assert result == (0, 4, 4)
+    assert drain_calls == [(0, 1), (0, 1), (0, 1), (0, 1)]
+    assert sleep_calls == [0.01, 0.01, 0.01]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -28,6 +28,7 @@ from pyrallel_consumer.execution_plane.process_engine import (
     _serialize_batch_payload,
     _work_item_from_dict,
     _work_item_to_dict,
+    _worker_loop,
 )
 from pyrallel_consumer.execution_plane.process_transport import (
     PendingDispatchRecovery,
@@ -995,6 +996,51 @@ def test_registry_done_event_keeps_in_flight_when_identity_differs() -> None:
     )
 
     assert engine_any._in_flight_registry == {(0, "topic", 1, 42): current_payload}
+
+
+def test_worker_done_registry_event_uses_identity_payload_only() -> None:
+    task_source: queue.Queue[object] = queue.Queue()
+    completion_queue: queue.Queue[object] = queue.Queue()
+    registry_event_queue: queue.Queue[object] = queue.Queue()
+    work_item = WorkItem(
+        id="work-42",
+        tp=TopicPartition("topic", 1),
+        offset=42,
+        epoch=7,
+        key=b"large-key",
+        payload=b"large-payload",
+    )
+    task_source.put([_work_item_to_dict(work_item)])
+    task_source.put(None)
+
+    _worker_loop(
+        task_source,
+        completion_queue,  # type: ignore[arg-type]
+        registry_event_queue,  # type: ignore[arg-type]
+        lambda _item: None,
+        0,
+        ExecutionConfig(
+            mode=ExecutionMode.PROCESS,
+            max_retries=1,
+            process_config=ProcessConfig(process_count=1),
+        ),
+    )
+
+    registry_events: list[dict[str, Any]] = []
+    while not registry_event_queue.empty():
+        registry_events.append(cast(dict[str, Any], registry_event_queue.get_nowait()))
+    done_events = [event for event in registry_events if event.get("kind") == "done"]
+
+    assert len(done_events) == 1
+    assert done_events[0]["payload"] == {
+        "id": "work-42",
+        "topic": "topic",
+        "partition": 1,
+        "offset": 42,
+        "epoch": 7,
+    }
+    assert "key" not in done_events[0]["payload"]
+    assert "payload" not in done_events[0]["payload"]
 
 
 def test_registry_start_event_ignores_older_identity_when_identity_differs() -> None:

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -25,6 +25,7 @@ from pyrallel_consumer.execution_plane.process_engine import (
     ProcessExecutionEngine,
     _completion_event_from_dict,
     _completion_event_to_dict,
+    _serialize_batch_payload,
     _work_item_from_dict,
     _work_item_to_dict,
 )
@@ -661,6 +662,179 @@ def test_worker_pipe_start_event_releases_pending_dispatch_capacity() -> None:
     assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
 
 
+def test_worker_pipe_slot_wait_blocks_until_start_event_releases_capacity() -> None:
+    sender = _PipeSender()
+    liveness_checks = 0
+
+    def record_liveness_check() -> None:
+        nonlocal liveness_checks
+        liveness_checks += 1
+
+    transport = WorkerPipesProcessTransport(
+        process_count=1,
+        queue_size=1,
+        max_payload_bytes=1024,
+        serialize_work_item=_work_item_to_dict,
+        serialize_batch_payload=_serialize_batch_payload,
+        work_item_from_dict=_work_item_from_dict,
+        get_worker_pipe_senders=lambda: [sender],
+        increment_in_flight=lambda: None,
+        pipe_sentinel=b"sentinel",
+        slot_wait_liveness_check=record_liveness_check,
+        slot_wait_timeout_seconds=0.01,
+    )
+    first_payload = _work_item_to_dict(
+        WorkItem(
+            id="work-42",
+            tp=TopicPartition("topic", 1),
+            offset=42,
+            epoch=7,
+            key=b"same-key",
+            payload=b"payload-1",
+        )
+    )
+    second_payload = _work_item_to_dict(
+        WorkItem(
+            id="work-43",
+            tp=TopicPartition("topic", 1),
+            offset=43,
+            epoch=7,
+            key=b"same-key",
+            payload=b"payload-2",
+        )
+    )
+
+    transport.dispatch_payload(
+        first_payload,
+        route_identity=RouteIdentity("topic", 1, b"same-key"),
+        count_in_flight=False,
+    )
+
+    errors: list[BaseException] = []
+
+    def dispatch_second() -> None:
+        try:
+            transport.dispatch_payload(
+                second_payload,
+                route_identity=RouteIdentity("topic", 1, b"same-key"),
+                count_in_flight=False,
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    thread = threading.Thread(target=dispatch_second)
+    thread.start()
+
+    released_by_start_event = False
+    try:
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            if liveness_checks > 0:
+                break
+            time.sleep(0.01)
+
+        assert liveness_checks > 0
+        assert len(sender.payloads) == 1
+
+        transport.handle_registry_event(
+            {"kind": "start", "key": (0, "topic", 1, 42), "payload": first_payload}
+        )
+        released_by_start_event = True
+        thread.join(timeout=1.0)
+    finally:
+        if thread.is_alive():
+            if not released_by_start_event:
+                transport.handle_registry_event(
+                    {
+                        "kind": "start",
+                        "key": (0, "topic", 1, 42),
+                        "payload": first_payload,
+                    }
+                )
+            thread.join(timeout=1.0)
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert len(sender.payloads) == 2
+    assert transport._pending_dispatch == {
+        (0, "topic", 1, 43, "work-43", 7): second_payload,
+    }
+
+
+def test_worker_pipe_start_event_requires_matching_identity_to_release_capacity() -> (
+    None
+):
+    sender = _PipeSender()
+    transport = WorkerPipesProcessTransport(
+        process_count=1,
+        queue_size=1,
+        max_payload_bytes=1024,
+        serialize_work_item=_work_item_to_dict,
+        serialize_batch_payload=_serialize_batch_payload,
+        work_item_from_dict=_work_item_from_dict,
+        get_worker_pipe_senders=lambda: [sender],
+        increment_in_flight=lambda: None,
+        pipe_sentinel=b"sentinel",
+    )
+    original_payload = _work_item_to_dict(
+        WorkItem(
+            id="work-original",
+            tp=TopicPartition("topic", 1),
+            offset=42,
+            epoch=7,
+            key=b"same-key",
+            payload=b"payload-original",
+        )
+    )
+    redelivered_payload = {
+        **original_payload,
+        "id": "work-redelivered",
+        "epoch": 8,
+    }
+
+    transport.dispatch_payload(
+        original_payload,
+        route_identity=RouteIdentity("topic", 1, b"same-key"),
+        count_in_flight=False,
+    )
+    transport.handle_registry_event(
+        {
+            "kind": "start",
+            "key": (0, "topic", 1, 42),
+            "payload": redelivered_payload,
+        }
+    )
+
+    assert transport._pending_dispatch == {
+        (0, "topic", 1, 42, "work-original", 7): original_payload
+    }
+    assert transport._worker_pipe_queue_slots.acquire(blocking=False) is False
+
+    transport.handle_registry_event(
+        {
+            "kind": "start",
+            "key": (0, "topic", 1, 43),
+            "payload": original_payload,
+        }
+    )
+
+    assert transport._pending_dispatch == {
+        (0, "topic", 1, 42, "work-original", 7): original_payload
+    }
+    assert transport._worker_pipe_queue_slots.acquire(blocking=False) is False
+
+    transport.handle_registry_event(
+        {
+            "kind": "start",
+            "key": (0, "topic", 1, 42),
+            "payload": original_payload,
+        }
+    )
+
+    assert transport._pending_dispatch == {}
+    assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
+
+
 def test_prefetch_completion_discards_only_matching_in_flight_identity() -> None:
     engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
     engine_any = cast(Any, engine)
@@ -1109,6 +1283,104 @@ def test_worker_pipe_transport_blocks_for_slot_without_reentrant_recovery() -> N
 
     transport._worker_pipe_queue_slots.release()
     thread.join(timeout=1.0)
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert senders[0].payloads == [b"packed"]
+    assert transport._pending_dispatch == {
+        (0, "topic", 1, 42, "work-42", 7): payload,
+    }
+
+
+def test_worker_pipe_backpressure_waits_for_healthy_slot_without_recovery() -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    senders = [_PipeSender()]
+    worker = _CountingAliveWorker()
+    engine_any._config = ExecutionConfig(
+        mode=ExecutionMode.PROCESS,
+        max_retries=3,
+        process_config=ProcessConfig(
+            process_count=1,
+            queue_size=1,
+            transport_mode="worker_pipes",
+            batch_size=1,
+            max_batch_wait_ms=0,
+        ),
+    )
+    engine_any._transport_mode = "worker_pipes"
+    engine_any._in_flight_registry = {}
+    engine_any._registry_event_queue = queue.Queue()
+    engine_any._completion_queue = queue.Queue()
+    engine_any._prefetched_completion_events = deque()
+    engine_any._workers = [worker]
+    engine_any._logger = logging.getLogger(__name__)
+    engine_any._last_worker_liveness_check = 0.0
+    engine_any._worker_liveness_check_interval_seconds = 0.0
+    engine_any._start_worker = Mock()  # type: ignore[method-assign]
+    transport = WorkerPipesProcessTransport(
+        process_count=1,
+        queue_size=1,
+        max_payload_bytes=1024,
+        serialize_work_item=_work_item_to_dict,
+        serialize_batch_payload=lambda _batch, _flush_enqueued_at: b"packed",
+        work_item_from_dict=_work_item_from_dict,
+        get_worker_pipe_senders=lambda: senders,
+        increment_in_flight=lambda: None,
+        pipe_sentinel=b"sentinel",
+        slot_wait_liveness_check=engine._signal_worker_pipe_slot_wait,
+        slot_wait_timeout_seconds=0.01,
+    )
+    engine_any._transport = transport
+    assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
+
+    payload = _work_item_to_dict(
+        WorkItem(
+            id="work-42",
+            tp=TopicPartition("topic", 1),
+            offset=42,
+            epoch=7,
+            key=b"same-key",
+            payload=b"payload",
+        )
+    )
+    errors: list[BaseException] = []
+
+    def dispatch() -> None:
+        try:
+            transport.dispatch_payload(
+                payload,
+                route_identity=RouteIdentity("topic", 1, b"same-key"),
+                count_in_flight=False,
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    thread = threading.Thread(target=dispatch)
+    thread.start()
+
+    try:
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            if worker.is_alive_calls > 0:
+                break
+            time.sleep(0.01)
+
+        assert thread.is_alive()
+        assert errors == []
+        assert senders[0].payloads == []
+        assert worker.is_alive_calls > 0
+        engine_any._start_worker.assert_not_called()
+        assert engine_any._in_flight_registry == {}
+        assert list(engine_any._prefetched_completion_events) == []
+        assert engine_any._completion_queue.empty()
+
+        transport._worker_pipe_queue_slots.release()
+        thread.join(timeout=1.0)
+    finally:
+        if thread.is_alive():
+            transport._worker_pipe_queue_slots.release()
+            thread.join(timeout=1.0)
 
     assert not thread.is_alive()
     assert errors == []
@@ -1682,7 +1954,141 @@ def test_worker_pipe_slot_wait_signals_engine_recovery_for_dead_worker(
     }
 
 
-def test_worker_pipe_slot_wait_drains_events_for_reentrant_recovery_owner() -> None:
+def test_worker_pipe_slot_wait_blocks_healthy_worker_until_start_event() -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    senders = [_PipeSender()]
+    worker = _CountingAliveWorker()
+
+    engine_any._config = ExecutionConfig(
+        mode=ExecutionMode.PROCESS,
+        max_retries=3,
+        process_config=ProcessConfig(
+            process_count=1,
+            queue_size=1,
+            transport_mode="worker_pipes",
+            batch_size=1,
+            max_batch_wait_ms=0,
+        ),
+    )
+    engine_any._transport_mode = "worker_pipes"
+    engine_any._in_flight_registry = {}
+    engine_any._registry_event_queue = queue.Queue()
+    engine_any._completion_queue = queue.Queue()
+    engine_any._prefetched_completion_events = deque()
+    engine_any._workers = [worker]
+    engine_any._logger = logging.getLogger(__name__)
+    engine_any._last_worker_liveness_check = 0.0
+    engine_any._worker_liveness_check_interval_seconds = 0.0
+    engine_any._record_main_to_worker_ipc = lambda *_args, **_kwargs: None
+    engine_any._record_worker_exec = lambda *_args, **_kwargs: None
+    transport = WorkerPipesProcessTransport(
+        process_count=1,
+        queue_size=1,
+        max_payload_bytes=1024,
+        serialize_work_item=_work_item_to_dict,
+        serialize_batch_payload=lambda batch, _flush_enqueued_at: (
+            f"packed:{batch[0].offset}".encode()
+        ),
+        work_item_from_dict=_work_item_from_dict,
+        get_worker_pipe_senders=lambda: senders,
+        increment_in_flight=lambda: None,
+        pipe_sentinel=b"sentinel",
+        slot_wait_liveness_check=engine._signal_worker_pipe_slot_wait,
+        slot_wait_timeout_seconds=0.01,
+    )
+    engine_any._transport = transport
+
+    first_payload = _work_item_to_dict(
+        WorkItem(
+            id="work-42",
+            tp=TopicPartition("topic", 1),
+            offset=42,
+            epoch=7,
+            key=b"same-key",
+            payload=b"payload-1",
+        )
+    )
+    second_payload = _work_item_to_dict(
+        WorkItem(
+            id="work-43",
+            tp=TopicPartition("topic", 1),
+            offset=43,
+            epoch=7,
+            key=b"same-key",
+            payload=b"payload-2",
+        )
+    )
+    transport.dispatch_payload(
+        first_payload,
+        route_identity=RouteIdentity("topic", 1, b"same-key"),
+        count_in_flight=False,
+    )
+
+    errors: list[BaseException] = []
+
+    def dispatch_second() -> None:
+        try:
+            transport.dispatch_payload(
+                second_payload,
+                route_identity=RouteIdentity("topic", 1, b"same-key"),
+                count_in_flight=False,
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    thread = threading.Thread(target=dispatch_second)
+    thread.start()
+
+    start_event_enqueued = False
+    try:
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            if worker.is_alive_calls > 0:
+                break
+            time.sleep(0.01)
+
+        assert worker.is_alive_calls > 0
+        assert thread.is_alive()
+        assert errors == []
+        assert senders[0].payloads == [b"packed:42"]
+        assert transport._pending_dispatch == {
+            (0, "topic", 1, 42, "work-42", 7): first_payload,
+        }
+
+        engine_any._registry_event_queue.put(
+            {
+                "kind": "start",
+                "key": (0, "topic", 1, 42),
+                "payload": {**first_payload, "requeue_attempts": 0},
+            }
+        )
+        start_event_enqueued = True
+        thread.join(timeout=1.0)
+    finally:
+        if thread.is_alive():
+            if not start_event_enqueued:
+                engine_any._registry_event_queue.put(
+                    {
+                        "kind": "start",
+                        "key": (0, "topic", 1, 42),
+                        "payload": {**first_payload, "requeue_attempts": 0},
+                    }
+                )
+            thread.join(timeout=1.0)
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert senders[0].payloads == [b"packed:42", b"packed:43"]
+    assert transport._pending_dispatch == {
+        (0, "topic", 1, 43, "work-43", 7): second_payload,
+    }
+    assert engine_any._registry_event_queue.empty()
+
+
+def test_worker_pipe_slot_wait_reentrant_owner_drains_events_and_releases_slot() -> (
+    None
+):
     engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
     engine_any = cast(Any, engine)
     senders = [_PipeSender()]
@@ -1772,7 +2178,7 @@ def test_worker_pipe_slot_wait_drains_events_for_reentrant_recovery_owner() -> N
     assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
 
 
-def test_worker_pipe_slot_wait_is_side_effect_free_when_another_thread_owns_lock() -> (
+def test_worker_pipe_slot_wait_cross_thread_contention_noops_until_owner_releases() -> (
     None
 ):
     engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
@@ -1864,16 +2270,23 @@ def test_worker_pipe_slot_wait_is_side_effect_free_when_another_thread_owns_lock
     thread = threading.Thread(target=signal_from_other_thread)
     thread.start()
     thread.join(timeout=1.0)
-    liveness_lock.release()
 
     assert not thread.is_alive()
     assert errors == []
     assert not engine_any._registry_event_queue.empty()
-    assert engine_any._completion_queue.get_nowait() == packed_completion
     assert list(engine_any._prefetched_completion_events) == []
     assert engine_any._in_flight_registry == {}
     assert worker.is_alive_calls == 0
     assert transport._pending_dispatch != {}
+
+    liveness_lock.release()
+    engine._signal_worker_pipe_slot_wait()
+
+    assert engine_any._registry_event_queue.empty()
+    assert list(engine_any._prefetched_completion_events) == [completion]
+    assert worker.is_alive_calls == 1
+    assert transport._pending_dispatch == {}
+    assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
 
 
 def test_ensure_workers_alive_caps_pending_worker_pipe_retries(

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -2838,16 +2838,26 @@ def test_worker_pipe_dispatch_rejects_invalid_payload_before_send() -> None:
 
 
 @pytest.mark.asyncio
-async def test_shutdown_delegates_signal_and_close_through_transport_seam() -> None:
+async def test_shutdown_delegates_signal_and_close_through_transport_seam(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
     engine_any = cast(Any, engine)
     engine_any._is_shutdown = False
     engine_any._prefetched_completion_events = [Mock()]
-    engine_any._in_flight_registry = {(0, "topic", 1, 42): {"offset": 42}}
+    engine_any._in_flight_registry = {
+        (0, "topic", 1, 42): {
+            "id": "work-42",
+            "topic": "topic",
+            "partition": 1,
+            "offset": 42,
+            "epoch": 7,
+        }
+    }
     engine_any._workers = [Mock(), Mock()]
     engine_any._task_queue = None
-    engine_any._completion_queue = None
-    engine_any._registry_event_queue = None
+    engine_any._completion_queue = queue.Queue()
+    engine_any._registry_event_queue = queue.Queue()
     engine_any._batch_accumulator = Mock()
     engine_any._drain_registry_events = Mock()
     engine_any._drain_shutdown_ipc_once = Mock(return_value=(0, 0))
@@ -2856,14 +2866,138 @@ async def test_shutdown_delegates_signal_and_close_through_transport_seam() -> N
     engine_any._in_flight_lock = threading.Lock()
     engine_any._in_flight_count = 3
     engine_any._worker_pid_by_index = {}
+    engine_any._emit_worker_recovery_failure = Mock()
     transport = Mock()
     engine_any._transport = transport
 
-    await engine.shutdown()
+    with caplog.at_level(logging.WARNING):
+        await engine.shutdown()
 
     transport.signal_shutdown.assert_called_once_with(2)
     transport.close.assert_called_once_with()
     engine_any._batch_accumulator.close.assert_called_once_with()
+    assert engine_any._prefetched_completion_events == []
+    assert engine_any._in_flight_registry == {}
+    assert engine.get_in_flight_count() == 0
+    engine_any._emit_worker_recovery_failure.assert_not_called()
+    assert engine_any._completion_queue.empty()
+    assert "Residual in-flight registry after shutdown drain" in caplog.text
+    assert "id=work-42 epoch=7" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_shutdown_worker_pipes_clears_pending_dispatches_without_requeueing() -> (
+    None
+):
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    engine_any._is_shutdown = False
+    engine_any._prefetched_completion_events = []
+    engine_any._in_flight_registry = {}
+    engine_any._workers = [Mock()]
+    engine_any._task_queue = None
+    engine_any._completion_queue = queue.Queue()
+    engine_any._registry_event_queue = queue.Queue()
+    engine_any._batch_accumulator = Mock()
+    engine_any._join_worker_with_escalation = Mock()
+    engine_any._log_listener = Mock()
+    engine_any._in_flight_lock = threading.Lock()
+    engine_any._in_flight_count = 1
+    engine_any._worker_pid_by_index = {}
+    engine_any._ensure_workers_alive = Mock()
+    engine_any._recover_pending_pipe_dispatches = Mock()
+    engine_any._requeue_recovered_payloads = Mock()
+    engine_any._emit_worker_recovery_failure = Mock()
+    sender = _PipeSender()
+    transport = WorkerPipesProcessTransport(
+        process_count=1,
+        queue_size=1,
+        max_payload_bytes=1024,
+        serialize_work_item=_work_item_to_dict,
+        serialize_batch_payload=_serialize_batch_payload,
+        work_item_from_dict=_work_item_from_dict,
+        get_worker_pipe_senders=lambda: [sender],
+        increment_in_flight=lambda: None,
+        pipe_sentinel=b"sentinel",
+    )
+    payload = _work_item_to_dict(
+        WorkItem(
+            id="work-pending",
+            tp=TopicPartition("topic", 1),
+            offset=42,
+            epoch=7,
+            key=b"key",
+            payload=b"payload",
+        )
+    )
+    transport._pending_dispatch[(0, "topic", 1, 42, "work-pending", 7)] = payload
+    engine_any._transport = transport
+
+    await engine.shutdown()
+
+    assert sender.payloads == [b"sentinel"]
+    assert transport._pending_dispatch == {}
+    engine_any._ensure_workers_alive.assert_not_called()
+    engine_any._recover_pending_pipe_dispatches.assert_not_called()
+    engine_any._requeue_recovered_payloads.assert_not_called()
+    engine_any._emit_worker_recovery_failure.assert_not_called()
+    assert engine.get_in_flight_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_worker_pipes_drains_completion_before_joining_workers() -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    engine_any._is_shutdown = False
+    engine_any._prefetched_completion_events = []
+    engine_any._in_flight_registry = {
+        (0, "topic", 1, 42): {
+            "id": "work-42",
+            "topic": "topic",
+            "partition": 1,
+            "offset": 42,
+            "epoch": 7,
+            "requeue_attempts": 0,
+        }
+    }
+    engine_any._workers = [Mock()]
+    engine_any._task_queue = None
+    engine_any._completion_queue = queue.Queue()
+    engine_any._registry_event_queue = queue.Queue()
+    engine_any._batch_accumulator = Mock()
+    engine_any._log_listener = Mock()
+    engine_any._in_flight_lock = threading.Lock()
+    engine_any._in_flight_count = 1
+    engine_any._worker_pid_by_index = {}
+    transport = Mock()
+    engine_any._transport = transport
+    completion = CompletionEvent(
+        id="work-42",
+        tp=TopicPartition("topic", 1),
+        offset=42,
+        epoch=7,
+        status=CompletionStatus.SUCCESS,
+        error=None,
+        attempt=1,
+    )
+    engine_any._completion_queue.put(
+        msgpack.packb(_completion_event_to_dict(completion), use_bin_type=True)
+    )
+
+    def assert_drained_before_join(_worker: object) -> None:
+        assert engine_any._in_flight_registry == {}
+        assert engine_any._prefetched_completion_events == [completion]
+
+    engine_any._join_worker_with_escalation = Mock(
+        side_effect=assert_drained_before_join
+    )
+
+    await engine.shutdown()
+
+    transport.signal_shutdown.assert_called_once_with(1)
+    engine_any._join_worker_with_escalation.assert_called_once()
+    transport.clear_pending_dispatches.assert_called_once_with()
+    transport.close.assert_called_once_with()
     assert engine_any._prefetched_completion_events == []
     assert engine_any._in_flight_registry == {}
     assert engine.get_in_flight_count() == 0

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -113,6 +113,33 @@ class _FakeProcess:
         self.started = True
 
 
+class _JoinedWorker:
+    pid = 9876
+    exitcode = 0
+
+    def __init__(self) -> None:
+        self.join_calls = 0
+
+    def join(self, timeout: float | None = None) -> None:
+        del timeout
+        self.join_calls += 1
+
+    def is_alive(self) -> bool:
+        return False
+
+
+class _Closable:
+    def __init__(self) -> None:
+        self.closed = False
+        self.stopped = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
 class _RequeueRecordingTransport:
     def __init__(self) -> None:
         self.requeued_payloads: list[list[dict[str, Any]]] = []
@@ -2592,6 +2619,104 @@ def test_drain_shutdown_ipc_once_reuses_registry_event_rules_and_prefetches_comp
     assert prefetched.offset == 42
 
 
+def _make_shutdown_engine() -> (
+    tuple[ProcessExecutionEngine, _RequeueRecordingTransport]
+):
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    engine_any._is_shutdown = False
+    engine_any._config = ExecutionConfig(
+        mode=ExecutionMode.PROCESS,
+        process_config=ProcessConfig(process_count=1, worker_join_timeout_ms=1),
+    )
+    engine_any._batch_accumulator = _Closable()
+    engine_any._task_queue = queue.Queue()
+    engine_any._completion_queue = queue.Queue()
+    engine_any._registry_event_queue = queue.Queue()
+    engine_any._prefetched_completion_events = deque()
+    engine_any._in_flight_registry = {}
+    engine_any._in_flight_lock = threading.Lock()
+    engine_any._in_flight_count = 0
+    engine_any._worker_pid_by_index = {0: 9876}
+    engine_any._workers = [_JoinedWorker()]
+    engine_any._logger = logging.getLogger(__name__)
+    engine_any._log_listener = _Closable()
+    transport = _RequeueRecordingTransport()
+    engine_any._transport = transport
+    return engine, transport
+
+
+@pytest.mark.asyncio
+async def test_shutdown_residual_work_is_diagnostic_only(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine, _transport = _make_shutdown_engine()
+    engine_any = cast(Any, engine)
+    residual_payload = {
+        "id": "work-42",
+        "topic": "topic",
+        "partition": 1,
+        "offset": 42,
+        "epoch": 7,
+        "requeue_attempts": 0,
+    }
+    engine_any._in_flight_registry = {
+        (0, "topic", 1, 42): residual_payload,
+    }
+    engine_any._in_flight_count = 1
+
+    async def fast_sleep(_delay: float) -> None:
+        return None
+
+    monotonic_values = iter([100.0, 100.0, 102.0])
+    monkeypatch.setattr(
+        "pyrallel_consumer.execution_plane.process_engine.time.monotonic",
+        lambda: next(monotonic_values, 102.0),
+    )
+    monkeypatch.setattr(
+        "pyrallel_consumer.execution_plane.process_engine.asyncio.sleep",
+        fast_sleep,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await engine.shutdown()
+
+    assert "Residual in-flight registry after shutdown drain" in caplog.text
+    assert "topic-1@42 id=work-42 epoch=7" in caplog.text
+    assert engine_any._completion_queue.empty()
+    assert list(engine_any._prefetched_completion_events) == []
+    assert engine_any._in_flight_registry == {}
+    assert engine.get_in_flight_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_preserves_visible_completion_drained_before_cleanup() -> None:
+    engine, _transport = _make_shutdown_engine()
+    engine_any = cast(Any, engine)
+    completion = CompletionEvent(
+        id="work-42",
+        tp=TopicPartition("topic", 1),
+        offset=42,
+        epoch=7,
+        status=CompletionStatus.SUCCESS,
+        error=None,
+        attempt=1,
+    )
+    engine_any._completion_queue.put(
+        msgpack.packb(_completion_event_to_dict(completion), use_bin_type=True)
+    )
+    engine_any._in_flight_count = 1
+
+    await engine.shutdown()
+
+    assert list(engine_any._prefetched_completion_events) == [completion]
+    assert engine.get_in_flight_count() == 1
+    assert await engine.wait_for_completion(timeout_seconds=0) is True
+    assert await engine.poll_completed_events() == [completion]
+    assert engine.get_in_flight_count() == 0
+
+
 @pytest.mark.asyncio
 async def test_poll_completed_events_ignores_queue_empty_race(
     monkeypatch: pytest.MonkeyPatch,
@@ -2998,6 +3123,135 @@ async def test_shutdown_worker_pipes_drains_completion_before_joining_workers() 
     engine_any._join_worker_with_escalation.assert_called_once()
     transport.clear_pending_dispatches.assert_called_once_with()
     transport.close.assert_called_once_with()
-    assert engine_any._prefetched_completion_events == []
+    assert engine_any._prefetched_completion_events == [completion]
     assert engine_any._in_flight_registry == {}
+    assert engine.get_in_flight_count() == 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown_runs_post_join_drain_before_local_cleanup(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    engine_any._is_shutdown = False
+    engine_any._prefetched_completion_events = []
+    engine_any._in_flight_registry = {}
+    engine_any._workers = [Mock()]
+    engine_any._task_queue = None
+    engine_any._completion_queue = queue.Queue()
+    engine_any._registry_event_queue = queue.Queue()
+    engine_any._batch_accumulator = Mock()
+    engine_any._drain_registry_events = Mock()
+    engine_any._log_listener = Mock()
+    engine_any._in_flight_lock = threading.Lock()
+    engine_any._in_flight_count = 0
+    engine_any._worker_pid_by_index = {}
+    order: list[str] = []
+
+    def drain_once() -> tuple[int, int]:
+        order.append("drain")
+        if order.count("drain") == 1:
+            return (0, 0)
+        return (0, 1)
+
+    def join_worker(_worker: object) -> None:
+        order.append("join")
+
+    transport = Mock()
+    transport.clear_pending_dispatches.side_effect = lambda: order.append("clear")
+    transport.close.side_effect = lambda: order.append("close")
+    engine_any._transport = transport
+    engine_any._drain_shutdown_ipc_once = Mock(side_effect=drain_once)
+    engine_any._join_worker_with_escalation = Mock(side_effect=join_worker)
+
+    with caplog.at_level(logging.DEBUG):
+        await engine.shutdown()
+
+    assert order == ["drain", "join", "drain", "clear", "close"]
+    assert engine_any._drain_shutdown_ipc_once.call_count == 2
+    assert "ProcessExecutionEngine shutdown post-join drain" in caplog.text
+    assert "completion_events=1" in caplog.text
+    transport.signal_shutdown.assert_called_once_with(1)
     assert engine.get_in_flight_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_post_join_drain_reconciles_late_completion_before_cleanup(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    engine_any._is_shutdown = False
+    engine_any._prefetched_completion_events = []
+    engine_any._in_flight_registry = {
+        (0, "topic", 1, 42): {
+            "id": "work-42",
+            "topic": "topic",
+            "partition": 1,
+            "offset": 42,
+            "epoch": 7,
+            "requeue_attempts": 0,
+        }
+    }
+    engine_any._workers = [Mock()]
+    engine_any._task_queue = None
+    engine_any._completion_queue = queue.Queue()
+    engine_any._registry_event_queue = queue.Queue()
+    engine_any._batch_accumulator = Mock()
+    engine_any._drain_registry_events = Mock()
+    engine_any._log_listener = Mock()
+    engine_any._in_flight_lock = threading.Lock()
+    engine_any._in_flight_count = 1
+    engine_any._worker_pid_by_index = {}
+    completion = CompletionEvent(
+        id="work-42",
+        tp=TopicPartition("topic", 1),
+        offset=42,
+        epoch=7,
+        status=CompletionStatus.SUCCESS,
+        error=None,
+        attempt=1,
+    )
+
+    engine_any._prefetched_completion_events = []
+
+    async def fast_sleep(_delay: float) -> None:
+        return None
+
+    monotonic_values = iter([0.0, 2.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(monotonic_values, 2.0))
+    monkeypatch.setattr(
+        "pyrallel_consumer.execution_plane.process_engine.asyncio.sleep",
+        fast_sleep,
+    )
+
+    def join_worker(_worker: object) -> None:
+        engine_any._completion_queue.put(
+            msgpack.packb(_completion_event_to_dict(completion), use_bin_type=True)
+        )
+
+    def assert_reconciled_before_local_cleanup() -> None:
+        assert engine_any._in_flight_registry == {}
+        assert engine_any._prefetched_completion_events == [completion]
+
+    transport = Mock()
+    transport.clear_pending_dispatches.side_effect = (
+        assert_reconciled_before_local_cleanup
+    )
+    engine_any._transport = transport
+    engine_any._join_worker_with_escalation = Mock(side_effect=join_worker)
+
+    with caplog.at_level(logging.DEBUG):
+        await engine.shutdown()
+
+    engine_any._join_worker_with_escalation.assert_called_once()
+    transport.clear_pending_dispatches.assert_called_once_with()
+    transport.close.assert_called_once_with()
+    assert engine_any._prefetched_completion_events == [completion]
+    assert engine_any._in_flight_registry == {}
+    assert engine.get_in_flight_count() == 1
+    assert "ProcessExecutionEngine shutdown post-join drain" in caplog.text
+    assert "completion_events=1" in caplog.text
+    assert "residual_in_flight_registry=0" in caplog.text

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -2969,7 +2969,8 @@ async def test_shutdown_delegates_signal_and_close_through_transport_seam(
     engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
     engine_any = cast(Any, engine)
     engine_any._is_shutdown = False
-    engine_any._prefetched_completion_events = [Mock()]
+    prefetched_event = Mock()
+    engine_any._prefetched_completion_events = [prefetched_event]
     engine_any._in_flight_registry = {
         (0, "topic", 1, 42): {
             "id": "work-42",
@@ -3001,9 +3002,9 @@ async def test_shutdown_delegates_signal_and_close_through_transport_seam(
     transport.signal_shutdown.assert_called_once_with(2)
     transport.close.assert_called_once_with()
     engine_any._batch_accumulator.close.assert_called_once_with()
-    assert engine_any._prefetched_completion_events == []
+    assert engine_any._prefetched_completion_events == [prefetched_event]
     assert engine_any._in_flight_registry == {}
-    assert engine.get_in_flight_count() == 0
+    assert engine.get_in_flight_count() == 1
     engine_any._emit_worker_recovery_failure.assert_not_called()
     assert engine_any._completion_queue.empty()
     assert "Residual in-flight registry after shutdown drain" in caplog.text
@@ -3153,7 +3154,9 @@ async def test_shutdown_runs_post_join_drain_before_local_cleanup(
         order.append("drain")
         if order.count("drain") == 1:
             return (0, 0)
-        return (0, 1)
+        if order.count("drain") == 2:
+            return (0, 1)
+        return (0, 0)
 
     def join_worker(_worker: object) -> None:
         order.append("join")
@@ -3168,11 +3171,114 @@ async def test_shutdown_runs_post_join_drain_before_local_cleanup(
     with caplog.at_level(logging.DEBUG):
         await engine.shutdown()
 
-    assert order == ["drain", "join", "drain", "clear", "close"]
-    assert engine_any._drain_shutdown_ipc_once.call_count == 2
+    assert order == ["drain", "join", "drain", "drain", "drain", "clear", "close"]
+    assert engine_any._drain_shutdown_ipc_once.call_count == 4
     assert "ProcessExecutionEngine shutdown post-join drain" in caplog.text
     assert "completion_events=1" in caplog.text
     transport.signal_shutdown.assert_called_once_with(1)
+    assert engine.get_in_flight_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_post_join_drain_waits_for_stable_empty_before_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    engine_any._is_shutdown = False
+    engine_any._prefetched_completion_events = []
+    engine_any._in_flight_registry = {}
+    engine_any._workers = [Mock()]
+    engine_any._task_queue = None
+    engine_any._completion_queue = queue.Queue()
+    engine_any._registry_event_queue = queue.Queue()
+    engine_any._batch_accumulator = Mock()
+    engine_any._log_listener = Mock()
+    engine_any._in_flight_lock = threading.Lock()
+    engine_any._in_flight_count = 0
+    engine_any._worker_pid_by_index = {}
+    drain_results = [
+        (0, 0),  # pre-join bounded drain observes no visible IPC
+        (0, 0),  # first post-join pass is empty but not yet stable
+        (0, 1),  # late completion becomes visible after one empty pass
+        (0, 0),
+        (0, 0),  # stable-empty post-join exit
+    ]
+    drain_calls: list[tuple[int, int]] = []
+
+    async def fast_sleep(_delay: float) -> None:
+        return None
+
+    def drain_once() -> tuple[int, int]:
+        result = drain_results.pop(0) if drain_results else (0, 0)
+        drain_calls.append(result)
+        return result
+
+    def assert_stable_empty_before_local_cleanup() -> None:
+        assert drain_calls == [(0, 0), (0, 0), (0, 1), (0, 0), (0, 0)]
+
+    transport = Mock()
+    transport.clear_pending_dispatches.side_effect = (
+        assert_stable_empty_before_local_cleanup
+    )
+    engine_any._transport = transport
+    engine_any._drain_shutdown_ipc_once = Mock(side_effect=drain_once)
+    engine_any._join_worker_with_escalation = Mock()
+    monkeypatch.setattr(
+        "pyrallel_consumer.execution_plane.process_engine.asyncio.sleep",
+        fast_sleep,
+    )
+
+    await engine.shutdown()
+
+    assert drain_calls == [(0, 0), (0, 0), (0, 1), (0, 0), (0, 0)]
+    transport.clear_pending_dispatches.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_post_join_stable_empty_prefetches_real_late_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine, transport = _make_shutdown_engine()
+    engine_any = cast(Any, engine)
+    engine_any._in_flight_count = 1
+    completion = CompletionEvent(
+        id="work-42",
+        tp=TopicPartition("topic", 1),
+        offset=42,
+        epoch=7,
+        status=CompletionStatus.SUCCESS,
+        error=None,
+        attempt=1,
+    )
+    sleep_calls = 0
+
+    async def enqueue_after_first_post_join_empty(_delay: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 1:
+            engine_any._completion_queue.put(
+                msgpack.packb(_completion_event_to_dict(completion), use_bin_type=True)
+            )
+
+    def assert_prefetched_before_local_cleanup() -> None:
+        assert list(engine_any._prefetched_completion_events) == [completion]
+
+    monkeypatch.setattr(
+        transport,
+        "clear_pending_dispatches",
+        Mock(side_effect=assert_prefetched_before_local_cleanup),
+    )
+    monkeypatch.setattr(
+        "pyrallel_consumer.execution_plane.process_engine.asyncio.sleep",
+        enqueue_after_first_post_join_empty,
+    )
+
+    await engine.shutdown()
+
+    assert list(engine_any._prefetched_completion_events) == [completion]
+    assert await engine.wait_for_completion(timeout_seconds=0) is True
+    assert await engine.poll_completed_events() == [completion]
     assert engine.get_in_flight_count() == 0
 
 

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -1120,6 +1120,40 @@ def test_registry_start_event_overwrites_stale_identity_when_epoch_advances() ->
     }
 
 
+def test_registry_start_event_ignores_equal_epoch_identity_mismatch() -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    current_payload = {
+        "id": "work-redelivered",
+        "topic": "topic",
+        "partition": 1,
+        "offset": 42,
+        "epoch": 8,
+        "requeue_attempts": 0,
+    }
+    engine_any._in_flight_registry = {(0, "topic", 1, 42): current_payload}
+    engine_any._transport = Mock()
+    engine_any._initialize_runtime_timing_state = lambda: None  # type: ignore[method-assign]
+    engine_any._record_main_to_worker_ipc = lambda *_args: None  # type: ignore[method-assign]
+    engine_any._record_worker_exec = lambda *_args: None  # type: ignore[method-assign]
+
+    engine._apply_registry_event(
+        {
+            "kind": "start",
+            "key": (0, "topic", 1, 42),
+            "payload": {
+                "id": "work-first",
+                "topic": "topic",
+                "partition": 1,
+                "offset": 42,
+                "epoch": 8,
+            },
+        }
+    )
+
+    assert engine_any._in_flight_registry == {(0, "topic", 1, 42): current_payload}
+
+
 def test_dead_worker_recovery_uses_superseding_start_identity() -> None:
     engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
     engine_any = cast(Any, engine)
@@ -3416,7 +3450,7 @@ async def test_shutdown_post_join_drain_observes_stable_empty_after_deadline_eve
 
     assert result == (0, 1, 3)
     assert drain_calls == [(0, 1), (0, 0), (0, 0)]
-    assert sleep_calls == [0.0, 0.0]
+    assert sleep_calls == [0.01, 0.01]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -3283,6 +3283,64 @@ async def test_shutdown_post_join_stable_empty_prefetches_real_late_completion(
 
 
 @pytest.mark.asyncio
+async def test_shutdown_post_join_late_completion_keeps_different_identity_registry(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine, transport = _make_shutdown_engine()
+    engine_any = cast(Any, engine)
+    current_payload = {
+        "id": "work-redelivered",
+        "topic": "topic",
+        "partition": 1,
+        "offset": 42,
+        "epoch": 8,
+        "requeue_attempts": 0,
+    }
+    engine_any._in_flight_registry = {(0, "topic", 1, 42): current_payload}
+    engine_any._in_flight_count = 1
+    stale_completion = CompletionEvent(
+        id="work-first",
+        tp=TopicPartition("topic", 1),
+        offset=42,
+        epoch=7,
+        status=CompletionStatus.SUCCESS,
+        error=None,
+        attempt=1,
+    )
+    sleep_calls = 0
+
+    async def enqueue_after_first_post_join_empty(_delay: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 1:
+            engine_any._completion_queue.put(
+                msgpack.packb(
+                    _completion_event_to_dict(stale_completion),
+                    use_bin_type=True,
+                )
+            )
+
+    monotonic_values = iter([0.0, 2.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(monotonic_values, 2.0))
+    clear_pending_dispatches = Mock()
+    monkeypatch.setattr(transport, "clear_pending_dispatches", clear_pending_dispatches)
+    monkeypatch.setattr(
+        "pyrallel_consumer.execution_plane.process_engine.asyncio.sleep",
+        enqueue_after_first_post_join_empty,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await engine.shutdown()
+
+    assert list(engine_any._prefetched_completion_events) == [stale_completion]
+    assert engine_any._in_flight_registry == {}
+    assert engine.get_in_flight_count() == 1
+    assert "topic-1@42 id=work-redelivered epoch=8" in caplog.text
+    clear_pending_dispatches.assert_called_once_with()
+
+
+@pytest.mark.asyncio
 async def test_shutdown_post_join_drain_reconciles_late_completion_before_cleanup(
     caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -28,7 +28,12 @@ from pyrallel_consumer.execution_plane.process_engine import (
     _work_item_from_dict,
     _work_item_to_dict,
 )
-from pyrallel_consumer.execution_plane.process_transport import RouteIdentity
+from pyrallel_consumer.execution_plane.process_transport import (
+    PendingDispatchRecovery,
+    RouteIdentity,
+    WorkerExecutionIdentity,
+    logical_work_identity_from_payload,
+)
 from pyrallel_consumer.execution_plane.process_transport_shared_queue import (
     SharedQueueProcessTransport,
 )
@@ -136,7 +141,7 @@ class _RequeueRecordingTransport:
     def handle_registry_event(self, event: dict[str, Any]) -> None:
         del event
 
-    def recover_pending_dispatches(self, idx: int) -> list[dict[str, Any]]:
+    def recover_pending_dispatches(self, idx: int) -> list[PendingDispatchRecovery]:
         del idx
         return []
 
@@ -1148,6 +1153,62 @@ def test_worker_pipe_transport_releases_pending_slot_when_send_fails() -> None:
 
     assert transport._pending_dispatch == {}
     assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
+
+
+def test_worker_pipe_recover_pending_dispatches_returns_identity_metadata() -> None:
+    transport = WorkerPipesProcessTransport(
+        process_count=1,
+        queue_size=1,
+        max_payload_bytes=1024,
+        serialize_work_item=_work_item_to_dict,
+        serialize_batch_payload=lambda _batch, _flush_enqueued_at: b"packed",
+        work_item_from_dict=_work_item_from_dict,
+        get_worker_pipe_senders=lambda: [_PipeSender()],
+        increment_in_flight=lambda: None,
+        pipe_sentinel=b"sentinel",
+    )
+    payload = _work_item_to_dict(
+        WorkItem(
+            id="work-42",
+            tp=TopicPartition("topic", 1),
+            offset=42,
+            epoch=7,
+            key=b"same-key",
+            payload=b"payload",
+        )
+    )
+    transport._pending_dispatch[(0, "topic", 1, 42, "work-42", 7)] = payload
+    assert transport.capabilities.pending_dispatch_recovery is True
+    assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
+
+    recovered = transport.recover_pending_dispatches(0)
+
+    assert recovered == [
+        PendingDispatchRecovery(
+            identity=WorkerExecutionIdentity(
+                worker_index=0,
+                work=logical_work_identity_from_payload(payload),
+            ),
+            payload={**payload, "requeue_attempts": 1},
+        )
+    ]
+    assert transport._pending_dispatch == {}
+    assert transport.recover_pending_dispatches(0) == []
+    assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
+    assert transport._worker_pipe_queue_slots.acquire(blocking=False) is False
+
+
+def test_shared_queue_transport_declares_no_pending_dispatch_recovery() -> None:
+    transport = SharedQueueProcessTransport(
+        task_queue=cast(Any, queue.Queue()),
+        get_batch_accumulator=Mock(),
+        work_item_from_dict=_work_item_from_dict,
+        increment_in_flight=lambda: None,
+        sentinel=b"sentinel",
+    )
+
+    assert transport.capabilities.pending_dispatch_recovery is False
+    assert transport.recover_pending_dispatches(0) == []
 
 
 def test_ensure_workers_alive_stops_requeueing_after_max_retries(

--- a/tests/unit/test_public_contract_v1.py
+++ b/tests/unit/test_public_contract_v1.py
@@ -56,6 +56,9 @@ def test_public_contract_doc_freezes_runtime_snapshot_field_boundary() -> None:
         "Commit clamping is computed from the control-plane `WorkManager` dispatch ledger",
         "`process_batch_metrics` remains the frozen v1 compatibility projection",
         "Generic engine diagnostics remain an additive internal direction",
+        "Process-engine shutdown drain log lines are diagnostic-only reconciliation evidence",
+        "not a retry ledger",
+        "not be interpreted as commit-safety or DLQ-publish authority",
     ]
 
     for expected_term in expected_terms:


### PR DESCRIPTION
## Summary
- continue process worker-pipes V2.1-V2.6+ work on top of develop after PR #115 squash merge
- centralize worker identity/registry matching and transport pending recovery contracts
- keep shutdown residuals diagnostic-only while preserving visible/prefetched real completions
- add bounded stable-empty post-join shutdown IPC drain and control-plane boundary coverage

## Verification
- /Users/mqueue/Desktop/project/Pyrallel-Consumer/.venv/bin/python -m pytest tests/unit/execution_plane/test_process_execution_engine.py tests/unit/execution_plane/test_execution_engine_contract.py -q
- /Users/mqueue/Desktop/project/Pyrallel-Consumer/.venv/bin/ruff check pyrallel_consumer/execution_plane/process_engine.py pyrallel_consumer/execution_plane/process_transport_worker_pipes.py tests/unit/execution_plane/test_process_execution_engine.py
- /Users/mqueue/Desktop/project/Pyrallel-Consumer/.venv/bin/python -m mypy pyrallel_consumer/execution_plane/process_engine.py pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
- git diff --check

## Notes
- AGENTS.md local dirty state was intentionally not included.