### PR TITLE
ci(e2e): document retry dlq isolation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,6 +90,8 @@ jobs:
           PYRALLEL_E2E_REQUIRE_BROKER: "1"
         run: |
           mkdir -p .artifacts
+          # Isolate Issue #112 retry/DLQ process-mode cases into fresh pytest
+          # interpreters to avoid fork-after-thread Queue feeder contamination.
           if [ "${{ matrix.suite.name }}" = "recovery-retry-dlq" ]; then
             uv run pytest 'tests/e2e/test_process_recovery.py::test_process_retry_path_commits_only_after_success[async]' -q --maxfail=1 -ra --junitxml=.artifacts/e2e-junit-retry-async.xml
             uv run pytest 'tests/e2e/test_process_recovery.py::test_process_retry_path_commits_only_after_success[process]' -q --maxfail=1 -ra --junitxml=.artifacts/e2e-junit-retry-process.xml


### PR DESCRIPTION
## Summary
- document why the recovery retry/DLQ e2e suite is split into exact pytest invocations
- keep Issue #112 mitigation visible in the workflow while exercising the pull_request e2e path

## Verification
- `git diff --check`
- pre-commit hooks during commit: YAML/end-of-file/trailing-whitespace passed
- develop push e2e already passed with the isolated layout: run 25043203259
- this PR intentionally touches `.github/workflows/e2e.yml` to verify the same behavior under `pull_request`

Refs #112
