### PR TITLE
feat(process): add route-batch worker-pipe transport

### DIFF
--- a/benchmarks/benchmark_cli.py
+++ b/benchmarks/benchmark_cli.py
@@ -188,6 +188,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Override process-mode micro-batch size for benchmark runs",
     )
     parser.add_argument(
+        "--route-batch-size",
+        type=int,
+        default=1,
+        help="Override control-plane same-route batch lease size for benchmark runs",
+    )
+    parser.add_argument(
         "--process-max-batch-wait-ms",
         type=int,
         default=None,

--- a/benchmarks/benchmark_rounds.py
+++ b/benchmarks/benchmark_rounds.py
@@ -82,6 +82,7 @@ async def _run_pyrparallel_round(
     process_flush_policy: ProcessFlushPolicy | None = None,
     process_demand_flush_min_residence_ms: int | None = None,
     process_transport_mode: ProcessTransportMode | None = None,
+    route_batch_size: int = 1,
     metrics_port: int | None = None,
     adaptive_concurrency_enabled: bool = False,
 ) -> BenchmarkResult:
@@ -104,6 +105,10 @@ async def _run_pyrparallel_round(
         ordering=ordering,
         topic=topic_name,
         process_transport_mode=effective_process_transport_mode,
+        route_batch_size=route_batch_size,
+        process_batch_size=process_batch_size
+        if mode == ExecutionMode.PROCESS
+        else None,
         target_messages=num_messages,
     )
     timed_out, _, summary = await run_pyrallel_consumer_test(
@@ -126,6 +131,7 @@ async def _run_pyrparallel_round(
         process_flush_policy=process_flush_policy,
         process_demand_flush_min_residence_ms=(process_demand_flush_min_residence_ms),
         process_transport_mode=effective_process_transport_mode,
+        route_batch_size=route_batch_size,
         metrics_port=metrics_port,
         adaptive_concurrency_enabled=adaptive_concurrency_enabled,
     )

--- a/benchmarks/pyrallel_consumer_test.py
+++ b/benchmarks/pyrallel_consumer_test.py
@@ -257,6 +257,7 @@ def build_kafka_config(
     process_flush_policy: Optional[ProcessFlushPolicy] = None,
     process_demand_flush_min_residence_ms: Optional[int] = None,
     process_transport_mode: Optional[ProcessTransportMode] = None,
+    route_batch_size: int = 1,
     metrics_port: Optional[int] = None,
     adaptive_concurrency_enabled: bool = False,
 ) -> KafkaConfig:
@@ -276,6 +277,7 @@ def build_kafka_config(
     )
 
     kafka_config.parallel_consumer.execution.max_in_flight = 2000
+    kafka_config.parallel_consumer.execution.route_batch_size = route_batch_size
     kafka_config.parallel_consumer.execution.async_config.task_timeout_ms = 10000
     kafka_config.parallel_consumer.strict_completion_monitor_enabled = (
         strict_completion_monitor_enabled
@@ -345,6 +347,7 @@ async def run_pyrallel_consumer_test(
     process_flush_policy: Optional[ProcessFlushPolicy] = None,
     process_demand_flush_min_residence_ms: Optional[int] = None,
     process_transport_mode: Optional[ProcessTransportMode] = None,
+    route_batch_size: int = 1,
     metrics_port: Optional[int] = None,
     adaptive_concurrency_enabled: bool = False,
 ) -> tuple[bool, ConsumptionStats, Optional[BenchmarkResult]]:
@@ -378,6 +381,7 @@ async def run_pyrallel_consumer_test(
         process_flush_policy=process_flush_policy,
         process_demand_flush_min_residence_ms=(process_demand_flush_min_residence_ms),
         process_transport_mode=process_transport_mode,
+        route_batch_size=route_batch_size,
         metrics_port=metrics_port,
         adaptive_concurrency_enabled=adaptive_concurrency_enabled,
     )
@@ -523,6 +527,7 @@ async def run_pyrallel_consumer_test(
         max_in_flight_messages=execution_config.max_in_flight,
         ordering_mode=ordering_mode_value,
         metrics_exporter=metrics_observer,
+        route_batch_size=execution_config.route_batch_size,
     )  # type: ignore[call-arg]
 
     broker_poller = BrokerPoller(
@@ -655,6 +660,10 @@ async def run_pyrallel_consumer_test(
         await broker_poller.stop()
         final_metrics = broker_poller.get_metrics()
         _record_release_gate_metrics_from_snapshot(final_metrics)
+        if stats is not None:
+            stats.record_process_batch_metrics(
+                getattr(final_metrics, "process_batch_metrics", None)
+            )
         if prometheus_exporter is not None:
             prometheus_exporter.update_from_system_metrics(final_metrics)
         await engine.shutdown()

--- a/benchmarks/run_parallel_benchmark.py
+++ b/benchmarks/run_parallel_benchmark.py
@@ -152,6 +152,7 @@ async def _run_pyrparallel_round(
     process_flush_policy: ProcessFlushPolicy | None = None,
     process_demand_flush_min_residence_ms: int | None = None,
     process_transport_mode: ProcessTransportMode | None = None,
+    route_batch_size: int = 1,
     metrics_port: int | None = None,
     adaptive_concurrency_enabled: bool = False,
 ) -> BenchmarkResult:
@@ -174,6 +175,10 @@ async def _run_pyrparallel_round(
         ordering=ordering,
         topic=topic_name,
         process_transport_mode=effective_process_transport_mode,
+        route_batch_size=route_batch_size,
+        process_batch_size=process_batch_size
+        if mode == ExecutionMode.PROCESS
+        else None,
         target_messages=num_messages,
     )
     timed_out, _, summary = await run_pyrallel_consumer_test(
@@ -196,6 +201,7 @@ async def _run_pyrparallel_round(
         process_flush_policy=process_flush_policy,
         process_demand_flush_min_residence_ms=(process_demand_flush_min_residence_ms),
         process_transport_mode=effective_process_transport_mode,
+        route_batch_size=route_batch_size,
         metrics_port=metrics_port,
         adaptive_concurrency_enabled=adaptive_concurrency_enabled,
     )
@@ -468,6 +474,7 @@ def run_benchmark(
                                             args.process_demand_flush_min_residence_ms
                                         ),
                                         process_transport_mode=None,
+                                        route_batch_size=args.route_batch_size,
                                         metrics_port=metrics_port,
                                         adaptive_concurrency_enabled=(
                                             adaptive_concurrency_enabled
@@ -535,6 +542,7 @@ def run_benchmark(
                                     process_transport_mode=cast(
                                         ProcessTransportMode, args.process_transport
                                     ),
+                                    route_batch_size=args.route_batch_size,
                                     metrics_port=metrics_port,
                                     adaptive_concurrency_enabled=(
                                         adaptive_concurrency_enabled

--- a/benchmarks/stats.py
+++ b/benchmarks/stats.py
@@ -24,6 +24,16 @@ class BenchmarkResult:
     avg_processing_ms: float
     p99_processing_ms: float
     process_transport_mode: str | None = None
+    route_batch_size: int = 1
+    process_batch_size: int | None = None
+    items_per_input_ipc: float | None = None
+    items_per_completion_ipc: float | None = None
+    route_batch_count: int | None = None
+    route_batch_item_count: int | None = None
+    route_batch_size_avg: float | None = None
+    route_batch_size_max: int | None = None
+    completion_item_payload_count: int | None = None
+    completion_batch_payload_count: int | None = None
     window_size_messages: int | None = None
     tps_p50_window: float | None = None
     tps_p10_window: float | None = None
@@ -48,6 +58,8 @@ class BenchmarkStats:
         ordering: str,
         topic: str,
         process_transport_mode: str | None = None,
+        route_batch_size: int = 1,
+        process_batch_size: int | None = None,
         target_messages: Optional[int] = None,
     ) -> None:
         self.run_name = run_name
@@ -56,6 +68,8 @@ class BenchmarkStats:
         self.ordering = ordering
         self.topic = topic
         self.process_transport_mode = process_transport_mode
+        self.route_batch_size = route_batch_size
+        self.process_batch_size = process_batch_size
         self.target_messages = target_messages
         self._start_time: Optional[float] = None
         self._end_time: Optional[float] = None
@@ -64,6 +78,7 @@ class BenchmarkStats:
         self._processed = 0
         self._window_size_messages = 100
         self._release_gate_observations: list[dict[str, Any]] = []
+        self._process_batch_metrics: Any = None
 
     def start(self) -> None:
         """Handle start within stats."""
@@ -103,6 +118,10 @@ class BenchmarkStats:
             }
         )
 
+    def record_process_batch_metrics(self, metrics: Any) -> None:
+        """Record latest process runtime metrics for benchmark summary."""
+        self._process_batch_metrics = metrics
+
     @property
     def processed(self) -> int:
         """Handle processed within stats."""
@@ -136,6 +155,40 @@ class BenchmarkStats:
             ordering=self.ordering,
             topic=self.topic,
             process_transport_mode=self.process_transport_mode,
+            route_batch_size=self.route_batch_size,
+            process_batch_size=self.process_batch_size,
+            items_per_input_ipc=_metric_value(
+                self._process_batch_metrics,
+                "items_per_input_ipc",
+            ),
+            items_per_completion_ipc=_metric_value(
+                self._process_batch_metrics,
+                "items_per_completion_ipc",
+            ),
+            route_batch_count=_metric_value(
+                self._process_batch_metrics,
+                "route_batch_count",
+            ),
+            route_batch_item_count=_metric_value(
+                self._process_batch_metrics,
+                "route_batch_item_count",
+            ),
+            route_batch_size_avg=_metric_value(
+                self._process_batch_metrics,
+                "route_batch_size_avg",
+            ),
+            route_batch_size_max=_metric_value(
+                self._process_batch_metrics,
+                "route_batch_size_max",
+            ),
+            completion_item_payload_count=_metric_value(
+                self._process_batch_metrics,
+                "completion_item_payload_count",
+            ),
+            completion_batch_payload_count=_metric_value(
+                self._process_batch_metrics,
+                "completion_batch_payload_count",
+            ),
             messages_processed=self._processed,
             total_time_sec=total_time,
             throughput_tps=throughput,
@@ -208,6 +261,13 @@ def _optional_percentile(values: list[float], percentile: float) -> float | None
     if not values:
         return None
     return _percentile(values, percentile)
+
+
+def _metric_value(metrics: Any, field_name: str) -> Any:
+    """Return a runtime metric value or None when unavailable."""
+    if metrics is None:
+        return None
+    return getattr(metrics, field_name, None)
 
 
 def write_results_json(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kafka-1:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.6.0
     hostname: kafka-1
     container_name: kafka-1
     ports:
@@ -30,7 +30,7 @@ services:
       - yamong_network
 
   kafka-ui:
-    image: provectuslabs/kafka-ui:latest
+    image: provectuslabs/kafka-ui:v0.7.2
     container_name: kafka-ui
     ports:
       - "8080:8080"
@@ -43,7 +43,7 @@ services:
       - yamong_network
 
   kafka-exporter:
-    image: danielqsj/kafka-exporter:latest
+    image: danielqsj/kafka-exporter@sha256:bfae1aa15e873268c75899d02fcb5479418d3cde69d5d0b424511e067caf6f22
     container_name: kafka-exporter
     command:
       - "--kafka.server=kafka-1:29092"
@@ -56,7 +56,7 @@ services:
       - yamong_network
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus@sha256:b1935d181b6dd8e9c827705e89438815337e1b10ae35605126f05f44e5c6940f
     container_name: prometheus
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
@@ -68,7 +68,7 @@ services:
       - yamong_network
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana@sha256:3aa2a03d88ad9628485f78e89adcd5b18bcde1aced3e6146bbbd7a718b82b797
     container_name: grafana
     ports:
       - "3000:3000"

--- a/pyrallel_consumer/config.py
+++ b/pyrallel_consumer/config.py
@@ -32,9 +32,9 @@ class ProcessConfig(BaseSettings):
     batch_bytes: str = "256KB"
     transport_mode: Literal["shared_queue", "worker_pipes"] = "shared_queue"
     max_batch_wait_ms: int = 5
-    flush_policy: Literal["size_or_timer", "demand", "demand_min_residence"] = (
-        "size_or_timer"
-    )
+    flush_policy: Literal[
+        "size_or_timer", "demand", "demand_min_residence"
+    ] = "size_or_timer"
     demand_flush_min_residence_ms: int = 0
     shutdown_drain_timeout_ms: int = 5000
     worker_join_timeout_ms: int = 30000
@@ -120,6 +120,7 @@ class ExecutionConfig(BaseSettings):
 
     mode: ExecutionMode = ExecutionMode.ASYNC
     max_in_flight: int = Field(default=1000, gt=0)
+    route_batch_size: int = Field(default=1, gt=0)
     max_revoke_grace_ms: int = 500
     shutdown_policy: Literal["graceful", "abort"] = "graceful"
     consumer_task_stop_timeout_ms: int = Field(default=5000, ge=0)
@@ -185,9 +186,9 @@ class ParallelConsumerConfig(BaseSettings):
     adaptive_backpressure: AdaptiveBackpressureConfig = AdaptiveBackpressureConfig()
     adaptive_concurrency: AdaptiveConcurrencyConfig = AdaptiveConcurrencyConfig()
     poison_message: PoisonMessageConfig = PoisonMessageConfig()
-    rebalance_state_strategy: Literal["contiguous_only", "metadata_snapshot"] = (
-        "contiguous_only"
-    )
+    rebalance_state_strategy: Literal[
+        "contiguous_only", "metadata_snapshot"
+    ] = "contiguous_only"
     execution: ExecutionConfig = ExecutionConfig()
 
     @field_validator("ordering_mode", mode="before")

--- a/pyrallel_consumer/consumer.py
+++ b/pyrallel_consumer/consumer.py
@@ -141,6 +141,7 @@ class PyrallelConsumer:
             ordering_mode=ordering_mode,
             max_revoke_grace_ms=execution_config.max_revoke_grace_ms,
             poison_message_circuit=poison_message_circuit,
+            route_batch_size=execution_config.route_batch_size,
         )
 
         # 3. Create Broker Poller (The main loop)

--- a/pyrallel_consumer/control_plane/broker_poller.py
+++ b/pyrallel_consumer/control_plane/broker_poller.py
@@ -155,6 +155,9 @@ class BrokerPoller:
                 cooldown_ms=int(getattr(self._poison_message_config, "cooldown_ms", 0)),
                 forced_failure_attempt=pc_conf.execution.max_retries,
             )
+        route_batch_size = getattr(pc_conf.execution, "route_batch_size", 1)
+        if not isinstance(route_batch_size, int):
+            route_batch_size = 1
         self._work_manager = work_manager or WorkManager(
             execution_engine=self._execution_engine,
             max_in_flight_messages=configured_max_in_flight,
@@ -162,6 +165,7 @@ class BrokerPoller:
             blocking_cache_ttl=getattr(pc_conf, "blocking_cache_ttl", 0),
             max_revoke_grace_ms=pc_conf.execution.max_revoke_grace_ms,
             poison_message_circuit=poison_message_circuit,
+            route_batch_size=route_batch_size,
         )
 
         self._diag_log_every = int(getattr(pc_conf, "diag_log_every", 1000) or 1000)

--- a/pyrallel_consumer/control_plane/broker_poller.py
+++ b/pyrallel_consumer/control_plane/broker_poller.py
@@ -156,8 +156,9 @@ class BrokerPoller:
                 forced_failure_attempt=pc_conf.execution.max_retries,
             )
         route_batch_size = getattr(pc_conf.execution, "route_batch_size", 1)
-        if not isinstance(route_batch_size, int):
+        if isinstance(route_batch_size, bool) or not isinstance(route_batch_size, int):
             route_batch_size = 1
+        route_batch_size = max(1, route_batch_size)
         self._work_manager = work_manager or WorkManager(
             execution_engine=self._execution_engine,
             max_in_flight_messages=configured_max_in_flight,

--- a/pyrallel_consumer/control_plane/work_manager.py
+++ b/pyrallel_consumer/control_plane/work_manager.py
@@ -74,7 +74,7 @@ class WorkManager:
             route_batch_size: Maximum same-route work items to lease per schedule step.
 
         """
-        if route_batch_size < 1:
+        if isinstance(route_batch_size, bool) or route_batch_size < 1:
             raise ValueError("route_batch_size must be >= 1")
         self._logger = logging.getLogger(__name__)
         self._execution_engine = execution_engine

--- a/pyrallel_consumer/control_plane/work_manager.py
+++ b/pyrallel_consumer/control_plane/work_manager.py
@@ -20,7 +20,7 @@ from pyrallel_consumer.dto import (
 )
 from pyrallel_consumer.dto import TopicPartition as DtoTopicPartition
 from pyrallel_consumer.dto import WorkItem
-from pyrallel_consumer.execution_plane.base import BaseExecutionEngine
+from pyrallel_consumer.execution_plane.base import BaseExecutionEngine, BatchSubmitError
 
 OffsetTrackerAssignment = Mapping[DtoTopicPartition, int | OffsetTracker]
 GroupedMessage = tuple[int, int, Any] | tuple[int, int, Any, Any]
@@ -59,6 +59,7 @@ class WorkManager:
         blocking_cache_ttl: int = 100,
         max_revoke_grace_ms: int = 500,
         poison_message_circuit: Optional[PoisonMessageCircuitBreaker] = None,
+        route_batch_size: int = 1,
     ):
         """Initialize this component.
 
@@ -70,8 +71,11 @@ class WorkManager:
             blocking_cache_ttl: Number of scheduling cycles to keep blocking-offset cache entries.
             max_revoke_grace_ms: Maximum revoke grace period in milliseconds.
             poison_message_circuit: Optional poison-message circuit breaker.
+            route_batch_size: Maximum same-route work items to lease per schedule step.
 
         """
+        if route_batch_size < 1:
+            raise ValueError("route_batch_size must be >= 1")
         self._logger = logging.getLogger(__name__)
         self._execution_engine = execution_engine
         self._offset_trackers: Dict[DtoTopicPartition, OffsetTracker] = {}
@@ -108,6 +112,7 @@ class WorkManager:
         self._head_offsets = self._queue_topology.head_offsets
         self._head_queue_keys_by_offset = self._queue_topology.head_queue_keys_by_offset
         self._poison_message_circuit = poison_message_circuit
+        self._route_batch_size = route_batch_size
 
     def get_ordering_mode(self) -> OrderingMode:
         """Return ordering mode for work scheduling and completion accounting.
@@ -117,6 +122,15 @@ class WorkManager:
 
         """
         return self._ordering_mode
+
+    def get_route_batch_size(self) -> int:
+        """Return configured route batch size for scheduling leases.
+
+        Returns:
+            Configured route batch size.
+
+        """
+        return self._route_batch_size
 
     def set_metrics_exporter(self, metrics_exporter: Optional[MetricsExporter]) -> None:
         """Install or update metrics exporter for work scheduling and completion accounting.
@@ -241,6 +255,23 @@ class WorkManager:
         """
         return WorkQueueTopology.peek_queue(queue)
 
+    @staticmethod
+    def _peek_queue_batch(
+        queue: asyncio.Queue[WorkItem],
+        limit: int,
+    ) -> list[WorkItem]:
+        """Peek at a same-queue route batch without mutating queue state.
+
+        Args:
+            queue: Queue being inspected.
+            limit: Maximum number of work items to inspect.
+
+        Returns:
+            Work items currently at the queue head, up to the limit.
+
+        """
+        return WorkQueueTopology.peek_queue_batch(queue, limit)
+
     def _cleanup_empty_queue(self, tp: DtoTopicPartition, key: Any) -> None:
         """Clean up empty queue for work scheduling and completion accounting.
 
@@ -350,6 +381,47 @@ class WorkManager:
         if self._ordering_mode == OrderingMode.PARTITION:
             return tp not in self._partitions_in_flight
         return True
+
+    def _resolve_route_batch_limit(self) -> int:
+        """Resolve same-queue route batch lease limit for the current schedule step."""
+        remaining_capacity = (
+            self._max_in_flight_messages - self._current_in_flight_count
+        )
+        if remaining_capacity <= 0:
+            return 0
+        if self._ordering_mode in {OrderingMode.KEY_HASH, OrderingMode.PARTITION}:
+            return 1
+        return min(self._route_batch_size, remaining_capacity)
+
+    def _select_same_queue_batch(
+        self,
+        queue: asyncio.Queue[WorkItem],
+    ) -> list[WorkItem]:
+        """Select a same-virtual-queue batch for Slice 2A route leasing."""
+        return self._peek_queue_batch(queue, self._resolve_route_batch_limit())
+
+    def _truncate_batch_before_force_fail(
+        self,
+        items: list[WorkItem],
+    ) -> list[WorkItem]:
+        """Keep batch candidates only until the first poison force-fail item."""
+        if self._poison_message_circuit is None:
+            return items
+
+        accepted_items: list[WorkItem] = []
+        for item in items:
+            if self._poison_message_circuit.should_force_fail(item):
+                break
+            accepted_items.append(item)
+        return accepted_items
+
+    def _record_submitted_items(self, items: list[WorkItem]) -> None:
+        """Record successfully accepted work items in dispatch accounting."""
+        for dequeued_item in items:
+            self._total_queued_messages = max(0, self._total_queued_messages - 1)
+            self._current_in_flight_count += 1
+            self._dispatch_timestamps[dequeued_item.id] = time.perf_counter()
+            self._record_ordering_lock(dequeued_item)
 
     def _record_ordering_lock(self, item: WorkItem) -> None:
         """Record ordering lock for work scheduling and completion accounting.
@@ -639,65 +711,119 @@ class WorkManager:
             blocking_offsets = self._blocking_cache
             self._blocking_cache_counter -= 1
 
-        while True:
-            if self._current_in_flight_count >= self._max_in_flight_messages:
-                return
-            if self._rebalancing:
-                return
-
-            selected_queue_key = self._pick_blocking_queue_key(blocking_offsets)
-            if selected_queue_key is None:
-                selected_queue_key = self._pick_next_runnable_queue_key()
-
-            item_to_submit: Optional[WorkItem] = None
-            queue_to_dequeue_from: Optional[asyncio.Queue[WorkItem]] = None
-
-            if selected_queue_key is not None:
-                selected_tp, selected_key = selected_queue_key
-                queue_to_dequeue_from = self._virtual_partition_queues.get(
-                    selected_tp, {}
-                ).get(selected_key)
-                if queue_to_dequeue_from is None or queue_to_dequeue_from.empty():
-                    self._deactivate_queue_key(selected_queue_key)
-                    continue
-
-                item_to_submit = self._peek_queue(queue_to_dequeue_from)
-
-            if item_to_submit:
-                force_failed = await self._force_fail_queued_item(
-                    item_to_submit=item_to_submit,
-                    selected_tp=selected_tp,
-                    selected_key=selected_key,
-                )
-                if force_failed:
-                    continue
-
-                try:
-                    await self._execution_engine.submit(item_to_submit)
-                    dequeued_item = self._queue_topology.dequeue_submitted_item(
-                        selected_tp, selected_key
-                    )
-                    if dequeued_item is None:
-                        return
-                    self._total_queued_messages = max(
-                        0, self._total_queued_messages - 1
-                    )
-                    self._current_in_flight_count += 1
-                    self._dispatch_timestamps[item_to_submit.id] = time.perf_counter()
-                    self._record_ordering_lock(item_to_submit)
-                except Exception:
-                    self._logger.exception(
-                        "Error submitting work item %s", item_to_submit.id
-                    )
-                    if queue_to_dequeue_from is not None:
-                        self._refresh_queue_head(
-                            item_to_submit.tp,
-                            item_to_submit.key,
-                            queue_to_dequeue_from,
-                        )
+        deferred_queue_keys: set[tuple[DtoTopicPartition, Any]] = set()
+        try:
+            while True:
+                if self._current_in_flight_count >= self._max_in_flight_messages:
                     return
-            else:
-                return
+                if self._rebalancing:
+                    return
+
+                selected_queue_key = self._pick_blocking_queue_key(blocking_offsets)
+                if selected_queue_key is None:
+                    selected_queue_key = self._pick_next_runnable_queue_key()
+
+                items_to_submit: list[WorkItem] = []
+                queue_to_dequeue_from: Optional[asyncio.Queue[WorkItem]] = None
+                selected_tp: Optional[DtoTopicPartition] = None
+                selected_key: Any = None
+
+                if selected_queue_key is not None:
+                    selected_tp, selected_key = selected_queue_key
+                    queue_to_dequeue_from = self._virtual_partition_queues.get(
+                        selected_tp, {}
+                    ).get(selected_key)
+                    if queue_to_dequeue_from is None or queue_to_dequeue_from.empty():
+                        self._deactivate_queue_key(selected_queue_key)
+                        continue
+
+                    items_to_submit = self._select_same_queue_batch(
+                        queue_to_dequeue_from
+                    )
+
+                if items_to_submit:
+                    if selected_tp is None:
+                        return
+                    item_to_submit = items_to_submit[0]
+                    force_failed = await self._force_fail_queued_item(
+                        item_to_submit=item_to_submit,
+                        selected_tp=selected_tp,
+                        selected_key=selected_key,
+                    )
+                    if force_failed:
+                        continue
+                    selected_batch_size = len(items_to_submit)
+                    items_to_submit = self._truncate_batch_before_force_fail(
+                        items_to_submit
+                    )
+                    if not items_to_submit:
+                        continue
+                    batch_truncated_by_force_fail = (
+                        len(items_to_submit) < selected_batch_size
+                    )
+
+                    try:
+                        if len(items_to_submit) == 1:
+                            await self._execution_engine.submit(items_to_submit[0])
+                        else:
+                            # Slice 2A assumes submit_batch is all-or-nothing from the
+                            # control plane perspective. Dequeue/accounting happens only
+                            # after the engine call returns successfully; partial accept
+                            # recovery is handled in later transport-specific slices.
+                            await self._execution_engine.submit_batch(items_to_submit)
+                        dequeued_items = self._queue_topology.dequeue_submitted_items(
+                            selected_tp, selected_key, len(items_to_submit)
+                        )
+                        if not dequeued_items:
+                            return
+                        self._record_submitted_items(dequeued_items)
+                        if (
+                            batch_truncated_by_force_fail
+                            and selected_queue_key is not None
+                        ):
+                            self._deactivate_queue_key(selected_queue_key)
+                            deferred_queue_keys.add(selected_queue_key)
+                        continue
+                    except BatchSubmitError as exc:
+                        self._logger.exception(
+                            "Error submitting work item %s after %d batch items accepted",
+                            item_to_submit.id,
+                            exc.accepted_count,
+                        )
+                        if exc.accepted_count > 0:
+                            dequeued_items = (
+                                self._queue_topology.dequeue_submitted_items(
+                                    selected_tp,
+                                    selected_key,
+                                    exc.accepted_count,
+                                )
+                            )
+                            self._record_submitted_items(dequeued_items)
+                        elif queue_to_dequeue_from is not None:
+                            self._refresh_queue_head(
+                                item_to_submit.tp,
+                                item_to_submit.key,
+                                queue_to_dequeue_from,
+                            )
+                        return
+                    except Exception:
+                        self._logger.exception(
+                            "Error submitting work item %s", item_to_submit.id
+                        )
+                        if queue_to_dequeue_from is not None:
+                            self._refresh_queue_head(
+                                item_to_submit.tp,
+                                item_to_submit.key,
+                                queue_to_dequeue_from,
+                            )
+                        return
+                else:
+                    return
+        finally:
+            for tp, key in deferred_queue_keys:
+                queue = self._virtual_partition_queues.get(tp, {}).get(key)
+                if queue is not None and not queue.empty():
+                    self._refresh_queue_head(tp, key, queue)
 
     async def poll_completed_events(
         self, *, schedule_after_release: bool = True
@@ -784,6 +910,7 @@ class WorkManager:
                 now=time.perf_counter(),
             )
         if dispatch_time is not None and self._metrics_exporter is not None:
+            duration = max(0.0, time.perf_counter() - dispatch_time)
             completion_observer = getattr(
                 self._metrics_exporter, "observe_work_completion", None
             )

--- a/pyrallel_consumer/control_plane/work_manager.py
+++ b/pyrallel_consumer/control_plane/work_manager.py
@@ -390,7 +390,13 @@ class WorkManager:
         if remaining_capacity <= 0:
             return 0
         if self._ordering_mode in {OrderingMode.KEY_HASH, OrderingMode.PARTITION}:
-            return 1
+            supports_ordered_route_batch = getattr(
+                self._execution_engine,
+                "supports_ordered_route_batch",
+                False,
+            )
+            if supports_ordered_route_batch is not True:
+                return 1
         return min(self._route_batch_size, remaining_capacity)
 
     def _select_same_queue_batch(
@@ -766,10 +772,9 @@ class WorkManager:
                         if len(items_to_submit) == 1:
                             await self._execution_engine.submit(items_to_submit[0])
                         else:
-                            # Slice 2A assumes submit_batch is all-or-nothing from the
-                            # control plane perspective. Dequeue/accounting happens only
-                            # after the engine call returns successfully; partial accept
-                            # recovery is handled in later transport-specific slices.
+                            # submit_batch must be atomic or raise BatchSubmitError
+                            # with accepted_count for a partially accepted prefix.
+                            # Generic exceptions are treated as zero accepted.
                             await self._execution_engine.submit_batch(items_to_submit)
                         dequeued_items = self._queue_topology.dequeue_submitted_items(
                             selected_tp, selected_key, len(items_to_submit)

--- a/pyrallel_consumer/control_plane/work_queue_topology.py
+++ b/pyrallel_consumer/control_plane/work_queue_topology.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
+from itertools import islice
 from typing import Any, Callable, Optional
 
 from pyrallel_consumer.dto import OffsetRange
@@ -130,6 +131,26 @@ class WorkQueueTopology:
         """
         internal = getattr(queue, "_queue")  # type: ignore[attr-defined]
         return internal[0]
+
+    @staticmethod
+    def peek_queue_batch(
+        queue: asyncio.Queue[WorkItem],
+        limit: int,
+    ) -> list[WorkItem]:
+        """Peek at up to limit work items without mutating the queue.
+
+        Args:
+            queue: Queue being inspected.
+            limit: Maximum number of items to return.
+
+        Returns:
+            Work items currently at the queue head, up to the limit.
+
+        """
+        if limit <= 0:
+            return []
+        internal = getattr(queue, "_queue")  # type: ignore[attr-defined]
+        return list(islice(internal, limit))
 
     @staticmethod
     def enqueue_work_items(
@@ -438,6 +459,42 @@ class WorkQueueTopology:
         else:
             self.refresh_queue_head(tp, key, queue)
         return work_item
+
+    def dequeue_submitted_items(
+        self,
+        tp: DtoTopicPartition,
+        key: Any,
+        count: int,
+    ) -> list[WorkItem]:
+        """Dequeue submitted items from a single virtual queue.
+
+        Args:
+            tp: Topic-partition affected by the operation.
+            key: Kafka record key or virtual queue key.
+            count: Maximum number of submitted items to dequeue.
+
+        Returns:
+            Dequeued work items, preserving queue order.
+
+        """
+        if count <= 0:
+            return []
+        queue = self.get_queue(tp, key)
+        if queue is None or queue.empty():
+            self.deactivate_queue_key((tp, key))
+            return []
+
+        work_items: list[WorkItem] = []
+        for _ in range(count):
+            if queue.empty():
+                break
+            work_items.append(queue.get_nowait())
+
+        if queue.empty():
+            self.cleanup_empty_queue(tp, key)
+        else:
+            self.refresh_queue_head(tp, key, queue)
+        return work_items
 
     def get_virtual_queue_sizes(self) -> dict[DtoTopicPartition, dict[Any, int]]:
         """Return virtual queue sizes for virtual queue scheduling.

--- a/pyrallel_consumer/dto.py
+++ b/pyrallel_consumer/dto.py
@@ -108,6 +108,25 @@ class WorkItem:
     poison_key: Any = WORK_ITEM_POISON_KEY_UNSET
 
 
+@dataclass(frozen=True)
+class RouteBatch:
+    """Internal process transport route batch payload."""
+
+    batch_id: str
+    route_identity: tuple[Any, ...]
+    worker_index: Optional[int]
+    items: list[WorkItem]
+
+
+@dataclass(frozen=True)
+class BatchCompletion:
+    """Internal process transport batch completion payload."""
+
+    batch_id: str
+    route_identity: tuple[Any, ...]
+    results: list[CompletionEvent]
+
+
 # --- Process Execution ---
 @dataclass(frozen=True)
 class ProcessTask:

--- a/pyrallel_consumer/dto.py
+++ b/pyrallel_consumer/dto.py
@@ -226,6 +226,14 @@ class ProcessBatchMetrics:
     timer_flush_supported: bool = True
     demand_flush_supported: bool = True
     recycle_supported: bool = True
+    items_per_input_ipc: Optional[float] = None
+    items_per_completion_ipc: Optional[float] = None
+    route_batch_count: int = 0
+    route_batch_item_count: int = 0
+    route_batch_size_avg: Optional[float] = None
+    route_batch_size_max: Optional[int] = None
+    completion_item_payload_count: int = 0
+    completion_batch_payload_count: int = 0
 
 
 @dataclass(frozen=True)

--- a/pyrallel_consumer/execution_plane/base.py
+++ b/pyrallel_consumer/execution_plane/base.py
@@ -13,6 +13,15 @@ from pyrallel_consumer.dto import (
 )
 
 
+class BatchSubmitError(RuntimeError):
+    """Raised when default batch submission fails after partial acceptance."""
+
+    def __init__(self, accepted_count: int, original_error: Exception) -> None:
+        super().__init__(str(original_error))
+        self.accepted_count = accepted_count
+        self.original_error = original_error
+
+
 class BaseExecutionEngine(ABC):
     """Basic abstract class for execution engines.
 
@@ -33,6 +42,25 @@ class BaseExecutionEngine(ABC):
             work_item (WorkItem): 제출할 작업 항목
 
         """
+
+    async def submit_batch(self, work_items: list[WorkItem]) -> None:
+        """Submit WorkItems using the existing item-level engine contract.
+
+        This default fallback preserves existing engine semantics while allowing
+        the control plane to become batch-aware. Engines may override this method
+        for transport-specific batch optimizations.
+
+        Args:
+            work_items: Work items to submit in order.
+
+        """
+        accepted_count = 0
+        for work_item in work_items:
+            try:
+                await self.submit(work_item)
+            except Exception as exc:
+                raise BatchSubmitError(accepted_count, exc) from exc
+            accepted_count += 1
 
     @abstractmethod
     async def poll_completed_events(

--- a/pyrallel_consumer/execution_plane/base.py
+++ b/pyrallel_consumer/execution_plane/base.py
@@ -32,6 +32,11 @@ class BaseExecutionEngine(ABC):
 
     """
 
+    @property
+    def supports_ordered_route_batch(self) -> bool:
+        """Return whether this engine can run ordered route batches safely."""
+        return False
+
     @abstractmethod
     async def submit(self, work_item: WorkItem) -> None:
         """Submit a WorkItem to the execution engine for processing.
@@ -49,6 +54,10 @@ class BaseExecutionEngine(ABC):
         This default fallback preserves existing engine semantics while allowing
         the control plane to become batch-aware. Engines may override this method
         for transport-specific batch optimizations.
+
+        Contract: implementations must either submit the batch atomically, where
+        any failure means no item was accepted, or raise BatchSubmitError after
+        partial acceptance with accepted_count set to the accepted prefix length.
 
         Args:
             work_items: Work items to submit in order.

--- a/pyrallel_consumer/execution_plane/process_codec.py
+++ b/pyrallel_consumer/execution_plane/process_codec.py
@@ -36,12 +36,14 @@ def _require_fields(
     required_fields: tuple[str, ...],
     error_name: str,
 ) -> None:
+    """Raise a shaped validation error when required payload fields are absent."""
     missing_fields = [field for field in required_fields if field not in payload]
     if missing_fields:
         raise ValueError("%s_missing_%s" % (error_name, "_".join(missing_fields)))
 
 
 def _require_non_empty_list(value: Any, field_name: str, error_name: str) -> list[Any]:
+    """Return a non-empty list field or raise a shaped validation error."""
     if not isinstance(value, list):
         raise ValueError("%s_%s_not_list" % (error_name, field_name))
     if not value:

--- a/pyrallel_consumer/execution_plane/process_codec.py
+++ b/pyrallel_consumer/execution_plane/process_codec.py
@@ -24,6 +24,29 @@ SerializedRegistryEvent = dict[str, Any]
 SerializedBatchEnvelope = dict[str, Any]
 SerializedRouteBatch = dict[str, Any]
 SerializedBatchCompletion = dict[str, Any]
+SerializedWorkerPipePayload = dict[str, Any]
+
+WORKER_PIPE_KIND_WORK_ITEMS = "work_items"
+WORKER_PIPE_KIND_ROUTE_BATCH = "route_batch"
+BATCH_COMPLETION_KIND = "batch_completion"
+
+
+def _require_fields(
+    payload: dict[str, Any],
+    required_fields: tuple[str, ...],
+    error_name: str,
+) -> None:
+    missing_fields = [field for field in required_fields if field not in payload]
+    if missing_fields:
+        raise ValueError("%s_missing_%s" % (error_name, "_".join(missing_fields)))
+
+
+def _require_non_empty_list(value: Any, field_name: str, error_name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError("%s_%s_not_list" % (error_name, field_name))
+    if not value:
+        raise ValueError("%s_%s_empty" % (error_name, field_name))
+    return value
 
 
 def work_item_to_dict(item: WorkItem) -> SerializedWorkItem:
@@ -156,11 +179,22 @@ def route_batch_to_dict(batch: RouteBatch) -> SerializedRouteBatch:
 
 def route_batch_from_dict(payload: SerializedRouteBatch) -> RouteBatch:
     """Build an internal route batch from a process wire payload."""
+    _require_fields(
+        payload, ("batch_id", "route_identity", "items"), "invalid_route_batch"
+    )
+    route_identity = payload["route_identity"]
+    if not isinstance(route_identity, (list, tuple)):
+        raise ValueError("invalid_route_batch_route_identity_not_sequence")
+    items = _require_non_empty_list(
+        payload["items"],
+        "items",
+        "invalid_route_batch",
+    )
     return RouteBatch(
         batch_id=payload["batch_id"],
-        route_identity=tuple(payload["route_identity"]),
+        route_identity=tuple(route_identity),
         worker_index=payload.get("worker_index"),
-        items=[work_item_from_dict(item) for item in payload.get("items", [])],
+        items=[work_item_from_dict(item) for item in items],
     )
 
 
@@ -179,16 +213,58 @@ def batch_completion_from_dict(
     payload: SerializedBatchCompletion,
 ) -> BatchCompletion:
     """Build an internal batch completion from a process wire payload."""
+    _require_fields(
+        payload,
+        ("batch_id", "route_identity", "results"),
+        "invalid_batch_completion",
+    )
+    route_identity = payload["route_identity"]
+    if not isinstance(route_identity, (list, tuple)):
+        raise ValueError("invalid_batch_completion_route_identity_not_sequence")
+    results = _require_non_empty_list(
+        payload["results"],
+        "results",
+        "invalid_batch_completion",
+    )
     return BatchCompletion(
         batch_id=payload["batch_id"],
-        route_identity=tuple(payload["route_identity"]),
-        results=[
-            completion_event_from_dict(event) for event in payload.get("results", [])
-        ],
+        route_identity=tuple(route_identity),
+        results=[completion_event_from_dict(event) for event in results],
     )
 
 
-def serialize_batch_payload(batch: list[WorkItem], flush_enqueued_at: float) -> bytes:
+def serialize_batch_completion_payload(
+    completion: BatchCompletion,
+    completion_enqueued_at: float,
+) -> bytes:
+    """Serialize a worker-to-parent batch completion envelope."""
+    envelope = {
+        "kind": BATCH_COMPLETION_KIND,
+        "completion": batch_completion_to_dict(completion),
+        "timing": {"completion_enqueued_at": completion_enqueued_at},
+    }
+    return cast(bytes, msgpack.packb(envelope, use_bin_type=True))
+
+
+def decode_batch_completion_payload(
+    item: Any,
+    max_bytes: int,
+) -> dict[str, Any]:
+    """Decode and validate a worker-to-parent batch completion envelope."""
+    decoded = (
+        _decode_msgpack_payload(item, max_bytes)
+        if isinstance(item, (bytes, bytearray))
+        else item
+    )
+    if not isinstance(decoded, dict) or decoded.get("kind") != BATCH_COMPLETION_KIND:
+        raise ValueError("invalid_batch_completion_payload")
+    return dict(decoded)
+
+
+def serialize_batch_payload(
+    batch: list[WorkItem] | RouteBatch,
+    flush_enqueued_at: float,
+) -> bytes:
     """Serialize batch payload for process payload serialization.
 
     Args:
@@ -199,16 +275,78 @@ def serialize_batch_payload(batch: list[WorkItem], flush_enqueued_at: float) -> 
         bytes: msgpack으로 인코딩된 batch envelope입니다.
 
     """
-    envelope: SerializedBatchEnvelope = {
-        "items": [work_item_to_dict(item) for item in batch],
-        "timing": {"flush_enqueued_at": flush_enqueued_at},
-    }
+    return serialize_worker_pipe_payload(batch, flush_enqueued_at)
+
+
+def serialize_worker_pipe_payload(
+    payload: list[WorkItem] | RouteBatch,
+    flush_enqueued_at: float,
+) -> bytes:
+    """Serialize a worker-pipe payload with an explicit payload kind."""
+    timing = {"flush_enqueued_at": flush_enqueued_at}
+    if isinstance(payload, RouteBatch):
+        envelope: SerializedWorkerPipePayload = {
+            "kind": WORKER_PIPE_KIND_ROUTE_BATCH,
+            "batch": route_batch_to_dict(payload),
+            "timing": timing,
+        }
+    else:
+        envelope = {
+            "kind": WORKER_PIPE_KIND_WORK_ITEMS,
+            "items": [work_item_to_dict(item) for item in payload],
+            "timing": timing,
+        }
     return cast(bytes, msgpack.packb(envelope, use_bin_type=True))
+
+
+def _decode_msgpack_payload(item: bytes | bytearray, max_bytes: int) -> Any:
+    """Decode one msgpack payload while enforcing the configured byte limit."""
+    if len(item) > max_bytes:
+        raise ValueError("payload_too_large")
+    unpacker = msgpack.Unpacker(raw=False, max_buffer_size=max_bytes)
+    unpacker.feed(item)
+    decoded_items = list(unpacker)
+    if len(decoded_items) == 1:
+        return decoded_items[0]
+    return decoded_items
+
+
+def decode_worker_pipe_payload(
+    item: Any,
+    max_bytes: int,
+) -> SerializedWorkerPipePayload:
+    """Decode a worker-pipe payload envelope and validate its payload kind."""
+    decoded = (
+        _decode_msgpack_payload(item, max_bytes)
+        if isinstance(item, (bytes, bytearray))
+        else item
+    )
+    if not isinstance(decoded, dict):
+        return {
+            "kind": WORKER_PIPE_KIND_WORK_ITEMS,
+            "items": [dict(entry) for entry in decoded],
+            "timing": {},
+        }
+
+    kind = decoded.get("kind")
+    if kind is None:
+        if "items" in decoded:
+            payload = dict(decoded)
+            payload["kind"] = WORKER_PIPE_KIND_WORK_ITEMS
+            return payload
+        return {
+            "kind": WORKER_PIPE_KIND_WORK_ITEMS,
+            "items": [dict(decoded)],
+            "timing": {},
+        }
+    if kind not in {WORKER_PIPE_KIND_WORK_ITEMS, WORKER_PIPE_KIND_ROUTE_BATCH}:
+        raise ValueError("unknown_worker_pipe_payload_kind:%s" % kind)
+    return dict(decoded)
 
 
 def normalize_decoded_payloads(
     decoded: Any,
-) -> tuple[list[SerializedWorkItem], dict[str, float]]:
+) -> tuple[list[SerializedWorkItem], dict[str, Any]]:
     """Normalize decoded payloads for process payload serialization.
 
     Args:
@@ -219,6 +357,20 @@ def normalize_decoded_payloads(
 
     """
     if isinstance(decoded, dict):
+        kind = decoded.get("kind")
+        if kind == WORKER_PIPE_KIND_ROUTE_BATCH:
+            batch = route_batch_from_dict(decoded["batch"])
+            timing = decoded.get("timing", {})
+            timing_values: dict[str, Any] = {
+                key: float(value)
+                for key, value in dict(timing).items()
+                if isinstance(value, (int, float))
+            }
+            timing_values["route_batch_id"] = batch.batch_id
+            timing_values["route_identity"] = tuple(batch.route_identity)
+            return [work_item_to_dict(item) for item in batch.items], timing_values
+        if kind is not None and kind != WORKER_PIPE_KIND_WORK_ITEMS:
+            raise ValueError("unknown_worker_pipe_payload_kind:%s" % kind)
         if "items" in decoded:
             timing = decoded.get("timing", {})
             timing_values = {
@@ -252,7 +404,7 @@ def normalize_decoded_payloads(
 
 def decode_incoming_payloads(
     item: Any, max_bytes: int
-) -> tuple[list[SerializedWorkItem], dict[str, float]]:
+) -> tuple[list[SerializedWorkItem], dict[str, Any]]:
     """Decode incoming payloads for process payload serialization.
 
     Args:
@@ -267,15 +419,7 @@ def decode_incoming_payloads(
 
     """
     if isinstance(item, (bytes, bytearray)):
-        if len(item) > max_bytes:
-            raise ValueError("payload_too_large")
-        unpacker = msgpack.Unpacker(raw=False, max_buffer_size=max_bytes)
-        unpacker.feed(item)
-        decoded_items = list(unpacker)
-        if len(decoded_items) == 1:
-            decoded = decoded_items[0]
-        else:
-            decoded = decoded_items
+        decoded = _decode_msgpack_payload(item, max_bytes)
         return normalize_decoded_payloads(decoded)
     return normalize_decoded_payloads(item)
 

--- a/pyrallel_consumer/execution_plane/process_codec.py
+++ b/pyrallel_consumer/execution_plane/process_codec.py
@@ -4,14 +4,16 @@
 # Extend here for wire-format changes shared by process transports and workers.
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import msgpack  # type: ignore[import-untyped]
 
 from pyrallel_consumer.dto import (
     WORK_ITEM_POISON_KEY_UNSET,
+    BatchCompletion,
     CompletionEvent,
     CompletionStatus,
+    RouteBatch,
     TopicPartition,
     WorkItem,
 )
@@ -20,6 +22,8 @@ SerializedWorkItem = dict[str, Any]
 SerializedCompletionEvent = dict[str, Any]
 SerializedRegistryEvent = dict[str, Any]
 SerializedBatchEnvelope = dict[str, Any]
+SerializedRouteBatch = dict[str, Any]
+SerializedBatchCompletion = dict[str, Any]
 
 
 def work_item_to_dict(item: WorkItem) -> SerializedWorkItem:
@@ -140,6 +144,50 @@ def completion_event_from_dict(
     )
 
 
+def route_batch_to_dict(batch: RouteBatch) -> SerializedRouteBatch:
+    """Convert an internal route batch to a process wire payload."""
+    return {
+        "batch_id": batch.batch_id,
+        "route_identity": list(batch.route_identity),
+        "worker_index": batch.worker_index,
+        "items": [work_item_to_dict(item) for item in batch.items],
+    }
+
+
+def route_batch_from_dict(payload: SerializedRouteBatch) -> RouteBatch:
+    """Build an internal route batch from a process wire payload."""
+    return RouteBatch(
+        batch_id=payload["batch_id"],
+        route_identity=tuple(payload["route_identity"]),
+        worker_index=payload.get("worker_index"),
+        items=[work_item_from_dict(item) for item in payload.get("items", [])],
+    )
+
+
+def batch_completion_to_dict(
+    completion: BatchCompletion,
+) -> SerializedBatchCompletion:
+    """Convert an internal batch completion to a process wire payload."""
+    return {
+        "batch_id": completion.batch_id,
+        "route_identity": list(completion.route_identity),
+        "results": [completion_event_to_dict(event) for event in completion.results],
+    }
+
+
+def batch_completion_from_dict(
+    payload: SerializedBatchCompletion,
+) -> BatchCompletion:
+    """Build an internal batch completion from a process wire payload."""
+    return BatchCompletion(
+        batch_id=payload["batch_id"],
+        route_identity=tuple(payload["route_identity"]),
+        results=[
+            completion_event_from_dict(event) for event in payload.get("results", [])
+        ],
+    )
+
+
 def serialize_batch_payload(batch: list[WorkItem], flush_enqueued_at: float) -> bytes:
     """Serialize batch payload for process payload serialization.
 
@@ -155,7 +203,7 @@ def serialize_batch_payload(batch: list[WorkItem], flush_enqueued_at: float) -> 
         "items": [work_item_to_dict(item) for item in batch],
         "timing": {"flush_enqueued_at": flush_enqueued_at},
     }
-    return msgpack.packb(envelope, use_bin_type=True)
+    return cast(bytes, msgpack.packb(envelope, use_bin_type=True))
 
 
 def normalize_decoded_payloads(

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -98,6 +98,7 @@ from pyrallel_consumer.logger import LogManager
 _SHUTDOWN_DRAIN_SLEEP_SECONDS = 0.01
 _POST_JOIN_SHUTDOWN_DRAIN_SECONDS = 0.05
 _POST_JOIN_SHUTDOWN_STABLE_EMPTY_PASSES = 2
+_DEFAULT_MSGPACK_MAX_BYTES = 1_000_000
 _logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -1330,12 +1331,10 @@ class ProcessExecutionEngine(BaseExecutionEngine):
     ) -> list[CompletionEvent]:
         """Decode one completion queue item into item-level completion events."""
         if isinstance(raw_event, (bytes, bytearray)):
-            config = getattr(self, "_config", ExecutionConfig(mode="process"))
-            if not isinstance(config, ExecutionConfig):
-                config = ExecutionConfig(mode="process")
+            msgpack_max_bytes = self._completion_msgpack_max_bytes()
             payload = _decode_msgpack_payload(
                 raw_event,
-                config.process_config.msgpack_max_bytes,
+                msgpack_max_bytes,
             )
             if (
                 isinstance(payload, dict)
@@ -1343,7 +1342,7 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             ):
                 decoded_payload = _decode_batch_completion_payload(
                     payload,
-                    max_bytes=self._config.process_config.msgpack_max_bytes,
+                    max_bytes=msgpack_max_bytes,
                 )
                 timing = decoded_payload.get("timing", {})
                 completion_enqueued_at = timing.get("completion_enqueued_at")
@@ -1364,6 +1363,15 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             self._record_completion_ipc(1, batch_payload=False)
             return [_completion_event_from_dict(payload)]
         return [raw_event]
+
+    def _completion_msgpack_max_bytes(self) -> int:
+        """Return completion decode msgpack byte limit without config construction."""
+        config = getattr(self, "_config", None)
+        process_config = getattr(config, "process_config", None)
+        msgpack_max_bytes = getattr(process_config, "msgpack_max_bytes", None)
+        if isinstance(msgpack_max_bytes, int) and msgpack_max_bytes > 0:
+            return msgpack_max_bytes
+        return _DEFAULT_MSGPACK_MAX_BYTES
 
     def get_in_flight_count(self) -> int:
         """현재 처리 중인 작업 항목의 수를 반환합니다.

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -12,6 +12,7 @@ import pickle
 import queue
 import threading
 import time
+import uuid
 from collections import deque
 from collections.abc import Callable
 from multiprocessing import Process, Queue
@@ -26,6 +27,7 @@ from pyrallel_consumer.dto import (
     EngineRuntimeDiagnostics,
     ProcessBatchMetrics,
     ProcessRuntimeDiagnostics,
+    RouteBatch,
     TopicPartition,
     WorkItem,
 )
@@ -36,12 +38,22 @@ from pyrallel_consumer.execution_plane.process_batching import (
 from pyrallel_consumer.execution_plane.process_batching import (
     NoOpBatchAccumulator as _NoOpBatchAccumulator,
 )
-from pyrallel_consumer.execution_plane.process_codec import SerializedWorkItem
+from pyrallel_consumer.execution_plane.process_codec import (
+    BATCH_COMPLETION_KIND,
+    SerializedWorkItem,
+    _decode_msgpack_payload,
+)
+from pyrallel_consumer.execution_plane.process_codec import (
+    batch_completion_from_dict as _batch_completion_from_dict,
+)
 from pyrallel_consumer.execution_plane.process_codec import (
     completion_event_from_dict as _completion_event_from_dict,
 )
 from pyrallel_consumer.execution_plane.process_codec import (
     completion_event_to_dict as _completion_event_to_dict,
+)
+from pyrallel_consumer.execution_plane.process_codec import (
+    decode_batch_completion_payload as _decode_batch_completion_payload,
 )
 from pyrallel_consumer.execution_plane.process_codec import (
     decode_incoming_item as _decode_incoming_item,
@@ -151,6 +163,7 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         self._completion_queue: Queue[Any] = Queue()
         self._registry_event_queue: Queue[Any] = Queue()
         self._prefetched_completion_events: Deque[CompletionEvent] = deque()
+        self._seen_completion_identities: set[tuple[str, str, int, int, int]] = set()
         self._in_flight_registry: dict[
             tuple[int, str, int, int], SerializedWorkItem
         ] = {}
@@ -215,6 +228,11 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             self._transport = worker_pipe_transport
 
         self._start_workers()
+
+    @property
+    def supports_ordered_route_batch(self) -> bool:
+        """Return whether process mode can dispatch ordered route batches safely."""
+        return self._get_transport_mode() == "worker_pipes"
 
     def _validate_transport_config(self) -> None:
         """Validate transport config for multiprocessing execution.
@@ -715,12 +733,45 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         transport = getattr(self, "_transport", None)
         if transport is not None:
             transport.handle_registry_event(event)
+        if self._recover_not_started_payloads(event):
+            return
         ProcessRegistrySupport.apply_registry_event(
             event=event,
             in_flight_registry=self._in_flight_registry,
             record_main_to_worker_ipc=self._record_main_to_worker_ipc,
             record_worker_exec=self._record_worker_exec,
         )
+
+    def _recover_not_started_payloads(self, event: dict[str, Any]) -> bool:
+        """Requeue ordered route-batch tail payloads that a live worker skipped."""
+        if event.get("kind") != "not_started":
+            return False
+        payloads = event.get("payloads")
+        if not isinstance(payloads, list):
+            return True
+        recovered_payloads = [
+            dict(payload) for payload in payloads if isinstance(payload, dict)
+        ]
+        if not recovered_payloads:
+            return True
+        try:
+            self._requeue_recovered_payloads(recovered_payloads)
+        except Exception as requeue_exc:
+            self._logger.error(
+                "Failed to requeue not_started route-batch tail payloads batch_id=%s: %s",
+                event.get("batch_id"),
+                requeue_exc,
+            )
+            for payload in recovered_payloads:
+                self._emit_worker_recovery_failure(
+                    -1,
+                    payload,
+                    error="not_started_requeue_failed: %s" % requeue_exc,
+                    attempt=int(
+                        payload.get("requeue_attempts", self._config.max_retries)
+                    ),
+                )
+        return True
 
     def _drain_registry_events(self) -> None:
         """Drain registry events for multiprocessing execution."""
@@ -744,19 +795,40 @@ class ProcessExecutionEngine(BaseExecutionEngine):
                     raw_event = completion_queue.get_nowait()
                 except queue.Empty:
                     return prefetched
-                event = self._decode_completion_queue_item(raw_event)
-                self._prefetch_completion_event(event)
+                for event in self._decode_completion_queue_item_events(raw_event):
+                    self._prefetch_completion_event(event)
                 prefetched += 1
 
-    def _prefetch_completion_event(self, event: CompletionEvent) -> None:
+    def _prefetch_completion_event(self, event: CompletionEvent) -> bool:
         """Handle prefetch completion event within multiprocessing execution.
 
         Args:
             event: Completion or registry event being processed.
 
         """
+        if self._is_duplicate_completion_event(event):
+            return False
         self._prefetched_completion_events.append(event)
         self._discard_registry_entry_for_completion(event)
+        return True
+
+    def _is_duplicate_completion_event(self, event: CompletionEvent) -> bool:
+        """Return True when this item completion was already surfaced."""
+        seen = getattr(self, "_seen_completion_identities", None)
+        if seen is None:
+            seen = set()
+            self._seen_completion_identities = seen
+        identity = (
+            event.id,
+            event.tp.topic,
+            event.tp.partition,
+            event.offset,
+            event.epoch,
+        )
+        if identity in seen:
+            return True
+        seen.add(identity)
+        return False
 
     def _discard_registry_entry_for_completion(self, event: CompletionEvent) -> None:
         """Handle discard registry entry for completion within multiprocessing execution.
@@ -790,9 +862,8 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             except queue.Empty:
                 break
             drained_completion += 1
-            self._prefetch_completion_event(
-                self._decode_completion_queue_item(raw_event)
-            )
+            for event in self._decode_completion_queue_item_events(raw_event):
+                self._prefetch_completion_event(event)
 
         return drained_registry, drained_completion
 
@@ -885,7 +956,8 @@ class ProcessExecutionEngine(BaseExecutionEngine):
 
         """
         self._drain_registry_events()
-        base_metrics = self._batch_accumulator.snapshot()
+        batch_accumulator = getattr(self, "_batch_accumulator", _NoOpBatchAccumulator())
+        base_metrics = batch_accumulator.snapshot()
         transport_mode = self._get_transport_mode()
         support_state = "bounded" if transport_mode == "worker_pipes" else "full"
         timer_flush_supported = transport_mode != "worker_pipes"
@@ -907,6 +979,24 @@ class ProcessExecutionEngine(BaseExecutionEngine):
                 self._worker_to_main_ipc_sum_seconds / self._worker_to_main_ipc_samples
                 if self._worker_to_main_ipc_samples > 0
                 else 0.0
+            )
+            items_per_input_ipc = (
+                self._input_ipc_item_count / self._input_ipc_count
+                if self._input_ipc_count > 0
+                else None
+            )
+            items_per_completion_ipc = (
+                self._completion_ipc_item_count / self._completion_ipc_count
+                if self._completion_ipc_count > 0
+                else None
+            )
+            route_batch_size_avg = (
+                self._route_batch_item_count / self._route_batch_count
+                if self._route_batch_count > 0
+                else None
+            )
+            route_batch_size_max = (
+                self._route_batch_size_max if self._route_batch_count > 0 else None
             )
             return EngineRuntimeDiagnostics(
                 engine_type="process",
@@ -932,6 +1022,18 @@ class ProcessExecutionEngine(BaseExecutionEngine):
                         timer_flush_supported=timer_flush_supported,
                         demand_flush_supported=demand_flush_supported,
                         recycle_supported=recycle_supported,
+                        items_per_input_ipc=items_per_input_ipc,
+                        items_per_completion_ipc=items_per_completion_ipc,
+                        route_batch_count=self._route_batch_count,
+                        route_batch_item_count=self._route_batch_item_count,
+                        route_batch_size_avg=route_batch_size_avg,
+                        route_batch_size_max=route_batch_size_max,
+                        completion_item_payload_count=(
+                            self._completion_item_payload_count
+                        ),
+                        completion_batch_payload_count=(
+                            self._completion_batch_payload_count
+                        ),
                     )
                 ),
             )
@@ -953,6 +1055,42 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             route_identity=resolve_route_identity(work_item),
             count_in_flight=True,
         )
+        if self._get_transport_mode() == "worker_pipes":
+            self._record_input_ipc(1)
+
+    async def submit_batch(self, work_items: list[WorkItem]) -> None:
+        """Submit a route-local work batch through the worker-pipe transport."""
+        if self._get_transport_mode() != "worker_pipes" or not work_items:
+            await super().submit_batch(work_items)
+            return
+
+        route_identity = resolve_route_identity(work_items[0])
+        if any(
+            resolve_route_identity(item) != route_identity for item in work_items[1:]
+        ):
+            await super().submit_batch(work_items)
+            return
+
+        self._drain_registry_events()
+        await asyncio.to_thread(self._ensure_workers_alive, force=True)
+        route_batch = RouteBatch(
+            batch_id=uuid.uuid4().hex,
+            route_identity=(
+                route_identity.topic,
+                route_identity.partition,
+                route_identity.key,
+            ),
+            worker_index=None,
+            items=work_items,
+        )
+        dispatch_route_batch = getattr(self._transport, "dispatch_route_batch")
+        await asyncio.to_thread(
+            dispatch_route_batch,
+            route_batch,
+            route_identity=route_identity,
+            count_in_flight=True,
+        )
+        self._record_input_ipc(len(work_items), route_batch=True)
 
     async def poll_completed_events(
         self, batch_limit: int = 1000
@@ -982,11 +1120,17 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         while len(completed_events) < batch_limit:
             try:
                 raw_event = self._completion_queue.get_nowait()
-                event = self._decode_completion_queue_item(raw_event)
-                self._discard_registry_entry_for_completion(event)
-                completed_events.append(event)
-                with self._in_flight_lock:
-                    self._in_flight_count -= 1
+                for event in self._decode_completion_queue_item_events(raw_event):
+                    if self._is_duplicate_completion_event(event):
+                        continue
+                    if len(completed_events) >= batch_limit:
+                        self._prefetched_completion_events.append(event)
+                        self._discard_registry_entry_for_completion(event)
+                        continue
+                    self._discard_registry_entry_for_completion(event)
+                    completed_events.append(event)
+                    with self._in_flight_lock:
+                        self._in_flight_count -= 1
             except queue.Empty:
                 break
             except Exception as e:
@@ -1023,9 +1167,8 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             raw_event = None
 
         if raw_event is not None:
-            self._prefetch_completion_event(
-                self._decode_completion_queue_item(raw_event)
-            )
+            for event in self._decode_completion_queue_item_events(raw_event):
+                self._prefetch_completion_event(event)
             return True
 
         if timeout_seconds is not None and timeout_seconds <= 0:
@@ -1040,7 +1183,8 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         except queue.Empty:
             return False
 
-        self._prefetch_completion_event(self._decode_completion_queue_item(raw_event))
+        for event in self._decode_completion_queue_item_events(raw_event):
+            self._prefetch_completion_event(event)
         return True
 
     def _initialize_runtime_timing_state(self) -> None:
@@ -1057,6 +1201,46 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         self._worker_to_main_ipc_samples = 0
         self._worker_to_main_ipc_sum_seconds = 0.0
         self._last_worker_to_main_ipc_seconds = 0.0
+        self._input_ipc_count = 0
+        self._input_ipc_item_count = 0
+        self._completion_ipc_count = 0
+        self._completion_ipc_item_count = 0
+        self._route_batch_count = 0
+        self._route_batch_item_count = 0
+        self._route_batch_size_max = 0
+        self._completion_item_payload_count = 0
+        self._completion_batch_payload_count = 0
+
+    def _record_input_ipc(self, item_count: int, *, route_batch: bool = False) -> None:
+        """Record parent-to-worker IPC item counts."""
+        if item_count <= 0:
+            return
+        self._initialize_runtime_timing_state()
+        with self._runtime_timing_lock:
+            self._input_ipc_count += 1
+            self._input_ipc_item_count += item_count
+            if route_batch:
+                self._route_batch_count += 1
+                self._route_batch_item_count += item_count
+                self._route_batch_size_max = max(self._route_batch_size_max, item_count)
+
+    def _record_completion_ipc(
+        self,
+        item_count: int,
+        *,
+        batch_payload: bool = False,
+    ) -> None:
+        """Record worker-to-parent completion IPC item counts."""
+        if item_count <= 0:
+            return
+        self._initialize_runtime_timing_state()
+        with self._runtime_timing_lock:
+            self._completion_ipc_count += 1
+            self._completion_ipc_item_count += item_count
+            if batch_payload:
+                self._completion_batch_payload_count += 1
+            else:
+                self._completion_item_payload_count += 1
 
     def _record_main_to_worker_ipc(self, duration_seconds: Any) -> None:
         """Convert record main to worker ipc.
@@ -1136,15 +1320,50 @@ class ProcessExecutionEngine(BaseExecutionEngine):
             Completion event produced by the operation.
 
         """
+        events = self._decode_completion_queue_item_events(raw_event)
+        if len(events) != 1:
+            raise ValueError("completion_queue_item_expanded_to_multiple_events")
+        return events[0]
+
+    def _decode_completion_queue_item_events(
+        self, raw_event: Any
+    ) -> list[CompletionEvent]:
+        """Decode one completion queue item into item-level completion events."""
         if isinstance(raw_event, (bytes, bytearray)):
-            payload = msgpack.unpackb(raw_event, raw=False)
+            config = getattr(self, "_config", ExecutionConfig(mode="process"))
+            if not isinstance(config, ExecutionConfig):
+                config = ExecutionConfig(mode="process")
+            payload = _decode_msgpack_payload(
+                raw_event,
+                config.process_config.msgpack_max_bytes,
+            )
+            if (
+                isinstance(payload, dict)
+                and payload.get("kind") == BATCH_COMPLETION_KIND
+            ):
+                decoded_payload = _decode_batch_completion_payload(
+                    payload,
+                    max_bytes=self._config.process_config.msgpack_max_bytes,
+                )
+                timing = decoded_payload.get("timing", {})
+                completion_enqueued_at = timing.get("completion_enqueued_at")
+                if isinstance(completion_enqueued_at, (int, float)):
+                    self._record_worker_to_main_ipc(
+                        time.monotonic() - float(completion_enqueued_at)
+                    )
+                results = list(
+                    _batch_completion_from_dict(decoded_payload["completion"]).results
+                )
+                self._record_completion_ipc(len(results), batch_payload=True)
+                return results
             completion_enqueued_at = payload.get("completion_enqueued_at")
             if isinstance(completion_enqueued_at, (int, float)):
                 self._record_worker_to_main_ipc(
                     time.monotonic() - float(completion_enqueued_at)
                 )
-            return _completion_event_from_dict(payload)
-        return raw_event
+            self._record_completion_ipc(1, batch_payload=False)
+            return [_completion_event_from_dict(payload)]
+        return [raw_event]
 
     def get_in_flight_count(self) -> int:
         """현재 처리 중인 작업 항목의 수를 반환합니다.

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -99,6 +99,7 @@ _SHUTDOWN_DRAIN_SLEEP_SECONDS = 0.01
 _POST_JOIN_SHUTDOWN_DRAIN_SECONDS = 0.05
 _POST_JOIN_SHUTDOWN_STABLE_EMPTY_PASSES = 2
 _DEFAULT_MSGPACK_MAX_BYTES = 1_000_000
+_MAX_SEEN_COMPLETION_IDENTITIES = 100_000
 _logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -165,6 +166,9 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         self._registry_event_queue: Queue[Any] = Queue()
         self._prefetched_completion_events: Deque[CompletionEvent] = deque()
         self._seen_completion_identities: set[tuple[str, str, int, int, int]] = set()
+        self._seen_completion_identity_order: Deque[
+            tuple[str, str, int, int, int]
+        ] = deque()
         self._in_flight_registry: dict[
             tuple[int, str, int, int], SerializedWorkItem
         ] = {}
@@ -819,6 +823,10 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         if seen is None:
             seen = set()
             self._seen_completion_identities = seen
+        order = getattr(self, "_seen_completion_identity_order", None)
+        if order is None:
+            order = deque()
+            self._seen_completion_identity_order = order
         identity = (
             event.id,
             event.tp.topic,
@@ -829,6 +837,10 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         if identity in seen:
             return True
         seen.add(identity)
+        order.append(identity)
+        max_seen = max(1, _MAX_SEEN_COMPLETION_IDENTITIES)
+        while len(order) > max_seen:
+            seen.discard(order.popleft())
         return False
 
     def _discard_registry_entry_for_completion(self, event: CompletionEvent) -> None:
@@ -1336,10 +1348,9 @@ class ProcessExecutionEngine(BaseExecutionEngine):
                 raw_event,
                 msgpack_max_bytes,
             )
-            if (
-                isinstance(payload, dict)
-                and payload.get("kind") == BATCH_COMPLETION_KIND
-            ):
+            if not isinstance(payload, dict):
+                raise ValueError("invalid_completion_payload_type")
+            if payload.get("kind") == BATCH_COMPLETION_KIND:
                 decoded_payload = _decode_batch_completion_payload(
                     payload,
                     max_bytes=msgpack_max_bytes,

--- a/pyrallel_consumer/execution_plane/process_engine.py
+++ b/pyrallel_consumer/execution_plane/process_engine.py
@@ -751,6 +751,8 @@ class ProcessExecutionEngine(BaseExecutionEngine):
         """Requeue ordered route-batch tail payloads that a live worker skipped."""
         if event.get("kind") != "not_started":
             return False
+        if event.get("_route_batch_pending_not_started") is False:
+            return True
         payloads = event.get("payloads")
         if not isinstance(payloads, list):
             return True

--- a/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
+++ b/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
@@ -132,7 +132,14 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
             worker_index=worker_idx,
             items=route_batch.items,
         )
-        self._acquire_worker_pipe_queue_slot(worker_idx=worker_idx, payload={})
+        serialized_items = [
+            self._serialize_work_item(item) for item in batch_with_worker.items
+        ]
+        representative_payload = serialized_items[0] if serialized_items else {}
+        self._acquire_worker_pipe_queue_slot(
+            worker_idx=worker_idx,
+            payload=representative_payload,
+        )
         pending_key = self._pending_dispatch_key_for_route_batch(
             worker_idx,
             batch_with_worker,
@@ -141,9 +148,7 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
             "batch_id": batch_with_worker.batch_id,
             "route_identity": list(batch_with_worker.route_identity),
             "worker_index": worker_idx,
-            "items": [
-                self._serialize_work_item(item) for item in batch_with_worker.items
-            ],
+            "items": serialized_items,
             "slot_released": False,
         }
         with self._pending_dispatch_lock:

--- a/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
+++ b/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
@@ -11,7 +11,7 @@ from typing import Any, Callable
 
 import msgpack  # type: ignore[import-untyped]
 
-from pyrallel_consumer.dto import WorkItem
+from pyrallel_consumer.dto import RouteBatch, WorkItem
 from pyrallel_consumer.execution_plane.process_transport import (
     AsyncToThreadSubmitMixin,
     PendingDispatchRecovery,
@@ -19,11 +19,12 @@ from pyrallel_consumer.execution_plane.process_transport import (
     ProcessTransportCapabilities,
     RouteIdentity,
     SerializedWorkItem,
+    logical_work_identity_from_payload,
     stable_worker_index_for_route,
     worker_execution_identity_from_payload,
 )
 
-PendingDispatchKey = tuple[int, str, int, int, str, int]
+PendingDispatchKey = tuple[int, str, int, int, str, int] | tuple[int, str]
 
 
 class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
@@ -36,7 +37,7 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
         queue_size: int,
         max_payload_bytes: int,
         serialize_work_item: Callable[[WorkItem], SerializedWorkItem],
-        serialize_batch_payload: Callable[[list[WorkItem], float], bytes],
+        serialize_batch_payload: Callable[[Any, float], bytes],
         work_item_from_dict: Callable[[SerializedWorkItem], WorkItem],
         get_worker_pipe_senders: Callable[[], list[Any]],
         increment_in_flight: Callable[[], None],
@@ -72,7 +73,7 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
         self._slot_wait_timeout_seconds = slot_wait_timeout_seconds
         self._worker_pipe_queue_slots = threading.BoundedSemaphore(value=queue_size)
         self._pending_dispatch_lock = threading.Lock()
-        self._pending_dispatch: dict[PendingDispatchKey, SerializedWorkItem] = {}
+        self._pending_dispatch: dict[PendingDispatchKey, dict[str, Any]] = {}
 
     def dispatch_payload(
         self,
@@ -116,6 +117,55 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
         if count_in_flight:
             self._increment_in_flight()
 
+    def dispatch_route_batch(
+        self,
+        route_batch: RouteBatch,
+        *,
+        route_identity: RouteIdentity,
+        count_in_flight: bool,
+    ) -> None:
+        """Dispatch one ordered route batch as a single worker-pipe payload."""
+        worker_idx = stable_worker_index_for_route(route_identity, self._process_count)
+        batch_with_worker = RouteBatch(
+            batch_id=route_batch.batch_id,
+            route_identity=route_batch.route_identity,
+            worker_index=worker_idx,
+            items=route_batch.items,
+        )
+        self._acquire_worker_pipe_queue_slot(worker_idx=worker_idx, payload={})
+        pending_key = self._pending_dispatch_key_for_route_batch(
+            worker_idx,
+            batch_with_worker,
+        )
+        pending_payload = {
+            "batch_id": batch_with_worker.batch_id,
+            "route_identity": list(batch_with_worker.route_identity),
+            "worker_index": worker_idx,
+            "items": [
+                self._serialize_work_item(item) for item in batch_with_worker.items
+            ],
+            "slot_released": False,
+        }
+        with self._pending_dispatch_lock:
+            self._pending_dispatch[pending_key] = pending_payload
+        try:
+            packed = self._serialize_batch_payload(batch_with_worker, time.monotonic())
+            self._validate_packed_payload(packed)
+            self._send_packed_route_batch(
+                worker_idx=worker_idx,
+                batch_id=batch_with_worker.batch_id,
+                packed_payload=packed,
+            )
+        except Exception:
+            with self._pending_dispatch_lock:
+                self._pending_dispatch.pop(pending_key, None)
+            self._release_worker_pipe_queue_slot()
+            raise
+
+        if count_in_flight:
+            for _item in batch_with_worker.items:
+                self._increment_in_flight()
+
     def start_worker_task_source(self, idx: int) -> tuple[Any, bool]:
         """Start worker task source for worker-pipe process transport.
 
@@ -155,18 +205,65 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
             event: Completion or registry event being processed.
 
         """
-        if event.get("kind") != "start":
+        kind = event.get("kind")
+        if kind == "not_started":
+            self._handle_not_started_route_batch_event(event)
+            return
+        if kind != "start":
             return
         key = event.get("key")
         payload = event.get("payload")
         pending_key = self._pending_dispatch_key_for_registry_start(key, payload)
+        release_slot = False
 
         with self._pending_dispatch_lock:
             if pending_key in self._pending_dispatch:
                 self._pending_dispatch.pop(pending_key, None)
+                release_slot = True
             else:
+                pending_key = self._pending_route_batch_key_for_registry_start(
+                    key,
+                    payload,
+                )
+                if pending_key in self._pending_dispatch:
+                    pending_payload = self._pending_dispatch[pending_key]
+                    self._remove_started_item_from_pending_route_batch(
+                        pending_payload,
+                        payload,
+                    )
+                    if not pending_payload.get("items"):
+                        self._pending_dispatch.pop(pending_key, None)
+                    if not pending_payload.get("slot_released", False):
+                        pending_payload["slot_released"] = True
+                        release_slot = True
+                else:
+                    return
+            if pending_key is None:
                 return
-        self._release_worker_pipe_queue_slot()
+        if release_slot:
+            self._release_worker_pipe_queue_slot()
+
+    def _handle_not_started_route_batch_event(self, event: dict[str, Any]) -> None:
+        """Remove skipped route-batch tail entries from pending dispatch state."""
+        batch_id = event.get("batch_id")
+        payloads = event.get("payloads")
+        if batch_id is None or not isinstance(payloads, list):
+            return
+        with self._pending_dispatch_lock:
+            for pending_key, pending_payload in list(self._pending_dispatch.items()):
+                if (
+                    not self._is_pending_route_batch(pending_payload)
+                    or pending_payload.get("batch_id") != batch_id
+                ):
+                    continue
+                for payload in payloads:
+                    self._remove_started_item_from_pending_route_batch(
+                        pending_payload,
+                        payload,
+                    )
+                if not pending_payload.get("items"):
+                    self._pending_dispatch.pop(pending_key, None)
+                return
 
     def recover_pending_dispatches(self, idx: int) -> list[PendingDispatchRecovery]:
         """Recover pending dispatches for worker-pipe process transport.
@@ -183,18 +280,32 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
             for key, payload in list(self._pending_dispatch.items()):
                 if key[0] != idx:
                     continue
-                recovered_payload = dict(payload)
-                recovered.append(
-                    PendingDispatchRecovery(
-                        identity=worker_execution_identity_from_payload(
-                            idx,
-                            recovered_payload,
-                        ),
-                        payload=recovered_payload,
+                if self._is_pending_route_batch(payload):
+                    for item_payload in payload["items"]:
+                        recovered_payload = dict(item_payload)
+                        recovered.append(
+                            PendingDispatchRecovery(
+                                identity=worker_execution_identity_from_payload(
+                                    idx,
+                                    recovered_payload,
+                                ),
+                                payload=recovered_payload,
+                            )
+                        )
+                else:
+                    recovered_payload = dict(payload)
+                    recovered.append(
+                        PendingDispatchRecovery(
+                            identity=worker_execution_identity_from_payload(
+                                idx,
+                                recovered_payload,
+                            ),
+                            payload=recovered_payload,
+                        )
                     )
-                )
                 self._pending_dispatch.pop(key, None)
-                self._release_worker_pipe_queue_slot()
+                if not payload.get("slot_released", False):
+                    self._release_worker_pipe_queue_slot()
         return recovered
 
     def requeue_payloads(self, payloads: list[SerializedWorkItem]) -> None:
@@ -292,6 +403,56 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
         ):
             return None
         return WorkerPipesProcessTransport._pending_dispatch_key(key[0], payload)
+
+    @staticmethod
+    def _pending_dispatch_key_for_route_batch(
+        worker_idx: int,
+        route_batch: RouteBatch,
+    ) -> PendingDispatchKey:
+        """Build the pending key for a pipe-level route batch send."""
+        return (worker_idx, route_batch.batch_id)
+
+    def _pending_route_batch_key_for_registry_start(
+        self,
+        key: Any,
+        payload: Any,
+    ) -> PendingDispatchKey | None:
+        """Match a worker item start event back to its pending route batch."""
+        if not isinstance(key, tuple) or len(key) < 4 or not isinstance(payload, dict):
+            return None
+        worker_idx = int(key[0])
+        for pending_key, pending_payload in self._pending_dispatch.items():
+            if pending_key[0] != worker_idx or not self._is_pending_route_batch(
+                pending_payload
+            ):
+                continue
+            for item_payload in pending_payload["items"]:
+                if self._pending_dispatch_key_for_registry_start(
+                    key,
+                    item_payload,
+                ) == self._pending_dispatch_key(worker_idx, payload):
+                    return pending_key
+        return None
+
+    @staticmethod
+    def _is_pending_route_batch(payload: dict[str, Any]) -> bool:
+        """Return whether a pending dispatch payload represents a route batch."""
+        return "batch_id" in payload and isinstance(payload.get("items"), list)
+
+    @staticmethod
+    def _remove_started_item_from_pending_route_batch(
+        pending_payload: dict[str, Any],
+        started_payload: Any,
+    ) -> None:
+        """Remove one started item from a pending route batch, leaving the tail."""
+        if not isinstance(started_payload, dict):
+            return
+        started_identity = logical_work_identity_from_payload(started_payload)
+        pending_payload["items"] = [
+            item_payload
+            for item_payload in pending_payload.get("items", [])
+            if logical_work_identity_from_payload(item_payload) != started_identity
+        ]
 
     def _release_worker_pipe_queue_slot(self) -> None:
         """Handle release worker pipe queue slot within worker-pipe process transport."""
@@ -391,4 +552,36 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
             raise RuntimeError(
                 "Failed to dispatch worker pipe payload worker=%d offset=%d"
                 % (worker_idx, payload["offset"])
+            ) from exc
+
+    def _send_packed_route_batch(
+        self,
+        *,
+        worker_idx: int,
+        batch_id: str,
+        packed_payload: bytes,
+    ) -> None:
+        """Send one encoded route batch to a worker pipe."""
+        senders = self._get_worker_pipe_senders()
+        try:
+            sender = senders[worker_idx]
+        except IndexError as exc:
+            raise RuntimeError(
+                "Missing worker pipe sender for worker=%d batch_id=%s"
+                % (worker_idx, batch_id)
+            ) from exc
+
+        send_bytes = getattr(sender, "send_bytes", None)
+        if not callable(send_bytes):
+            raise RuntimeError(
+                "Worker pipe sender for worker=%d batch_id=%s is not writable"
+                % (worker_idx, batch_id)
+            )
+
+        try:
+            send_bytes(packed_payload)
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to dispatch worker pipe route batch worker=%d batch_id=%s"
+                % (worker_idx, batch_id)
             ) from exc

--- a/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
+++ b/pyrallel_consumer/execution_plane/process_transport_worker_pipes.py
@@ -253,7 +253,9 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
         batch_id = event.get("batch_id")
         payloads = event.get("payloads")
         if batch_id is None or not isinstance(payloads, list):
+            event["_route_batch_pending_not_started"] = False
             return
+        pending_match = False
         with self._pending_dispatch_lock:
             for pending_key, pending_payload in list(self._pending_dispatch.items()):
                 if (
@@ -261,6 +263,7 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
                     or pending_payload.get("batch_id") != batch_id
                 ):
                     continue
+                pending_match = True
                 for payload in payloads:
                     self._remove_started_item_from_pending_route_batch(
                         pending_payload,
@@ -268,7 +271,8 @@ class WorkerPipesProcessTransport(AsyncToThreadSubmitMixin, ProcessTransport):
                     )
                 if not pending_payload.get("items"):
                     self._pending_dispatch.pop(pending_key, None)
-                return
+                break
+        event["_route_batch_pending_not_started"] = pending_match
 
     def recover_pending_dispatches(self, idx: int) -> list[PendingDispatchRecovery]:
         """Recover pending dispatches for worker-pipe process transport.

--- a/pyrallel_consumer/execution_plane/process_worker_runtime.py
+++ b/pyrallel_consumer/execution_plane/process_worker_runtime.py
@@ -253,6 +253,7 @@ def _worker_loop(
         batch_run_started_at: Optional[float] = None
         batch_completed_sent = False
         batch_completion_results: list[CompletionEvent] = []
+        deferred_done_events: list[dict[str, Any]] = []
 
         for idx, payload in enumerate(payloads):
             work_item = _work_item_from_dict(payload)
@@ -416,13 +417,15 @@ def _worker_loop(
                             process_idx,
                             put_exc,
                         )
-                registry_event_queue.put(
-                    {
-                        "kind": "done",
-                        "key": in_flight_key,
-                        "payload": _work_item_identity_payload(payload),
-                    }
-                )
+                done_event = {
+                    "kind": "done",
+                    "key": in_flight_key,
+                    "payload": _work_item_identity_payload(payload),
+                }
+                if route_batch_id is None:
+                    registry_event_queue.put(done_event)
+                else:
+                    deferred_done_events.append(done_event)
 
                 if status == CompletionStatus.FAILURE and route_batch_id is not None:
                     remaining_payloads = [dict(entry) for entry in payloads[idx + 1 :]]
@@ -498,6 +501,8 @@ def _worker_loop(
                 route_identity=route_identity,
                 batch_completion_results=batch_completion_results,
             )
+            for done_event in deferred_done_events:
+                registry_event_queue.put(done_event)
 
         if should_exit_after_batch:
             break

--- a/pyrallel_consumer/execution_plane/process_worker_runtime.py
+++ b/pyrallel_consumer/execution_plane/process_worker_runtime.py
@@ -17,6 +17,7 @@ import msgpack  # type: ignore[import-untyped]
 
 from pyrallel_consumer.config import ExecutionConfig
 from pyrallel_consumer.dto import (
+    BatchCompletion,
     CompletionEvent,
     CompletionStatus,
     TopicPartition,
@@ -27,6 +28,9 @@ from pyrallel_consumer.execution_plane.process_codec import (
 )
 from pyrallel_consumer.execution_plane.process_codec import (
     decode_incoming_payloads as _decode_incoming_payloads,
+)
+from pyrallel_consumer.execution_plane.process_codec import (
+    serialize_batch_completion_payload as _serialize_batch_completion_payload,
 )
 from pyrallel_consumer.execution_plane.process_codec import (
     work_item_from_dict as _work_item_from_dict,
@@ -85,6 +89,65 @@ def _calculate_backoff(
     jitter_ms = random.randint(0, retry_jitter_ms) if retry_jitter_ms > 0 else 0
     total_delay_ms = backoff_ms + jitter_ms
     return total_delay_ms / 1000.0
+
+
+def _flush_route_batch_completion(
+    *,
+    completion_queue: Queue,
+    registry_event_queue: Queue,
+    worker_logger: logging.Logger,
+    process_idx: int,
+    route_batch_id: object,
+    route_identity: tuple[Any, ...] | None,
+    batch_completion_results: list[CompletionEvent],
+) -> None:
+    """Flush executed route-batch prefix results to the parent completion queue."""
+    if not batch_completion_results:
+        return
+    batch_completion = BatchCompletion(
+        batch_id=str(route_batch_id),
+        route_identity=route_identity if route_identity is not None else (),
+        results=batch_completion_results,
+    )
+    try:
+        completion_queue.put(  # type: ignore[arg-type]
+            _serialize_batch_completion_payload(
+                batch_completion,
+                completion_enqueued_at=time.monotonic(),
+            )
+        )
+    except Exception as put_exc:
+        registry_event_queue.put(
+            {
+                "kind": "batch_completion_send_failed",
+                "batch_id": str(route_batch_id),
+                "error": str(put_exc),
+            }
+        )
+        worker_logger.error(
+            "Failed to enqueue batch completion for batch_id=%s in ProcessWorker[%d]: %s",
+            route_batch_id,
+            process_idx,
+            put_exc,
+        )
+        for completion_event in batch_completion_results:
+            try:
+                completion_queue.put(
+                    msgpack.packb(
+                        _completion_event_to_dict(
+                            completion_event,
+                            extra_fields={"completion_enqueued_at": time.monotonic()},
+                        ),
+                        use_bin_type=True,
+                    )
+                )
+            except Exception as fallback_exc:
+                worker_logger.error(
+                    "Failed to enqueue fallback completion for offset=%d in ProcessWorker[%d]: %s",
+                    completion_event.offset,
+                    process_idx,
+                    fallback_exc,
+                )
 
 
 def _worker_loop(
@@ -175,6 +238,8 @@ def _worker_loop(
             continue
 
         flush_enqueued_at = timing_metadata.get("flush_enqueued_at")
+        route_batch_id = timing_metadata.get("route_batch_id")
+        route_identity = timing_metadata.get("route_identity")
         if flush_enqueued_at is not None:
             registry_event_queue.put(
                 {
@@ -187,6 +252,7 @@ def _worker_loop(
 
         batch_run_started_at: Optional[float] = None
         batch_completed_sent = False
+        batch_completion_results: list[CompletionEvent] = []
 
         for idx, payload in enumerate(payloads):
             work_item = _work_item_from_dict(payload)
@@ -317,6 +383,8 @@ def _worker_loop(
                     error=error,
                     attempt=attempt,
                 )
+                if route_batch_id is not None:
+                    batch_completion_results.append(completion_event)
                 if (
                     not batch_completed_sent
                     and batch_run_started_at is not None
@@ -331,30 +399,43 @@ def _worker_loop(
                         }
                     )
                     batch_completed_sent = True
-                packed_completion = msgpack.packb(
-                    _completion_event_to_dict(
-                        completion_event,
-                        extra_fields={"completion_enqueued_at": time.monotonic()},
-                    ),
-                    use_bin_type=True,
+                if route_batch_id is None:
+                    packed_completion = msgpack.packb(
+                        _completion_event_to_dict(
+                            completion_event,
+                            extra_fields={"completion_enqueued_at": time.monotonic()},
+                        ),
+                        use_bin_type=True,
+                    )
+                    try:
+                        completion_queue.put(packed_completion)
+                    except Exception as put_exc:
+                        worker_logger.error(
+                            "Failed to enqueue completion for offset=%d in ProcessWorker[%d]: %s",
+                            work_item.offset,
+                            process_idx,
+                            put_exc,
+                        )
+                registry_event_queue.put(
+                    {
+                        "kind": "done",
+                        "key": in_flight_key,
+                        "payload": _work_item_identity_payload(payload),
+                    }
                 )
-                try:
-                    completion_queue.put(packed_completion)
-                except Exception as put_exc:
-                    worker_logger.error(
-                        "Failed to enqueue completion for offset=%d in ProcessWorker[%d]: %s",
-                        work_item.offset,
-                        process_idx,
-                        put_exc,
-                    )
-                finally:
-                    registry_event_queue.put(
-                        {
-                            "kind": "done",
-                            "key": in_flight_key,
-                            "payload": _work_item_identity_payload(payload),
-                        }
-                    )
+
+                if status == CompletionStatus.FAILURE and route_batch_id is not None:
+                    remaining_payloads = [dict(entry) for entry in payloads[idx + 1 :]]
+                    if remaining_payloads:
+                        registry_event_queue.put(
+                            {
+                                "kind": "not_started",
+                                "reason": "ordered_batch_failure",
+                                "batch_id": route_batch_id,
+                                "payloads": remaining_payloads,
+                            }
+                        )
+                    break
 
             # Check worker recycling after task completion
             if recycle_limit is not None:
@@ -378,6 +459,16 @@ def _worker_loop(
                     should_exit_after_batch = True
 
             if fatal_timeout:
+                if route_batch_id is not None:
+                    _flush_route_batch_completion(
+                        completion_queue=completion_queue,
+                        registry_event_queue=registry_event_queue,
+                        worker_logger=worker_logger,
+                        process_idx=process_idx,
+                        route_batch_id=route_batch_id,
+                        route_identity=route_identity,
+                        batch_completion_results=batch_completion_results,
+                    )
                 worker_logger.error(
                     "ProcessWorker[%d] exiting due to task timeout; parent will respawn",
                     process_idx,
@@ -395,6 +486,17 @@ def _worker_loop(
                         0.0, time.monotonic() - batch_run_started_at
                     ),
                 }
+            )
+
+        if route_batch_id is not None and batch_completion_results:
+            _flush_route_batch_completion(
+                completion_queue=completion_queue,
+                registry_event_queue=registry_event_queue,
+                worker_logger=worker_logger,
+                process_idx=process_idx,
+                route_batch_id=route_batch_id,
+                route_identity=route_identity,
+                batch_completion_results=batch_completion_results,
             )
 
         if should_exit_after_batch:

--- a/tests/unit/benchmarks/test_benchmark_runtime.py
+++ b/tests/unit/benchmarks/test_benchmark_runtime.py
@@ -70,6 +70,7 @@ def _build_args(**overrides: Any) -> argparse.Namespace:
         "strict_completion_monitor": ["on"],
         "adaptive_concurrency": ["off"],
         "process_transport": "shared_queue",
+        "route_batch_size": 1,
         "metrics_port": 0,
         "profile": False,
         "json_output": "benchmarks/results/test-runtime.json",
@@ -588,6 +589,70 @@ def test_benchmark_stats_summary_carries_process_transport_mode() -> None:
     assert summary.process_transport_mode == "worker_pipes"
 
 
+def test_benchmark_stats_summary_carries_route_batch_size() -> None:
+    stats = run_parallel_benchmark.BenchmarkStats(
+        run_name="process-run",
+        run_type="process",
+        workload="sleep",
+        ordering="key_hash",
+        topic="demo-topic",
+        route_batch_size=64,
+        target_messages=1,
+    )
+
+    stats.start()
+    assert stats._start_time is not None
+    stats.record(0.001, completed_at=stats._start_time + 0.001)
+    stats.stop()
+
+    summary = stats.summary()
+
+    assert summary.route_batch_size == 64
+
+
+def test_benchmark_stats_summary_carries_runtime_ipc_metrics() -> None:
+    stats = run_parallel_benchmark.BenchmarkStats(
+        run_name="process-run",
+        run_type="process",
+        workload="sleep",
+        ordering="key_hash",
+        topic="demo-topic",
+        process_transport_mode="worker_pipes",
+        route_batch_size=64,
+        process_batch_size=1,
+        target_messages=1,
+    )
+    process_metrics = SimpleNamespace(
+        items_per_input_ipc=2.0,
+        items_per_completion_ipc=2.0,
+        route_batch_count=1,
+        route_batch_item_count=2,
+        route_batch_size_avg=2.0,
+        route_batch_size_max=2,
+        completion_item_payload_count=0,
+        completion_batch_payload_count=1,
+    )
+
+    stats.start()
+    assert stats._start_time is not None
+    stats.record(0.001, completed_at=stats._start_time + 0.001)
+    stats.record_process_batch_metrics(process_metrics)
+    stats.stop()
+
+    summary = stats.summary()
+
+    assert summary.process_batch_size == 1
+    assert summary.route_batch_size == 64
+    assert summary.items_per_input_ipc == 2.0
+    assert summary.items_per_completion_ipc == 2.0
+    assert summary.route_batch_count == 1
+    assert summary.route_batch_item_count == 2
+    assert summary.route_batch_size_avg == 2.0
+    assert summary.route_batch_size_max == 2
+    assert summary.completion_item_payload_count == 0
+    assert summary.completion_batch_payload_count == 1
+
+
 def test_baseline_consumer_logs_effective_topic_name(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -885,6 +950,25 @@ def test_build_kafka_config_sets_process_batching_overrides() -> None:
     )
 
 
+def test_build_kafka_config_sets_route_batch_size_without_changing_process_batching() -> (
+    None
+):
+    config = pyrallel_consumer_test.build_kafka_config(
+        process_batch_size=1,
+        process_transport_mode="worker_pipes",
+        route_batch_size=64,
+    )
+
+    assert config.parallel_consumer.execution.route_batch_size == 64
+    assert config.parallel_consumer.execution.process_config.batch_size == 1
+
+
+def test_build_kafka_config_defaults_route_batch_size_to_one() -> None:
+    config = pyrallel_consumer_test.build_kafka_config()
+
+    assert config.parallel_consumer.execution.route_batch_size == 1
+
+
 def test_build_kafka_config_keeps_shared_queue_default_transport_mode() -> None:
     config = pyrallel_consumer_test.build_kafka_config()
 
@@ -1151,6 +1235,83 @@ async def test_run_pyrallel_consumer_test_passes_process_transport_mode_to_build
     )
 
     assert captured["process_transport_mode"] == "worker_pipes"
+
+
+@pytest.mark.asyncio
+async def test_run_pyrallel_consumer_test_passes_route_batch_size_to_config_and_work_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_config: dict[str, Any] = {}
+    captured_work_manager: dict[str, Any] = {}
+
+    class _FakePoller:
+        async def start(self) -> None:
+            return None
+
+        async def stop(self) -> None:
+            return None
+
+        def get_metrics(self):
+            return SimpleNamespace(
+                partitions=[SimpleNamespace(tp=TopicPartition("demo", 0))]
+            )
+
+    class _FakeConsumer:
+        async def shutdown(self) -> None:
+            return None
+
+    def _fake_build_kafka_config(**kwargs):
+        captured_config.update(kwargs)
+        config = pyrallel_consumer_test.KafkaConfig()
+        config.parallel_consumer.execution.route_batch_size = kwargs["route_batch_size"]
+        return config
+
+    def _capture_work_manager(**kwargs):
+        captured_work_manager.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        pyrallel_consumer_test,
+        "create_topic_if_not_exists",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        pyrallel_consumer_test, "build_kafka_config", _fake_build_kafka_config
+    )
+    monkeypatch.setattr(
+        pyrallel_consumer_test,
+        "ProcessExecutionEngine",
+        lambda **_kwargs: _FakeConsumer(),
+    )
+    monkeypatch.setattr(
+        pyrallel_consumer_test,
+        "WorkManager",
+        _capture_work_manager,
+    )
+    monkeypatch.setattr(
+        pyrallel_consumer_test,
+        "BrokerPoller",
+        lambda **_kwargs: _FakePoller(),
+    )
+    monkeypatch.setattr(
+        pyrallel_consumer_test,
+        "_wait_for_partition_assignment",
+        lambda *_args, **_kwargs: asyncio.sleep(0),
+    )
+
+    await pyrallel_consumer_test.run_pyrallel_consumer_test(
+        num_messages=0,
+        timeout_sec=0,
+        execution_mode="process",
+        process_worker_fn=lambda _item: None,
+        process_batch_size=1,
+        process_transport_mode="worker_pipes",
+        route_batch_size=64,
+    )
+
+    assert captured_config["route_batch_size"] == 64
+    assert captured_config["process_batch_size"] == 1
+    assert captured_work_manager["route_batch_size"] == 64
 
 
 @pytest.mark.asyncio
@@ -1425,6 +1586,62 @@ def test_run_benchmark_passes_process_transport_mode_to_process_round(
     )
 
     assert process_calls == ["worker_pipes"]
+
+
+def test_run_benchmark_passes_route_batch_size_to_process_round(
+    monkeypatch: pytest.MonkeyPatch,
+    benchmark_result: BenchmarkResult,
+) -> None:
+    process_calls: list[int] = []
+
+    monkeypatch.setattr(
+        run_parallel_benchmark, "_check_kafka_connection", lambda _bootstrap: None
+    )
+    monkeypatch.setattr(
+        run_parallel_benchmark,
+        "_select_workers",
+        lambda **_kwargs: (
+            lambda _payload: None,
+            lambda _item: None,
+            lambda _item: None,
+        ),
+    )
+    monkeypatch.setattr(run_parallel_benchmark, "_print_table", lambda _results: None)
+    monkeypatch.setattr(
+        run_parallel_benchmark,
+        "write_results_json",
+        lambda _results, _path, options=None, artifact_metadata=None: None,
+    )
+    monkeypatch.setattr(
+        run_parallel_benchmark, "reset_topics_and_groups", lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        run_parallel_benchmark,
+        "_run_baseline_round",
+        lambda **_kwargs: benchmark_result,
+    )
+
+    async def _async_round(**kwargs) -> BenchmarkResult:
+        if kwargs["mode"].value == "process":
+            process_calls.append(kwargs["route_batch_size"])
+        return benchmark_result
+
+    monkeypatch.setattr(run_parallel_benchmark, "_run_pyrparallel_round", _async_round)
+
+    run_parallel_benchmark.run_benchmark(
+        _build_args(
+            skip_async=True,
+            skip_process=False,
+            route_batch_size=64,
+        ),
+        raw_argv=[
+            "--skip-async",
+            "--route-batch-size",
+            "64",
+        ],
+    )
+
+    assert process_calls == [64]
 
 
 def test_run_benchmark_does_not_forward_process_transport_mode_to_async_round(

--- a/tests/unit/benchmarks/test_run_parallel_benchmark_tui.py
+++ b/tests/unit/benchmarks/test_run_parallel_benchmark_tui.py
@@ -111,6 +111,22 @@ def test_build_parser_accepts_process_batching_overrides() -> None:
     assert args.process_max_batch_wait_ms == 0
 
 
+def test_build_parser_accepts_route_batch_size_override() -> None:
+    parser = run_parallel_benchmark.build_parser()
+
+    args = parser.parse_args(["--route-batch-size", "64"])
+
+    assert args.route_batch_size == 64
+
+
+def test_build_parser_defaults_route_batch_size_to_one() -> None:
+    parser = run_parallel_benchmark.build_parser()
+
+    args = parser.parse_args([])
+
+    assert args.route_batch_size == 1
+
+
 def test_build_parser_accepts_process_flush_policy_overrides() -> None:
     parser = run_parallel_benchmark.build_parser()
 

--- a/tests/unit/benchmarks/test_stats.py
+++ b/tests/unit/benchmarks/test_stats.py
@@ -93,6 +93,128 @@ def test_benchmark_stats_summary_includes_release_gate_lag_gap_evidence() -> Non
     ]
 
 
+def test_benchmark_stats_summary_carries_route_batch_size_separately() -> None:
+    stats = BenchmarkStats(
+        run_name="demo-process",
+        run_type="process",
+        workload="sleep",
+        ordering="key_hash",
+        topic="demo-topic",
+        process_transport_mode="worker_pipes",
+        route_batch_size=64,
+    )
+    stats.start()
+    stats.record(0.001, completed_at=1.0)
+    stats.stop()
+
+    summary = stats.summary()
+
+    assert summary.process_transport_mode == "worker_pipes"
+    assert summary.route_batch_size == 64
+
+
+def test_write_results_json_includes_route_batch_size_field(tmp_path) -> None:
+    output_path = tmp_path / "summary.json"
+
+    write_results_json(
+        [
+            BenchmarkResult(
+                run_name="sleep-key_hash-pyrallel-process",
+                run_type="process",
+                workload="sleep",
+                ordering="key_hash",
+                topic="demo-sleep-key_hash-process",
+                process_transport_mode="worker_pipes",
+                route_batch_size=64,
+                messages_processed=100,
+                total_time_sec=1.0,
+                throughput_tps=100.0,
+                avg_processing_ms=1.0,
+                p99_processing_ms=2.0,
+            )
+        ],
+        output_path,
+        options={"process_batch_size": 1, "route_batch_size": 64},
+    )
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert payload["options"]["process_batch_size"] == 1
+    assert payload["options"]["route_batch_size"] == 64
+    assert payload["results"][0]["process_transport_mode"] == "worker_pipes"
+    assert payload["results"][0]["route_batch_size"] == 64
+
+
+def test_write_results_json_includes_nullable_route_batch_runtime_metrics(
+    tmp_path
+) -> None:
+    output_path = tmp_path / "summary.json"
+
+    write_results_json(
+        [
+            BenchmarkResult(
+                run_name="sleep-key_hash-baseline",
+                run_type="baseline",
+                workload="sleep",
+                ordering="key_hash",
+                topic="demo-sleep-key_hash-baseline",
+                messages_processed=100,
+                total_time_sec=2.0,
+                throughput_tps=50.0,
+                avg_processing_ms=1.0,
+                p99_processing_ms=2.0,
+            ),
+            BenchmarkResult(
+                run_name="sleep-key_hash-pyrallel-process",
+                run_type="process",
+                workload="sleep",
+                ordering="key_hash",
+                topic="demo-sleep-key_hash-process",
+                process_transport_mode="worker_pipes",
+                route_batch_size=64,
+                process_batch_size=1,
+                items_per_input_ipc=2.0,
+                items_per_completion_ipc=2.0,
+                route_batch_count=1,
+                route_batch_item_count=2,
+                route_batch_size_avg=2.0,
+                route_batch_size_max=2,
+                completion_item_payload_count=0,
+                completion_batch_payload_count=1,
+                messages_processed=100,
+                total_time_sec=1.0,
+                throughput_tps=100.0,
+                avg_processing_ms=1.0,
+                p99_processing_ms=2.0,
+            ),
+        ],
+        output_path,
+    )
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    baseline = payload["results"][0]
+    process = payload["results"][1]
+
+    assert baseline["items_per_input_ipc"] is None
+    assert baseline["items_per_completion_ipc"] is None
+    assert baseline["route_batch_count"] is None
+    assert baseline["route_batch_item_count"] is None
+    assert baseline["route_batch_size_avg"] is None
+    assert baseline["route_batch_size_max"] is None
+    assert baseline["completion_item_payload_count"] is None
+    assert baseline["completion_batch_payload_count"] is None
+    assert process["process_batch_size"] == 1
+    assert process["route_batch_size"] == 64
+    assert process["items_per_input_ipc"] == 2.0
+    assert process["items_per_completion_ipc"] == 2.0
+    assert process["route_batch_count"] == 1
+    assert process["route_batch_item_count"] == 2
+    assert process["route_batch_size_avg"] == 2.0
+    assert process["route_batch_size_max"] == 2
+    assert process["completion_item_payload_count"] == 0
+    assert process["completion_batch_payload_count"] == 1
+
+
 def test_write_results_json_includes_performance_improvement_analysis(tmp_path) -> None:
     output_path = tmp_path / "summary.json"
 

--- a/tests/unit/control_plane/test_broker_dispatch_support.py
+++ b/tests/unit/control_plane/test_broker_dispatch_support.py
@@ -90,6 +90,50 @@ async def test_dispatch_messages_groups_ordered_messages_and_uses_bulk_submit() 
 
 
 @pytest.mark.asyncio
+async def test_dispatch_messages_partition_mode_groups_by_partition_not_key() -> None:
+    from pyrallel_consumer.control_plane.broker_dispatch_support import (
+        BrokerDispatchSupport,
+    )
+
+    tp_0 = DtoTopicPartition(topic="test-topic", partition=0)
+    tp_1 = DtoTopicPartition(topic="test-topic", partition=1)
+    tracker_0 = _make_tracker(epoch=4)
+    tracker_1 = _make_tracker(epoch=5)
+    submit_message = AsyncMock()
+    submit_grouped_messages = AsyncMock()
+
+    support = BrokerDispatchSupport(
+        ordering_mode=OrderingMode.PARTITION,
+        offset_trackers={tp_0: tracker_0, tp_1: tracker_1},
+        cache_message_for_dlq=MagicMock(),
+        submit_message=submit_message,
+        submit_grouped_messages=submit_grouped_messages,
+        get_min_inflight_offset=lambda _tp: None,
+        logger=MagicMock(),
+    )
+
+    await support.dispatch_messages(
+        [
+            _make_message(partition=0, offset=0, key=b"key-a", value=b"payload-a"),
+            _make_message(partition=0, offset=1, key=b"key-b", value=b"payload-b"),
+            _make_message(partition=1, offset=0, key=b"key-a", value=b"payload-c"),
+        ]
+    )
+
+    submit_message.assert_not_awaited()
+    submit_grouped_messages.assert_awaited_once()
+    assert submit_grouped_messages.await_args is not None
+    grouped_messages = submit_grouped_messages.await_args.args[0]
+    assert grouped_messages == {
+        (tp_0, 0): [
+            (0, 4, b"payload-a", b"key-a"),
+            (1, 4, b"payload-b", b"key-b"),
+        ],
+        (tp_1, 1): [(0, 5, b"payload-c", b"key-a")],
+    }
+
+
+@pytest.mark.asyncio
 async def test_dispatch_messages_unordered_submits_directly_and_skips_invalid_messages() -> (
     None
 ):

--- a/tests/unit/control_plane/test_broker_poller.py
+++ b/tests/unit/control_plane/test_broker_poller.py
@@ -116,6 +116,21 @@ def test_broker_poller_wires_route_batch_size_to_fallback_work_manager(
     assert manager.call_args.kwargs["route_batch_size"] == 9
 
 
+def test_broker_poller_treats_bool_route_batch_size_as_default(
+    mock_kafka_config, mock_execution_engine
+):
+    mock_kafka_config.parallel_consumer.execution.route_batch_size = True
+
+    with patch("pyrallel_consumer.control_plane.broker_poller.WorkManager") as manager:
+        BrokerPoller(
+            consume_topic="test-topic",
+            kafka_config=mock_kafka_config,
+            execution_engine=mock_execution_engine,
+        )
+
+    assert manager.call_args.kwargs["route_batch_size"] == 1
+
+
 @pytest.mark.asyncio
 async def test_check_backpressure_updates_effective_inflight_limit_when_adaptive_enabled(
     mock_kafka_config, mock_execution_engine, mock_consumer

--- a/tests/unit/control_plane/test_broker_poller.py
+++ b/tests/unit/control_plane/test_broker_poller.py
@@ -24,6 +24,7 @@ def mock_kafka_config():
     parallel_consumer_mock = MagicMock()
     parallel_consumer_mock.poll_batch_size = 1000
     parallel_consumer_mock.worker_pool_size = 8
+    parallel_consumer_mock.execution.route_batch_size = 1
     config.parallel_consumer = parallel_consumer_mock
 
     return config
@@ -98,6 +99,21 @@ def test_broker_poller_uses_seventy_percent_resume_threshold(
     )
 
     assert poller.MIN_IN_FLIGHT_MESSAGES_TO_RESUME == 700
+
+
+def test_broker_poller_wires_route_batch_size_to_fallback_work_manager(
+    mock_kafka_config, mock_execution_engine
+):
+    mock_kafka_config.parallel_consumer.execution.route_batch_size = 9
+
+    with patch("pyrallel_consumer.control_plane.broker_poller.WorkManager") as manager:
+        BrokerPoller(
+            consume_topic="test-topic",
+            kafka_config=mock_kafka_config,
+            execution_engine=mock_execution_engine,
+        )
+
+    assert manager.call_args.kwargs["route_batch_size"] == 9
 
 
 @pytest.mark.asyncio

--- a/tests/unit/control_plane/test_transport_invariants.py
+++ b/tests/unit/control_plane/test_transport_invariants.py
@@ -17,6 +17,7 @@ ALLOWED_ENGINE_METHODS = {
     "submit",
     "submit_batch",
     "poll_completed_events",
+    "supports_ordered_route_batch",
     "wait_for_completion",
     "get_in_flight_count",
     "get_runtime_metrics",

--- a/tests/unit/control_plane/test_transport_invariants.py
+++ b/tests/unit/control_plane/test_transport_invariants.py
@@ -15,6 +15,7 @@ FORBIDDEN_TRANSPORT_TERMS = (
 )
 ALLOWED_ENGINE_METHODS = {
     "submit",
+    "submit_batch",
     "poll_completed_events",
     "wait_for_completion",
     "get_in_flight_count",

--- a/tests/unit/control_plane/test_work_manager.py
+++ b/tests/unit/control_plane/test_work_manager.py
@@ -16,7 +16,7 @@ from pyrallel_consumer.dto import (
 )
 from pyrallel_consumer.dto import TopicPartition as DtoTopicPartition
 from pyrallel_consumer.dto import WorkItem
-from pyrallel_consumer.execution_plane.base import BaseExecutionEngine
+from pyrallel_consumer.execution_plane.base import BaseExecutionEngine, BatchSubmitError
 
 
 @pytest.fixture
@@ -861,6 +861,85 @@ async def test_unordered_route_batch_truncation_does_not_stop_other_routes(
     assert submitted_offsets == [0, 2]
     assert work_manager.get_total_in_flight_count() == 2
     assert work_manager.get_total_queued_messages() == 1
+
+
+@pytest.mark.asyncio
+async def test_work_manager_batch_submit_error_accounts_only_accepted_count(
+    mock_execution_engine, mock_dto_topic_partition
+):
+    work_manager = WorkManager(
+        execution_engine=mock_execution_engine,
+        ordering_mode=OrderingMode.UNORDERED,
+        max_in_flight_messages=10,
+        route_batch_size=3,
+    )
+    tracker = OffsetTracker(
+        topic_partition=mock_dto_topic_partition,
+        starting_offset=0,
+        max_revoke_grace_ms=0,
+    )
+    work_manager.on_assign({mock_dto_topic_partition: tracker})
+    mock_execution_engine.submit_batch.side_effect = BatchSubmitError(
+        accepted_count=1,
+        original_error=RuntimeError("partial submit failed"),
+    )
+
+    await work_manager.submit_message_batch(
+        {
+            (mock_dto_topic_partition, b"route-key"): [
+                (0, tracker.get_current_epoch(), b"payload-0", b"key-0"),
+                (1, tracker.get_current_epoch(), b"payload-1", b"key-1"),
+                (2, tracker.get_current_epoch(), b"payload-2", b"key-2"),
+            ]
+        }
+    )
+
+    await work_manager.schedule()
+
+    assert mock_execution_engine.submit_batch.await_count == 1
+    assert work_manager.get_total_in_flight_count() == 1
+    assert work_manager.get_total_queued_messages() == 2
+    assert len(work_manager._dispatch_timestamps) == 1
+    dispatched_item_id = next(iter(work_manager._dispatch_timestamps))
+    assert work_manager._in_flight_work_items[dispatched_item_id].offset == 0
+
+
+@pytest.mark.asyncio
+async def test_work_manager_generic_submit_batch_exception_counts_zero_accepted(
+    mock_execution_engine, mock_dto_topic_partition
+):
+    work_manager = WorkManager(
+        execution_engine=mock_execution_engine,
+        ordering_mode=OrderingMode.UNORDERED,
+        max_in_flight_messages=10,
+        route_batch_size=3,
+    )
+    tracker = OffsetTracker(
+        topic_partition=mock_dto_topic_partition,
+        starting_offset=0,
+        max_revoke_grace_ms=0,
+    )
+    work_manager.on_assign({mock_dto_topic_partition: tracker})
+    mock_execution_engine.submit_batch.side_effect = RuntimeError(
+        "generic submit failed"
+    )
+
+    await work_manager.submit_message_batch(
+        {
+            (mock_dto_topic_partition, b"route-key"): [
+                (0, tracker.get_current_epoch(), b"payload-0", b"key-0"),
+                (1, tracker.get_current_epoch(), b"payload-1", b"key-1"),
+                (2, tracker.get_current_epoch(), b"payload-2", b"key-2"),
+            ]
+        }
+    )
+
+    await work_manager.schedule()
+
+    assert mock_execution_engine.submit_batch.await_count == 1
+    assert work_manager.get_total_in_flight_count() == 0
+    assert work_manager.get_total_queued_messages() == 3
+    assert work_manager._dispatch_timestamps == {}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/control_plane/test_work_manager.py
+++ b/tests/unit/control_plane/test_work_manager.py
@@ -56,6 +56,34 @@ def mock_dto_topic_partition_1():
     return DtoTopicPartition(topic="test-topic", partition=1)
 
 
+def _open_poison_circuit_for_key(
+    circuit: PoisonMessageCircuitBreaker,
+    tp: DtoTopicPartition,
+    poison_key: bytes,
+) -> None:
+    failed_item = WorkItem(
+        id=str(uuid.uuid4()),
+        tp=tp,
+        offset=999,
+        epoch=1,
+        key=b"route-key",
+        payload=b"failed-payload",
+        poison_key=poison_key,
+    )
+    circuit.record_completion(
+        CompletionEvent(
+            id=failed_item.id,
+            tp=failed_item.tp,
+            offset=failed_item.offset,
+            epoch=failed_item.epoch,
+            status=CompletionStatus.FAILURE,
+            error="permanent failure",
+            attempt=3,
+        ),
+        failed_item,
+    )
+
+
 @pytest.mark.asyncio
 async def test_work_manager_initialization(work_manager):
     assert isinstance(work_manager, WorkManager)
@@ -65,6 +93,17 @@ async def test_work_manager_initialization(work_manager):
     assert work_manager._in_flight_work_items == {}
     assert work_manager._current_in_flight_count == 0
     assert work_manager.get_total_queued_messages() == 0
+
+
+def test_work_manager_route_batch_size_defaults_to_one(mock_execution_engine):
+    work_manager = WorkManager(execution_engine=mock_execution_engine)
+
+    assert work_manager.get_route_batch_size() == 1
+
+
+def test_work_manager_rejects_invalid_route_batch_size(mock_execution_engine):
+    with pytest.raises(ValueError, match="route_batch_size must be >= 1"):
+        WorkManager(execution_engine=mock_execution_engine, route_batch_size=0)
 
 
 @pytest.mark.asyncio
@@ -729,6 +768,146 @@ async def test_poison_message_circuit_uses_original_key_under_partition_ordering
     assert [
         call.args[0].offset for call in mock_execution_engine.submit.await_args_list
     ] == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_unordered_route_batch_truncates_before_poison_force_fail_candidate(
+    mock_execution_engine, mock_dto_topic_partition
+):
+    poison_circuit = PoisonMessageCircuitBreaker(
+        enabled=True,
+        failure_threshold=1,
+        cooldown_ms=60000,
+        forced_failure_attempt=3,
+    )
+    _open_poison_circuit_for_key(poison_circuit, mock_dto_topic_partition, b"bad-key")
+    work_manager = WorkManager(
+        execution_engine=mock_execution_engine,
+        ordering_mode=OrderingMode.UNORDERED,
+        max_in_flight_messages=10,
+        poison_message_circuit=poison_circuit,
+        route_batch_size=3,
+    )
+    tracker = OffsetTracker(
+        topic_partition=mock_dto_topic_partition,
+        starting_offset=0,
+        max_revoke_grace_ms=0,
+    )
+    work_manager.on_assign({mock_dto_topic_partition: tracker})
+
+    await work_manager.submit_message_batch(
+        {
+            (mock_dto_topic_partition, b"route-key"): [
+                (0, tracker.get_current_epoch(), b"payload-0", b"good-key"),
+                (1, tracker.get_current_epoch(), b"payload-1", b"bad-key"),
+                (2, tracker.get_current_epoch(), b"payload-2", b"later-key"),
+            ]
+        }
+    )
+
+    await work_manager.schedule()
+
+    submitted_offsets = [
+        call.args[0].offset for call in mock_execution_engine.submit.await_args_list
+    ]
+    assert submitted_offsets == [0]
+    mock_execution_engine.submit_batch.assert_not_awaited()
+    assert work_manager.get_total_in_flight_count() == 1
+    assert work_manager.get_total_queued_messages() == 2
+
+
+@pytest.mark.asyncio
+async def test_unordered_route_batch_truncation_does_not_stop_other_routes(
+    mock_execution_engine, mock_dto_topic_partition
+):
+    poison_circuit = PoisonMessageCircuitBreaker(
+        enabled=True,
+        failure_threshold=1,
+        cooldown_ms=60000,
+        forced_failure_attempt=3,
+    )
+    _open_poison_circuit_for_key(poison_circuit, mock_dto_topic_partition, b"bad-key")
+    work_manager = WorkManager(
+        execution_engine=mock_execution_engine,
+        ordering_mode=OrderingMode.UNORDERED,
+        max_in_flight_messages=10,
+        poison_message_circuit=poison_circuit,
+        route_batch_size=3,
+    )
+    tracker = OffsetTracker(
+        topic_partition=mock_dto_topic_partition,
+        starting_offset=0,
+        max_revoke_grace_ms=0,
+    )
+    work_manager.on_assign({mock_dto_topic_partition: tracker})
+
+    await work_manager.submit_message_batch(
+        {
+            (mock_dto_topic_partition, b"route-key"): [
+                (0, tracker.get_current_epoch(), b"payload-0", b"good-key"),
+                (1, tracker.get_current_epoch(), b"payload-1", b"bad-key"),
+            ],
+            (mock_dto_topic_partition, b"other-route"): [
+                (2, tracker.get_current_epoch(), b"payload-2", b"other-key"),
+            ],
+        }
+    )
+
+    await work_manager.schedule()
+
+    submitted_offsets = [
+        call.args[0].offset for call in mock_execution_engine.submit.await_args_list
+    ]
+    assert submitted_offsets == [0, 2]
+    assert work_manager.get_total_in_flight_count() == 2
+    assert work_manager.get_total_queued_messages() == 1
+
+
+@pytest.mark.asyncio
+async def test_unordered_route_batch_first_poison_candidate_uses_forced_failure_path(
+    mock_execution_engine, mock_dto_topic_partition
+):
+    poison_circuit = PoisonMessageCircuitBreaker(
+        enabled=True,
+        failure_threshold=1,
+        cooldown_ms=60000,
+        forced_failure_attempt=3,
+    )
+    _open_poison_circuit_for_key(poison_circuit, mock_dto_topic_partition, b"bad-key")
+    work_manager = WorkManager(
+        execution_engine=mock_execution_engine,
+        ordering_mode=OrderingMode.UNORDERED,
+        max_in_flight_messages=10,
+        poison_message_circuit=poison_circuit,
+        route_batch_size=3,
+    )
+    tracker = OffsetTracker(
+        topic_partition=mock_dto_topic_partition,
+        starting_offset=0,
+        max_revoke_grace_ms=0,
+    )
+    work_manager.on_assign({mock_dto_topic_partition: tracker})
+
+    await work_manager.submit_message_batch(
+        {
+            (mock_dto_topic_partition, b"route-key"): [
+                (0, tracker.get_current_epoch(), b"payload-0", b"bad-key"),
+            ]
+        }
+    )
+
+    await work_manager.schedule()
+    completed_events = await work_manager.poll_completed_events(
+        schedule_after_release=False
+    )
+
+    mock_execution_engine.submit.assert_not_awaited()
+    mock_execution_engine.submit_batch.assert_not_awaited()
+    assert [event.offset for event in completed_events] == [0]
+    forced_event = completed_events[0]
+    assert forced_event.status == CompletionStatus.FAILURE
+    assert forced_event.attempt == 3
+    assert "Poison message circuit open" in str(forced_event.error)
 
 
 @pytest.mark.asyncio
@@ -1682,8 +1861,8 @@ async def test_on_revoke_cleans_revoked_in_flight_state(
     )
     await work_manager.schedule()
 
-    revoked_item = work_manager._execution_engine.submit.await_args_list[0].args[0]
-    kept_item = work_manager._execution_engine.submit.await_args_list[1].args[0]
+    revoked_item = mock_execution_engine.submit.await_args_list[0].args[0]
+    kept_item = mock_execution_engine.submit.await_args_list[1].args[0]
     assert work_manager._current_in_flight_count == 2
     assert (
         work_manager.get_min_in_flight_offset(mock_dto_topic_partition)
@@ -1773,7 +1952,7 @@ async def test_poll_completed_events_cleans_stale_epoch_in_flight_state(
     )
     await work_manager.schedule()
 
-    submitted_item = work_manager._execution_engine.submit.await_args_list[0].args[0]
+    submitted_item = mock_execution_engine.submit.await_args_list[0].args[0]
     assert work_manager._current_in_flight_count == 1
     assert (
         work_manager.get_min_in_flight_offset(mock_dto_topic_partition)
@@ -1826,7 +2005,7 @@ async def test_poll_completed_events_cleans_any_stale_epoch_for_tracked_work_ite
     )
     await work_manager.schedule()
 
-    submitted_item = work_manager._execution_engine.submit.await_args_list[0].args[0]
+    submitted_item = mock_execution_engine.submit.await_args_list[0].args[0]
 
     stale_completion = CompletionEvent(
         id=submitted_item.id,
@@ -1869,7 +2048,7 @@ async def test_stale_completion_after_reassign_does_not_touch_new_epoch_state(
         mock_dto_topic_partition, 10, old_tracker.get_current_epoch(), b"key-A", b"v1"
     )
     await work_manager.schedule()
-    old_item = work_manager._execution_engine.submit.await_args_list[0].args[0]
+    old_item = mock_execution_engine.submit.await_args_list[0].args[0]
 
     work_manager.on_revoke([mock_dto_topic_partition])
 
@@ -1886,7 +2065,7 @@ async def test_stale_completion_after_reassign_does_not_touch_new_epoch_state(
         mock_dto_topic_partition, 11, new_tracker.get_current_epoch(), b"key-A", b"v2"
     )
     await work_manager.schedule()
-    new_item = work_manager._execution_engine.submit.await_args_list[1].args[0]
+    new_item = mock_execution_engine.submit.await_args_list[1].args[0]
 
     stale_completion = CompletionEvent(
         id=old_item.id,

--- a/tests/unit/control_plane/test_work_manager.py
+++ b/tests/unit/control_plane/test_work_manager.py
@@ -106,6 +106,11 @@ def test_work_manager_rejects_invalid_route_batch_size(mock_execution_engine):
         WorkManager(execution_engine=mock_execution_engine, route_batch_size=0)
 
 
+def test_work_manager_rejects_bool_route_batch_size(mock_execution_engine):
+    with pytest.raises(ValueError, match="route_batch_size must be >= 1"):
+        WorkManager(execution_engine=mock_execution_engine, route_batch_size=True)
+
+
 @pytest.mark.asyncio
 async def test_on_assign_uses_configured_max_revoke_grace_ms(
     mock_execution_engine, mock_dto_topic_partition

--- a/tests/unit/control_plane/test_work_manager_ordering.py
+++ b/tests/unit/control_plane/test_work_manager_ordering.py
@@ -47,6 +47,121 @@ def _setup_wm(engine, tp, ordering_mode, max_in_flight=100):
     return wm, tracker
 
 
+class _PartiallyFailingBatchEngine(BaseExecutionEngine):
+    def __init__(self, fail_offset: int) -> None:
+        self.fail_offset = fail_offset
+        self.submitted_offsets: list[int] = []
+
+    async def submit(self, work_item) -> None:
+        self.submitted_offsets.append(work_item.offset)
+        if work_item.offset == self.fail_offset:
+            raise RuntimeError("submit failed")
+
+    async def poll_completed_events(self, batch_limit: int = 1000):
+        return []
+
+    async def wait_for_completion(self, timeout_seconds=None) -> bool:
+        return True
+
+    def get_in_flight_count(self) -> int:
+        return 0
+
+    async def shutdown(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_key_hash_route_batching_is_deferred_until_engine_batches_are_ordering_safe(
+    mock_engine, tp
+):
+    wm, tracker = _setup_wm(
+        mock_engine,
+        tp,
+        OrderingMode.KEY_HASH,
+        max_in_flight=10,
+    )
+    wm._route_batch_size = 3
+
+    await wm.submit_message(tp, 0, 1, b"key-A", b"payload-0")
+    await wm.submit_message(tp, 1, 1, b"key-A", b"payload-1")
+    await wm.submit_message(tp, 2, 1, b"key-A", b"payload-2")
+
+    await wm.schedule()
+
+    assert mock_engine.submit.await_count == 1
+    mock_engine.submit_batch.assert_not_awaited()
+    submitted_item = mock_engine.submit.await_args.args[0]
+    assert submitted_item.offset == 0
+    assert wm.get_total_in_flight_count() == 1
+    assert wm.get_total_queued_messages() == 2
+
+
+@pytest.mark.asyncio
+async def test_unordered_route_batch_respects_remaining_in_flight_capacity(
+    mock_engine, tp
+):
+    wm, tracker = _setup_wm(mock_engine, tp, OrderingMode.UNORDERED, max_in_flight=2)
+    wm._route_batch_size = 5
+
+    await wm.submit_message(tp, 0, 1, b"key-A", b"payload-0")
+    await wm.submit_message(tp, 1, 1, b"key-A", b"payload-1")
+    await wm.submit_message(tp, 2, 1, b"key-A", b"payload-2")
+
+    await wm.schedule()
+
+    batch = mock_engine.submit_batch.await_args.args[0]
+    assert [item.offset for item in batch] == [0, 1]
+    assert wm.get_total_in_flight_count() == 2
+    assert wm.get_total_queued_messages() == 1
+
+
+@pytest.mark.asyncio
+async def test_unordered_route_batch_tracks_items_accepted_before_later_submit_failure(
+    tp,
+):
+    engine = _PartiallyFailingBatchEngine(fail_offset=1)
+    wm, tracker = _setup_wm(engine, tp, OrderingMode.UNORDERED, max_in_flight=10)
+    wm._route_batch_size = 3
+
+    await wm.submit_message(tp, 0, 1, b"key-A", b"payload-0")
+    await wm.submit_message(tp, 1, 1, b"key-A", b"payload-1")
+    await wm.submit_message(tp, 2, 1, b"key-A", b"payload-2")
+
+    await wm.schedule()
+
+    assert engine.submitted_offsets == [0, 1]
+    assert wm.get_total_in_flight_count() == 1
+    assert wm.get_total_queued_messages() == 2
+
+
+@pytest.mark.asyncio
+async def test_route_batch_size_one_preserves_item_submit_path(mock_engine, tp):
+    wm, tracker = _setup_wm(mock_engine, tp, OrderingMode.KEY_HASH, max_in_flight=10)
+    wm._route_batch_size = 1
+
+    await wm.submit_message(tp, 0, 1, b"key-A", b"payload-0")
+    await wm.submit_message(tp, 1, 1, b"key-A", b"payload-1")
+
+    await wm.schedule()
+
+    assert mock_engine.submit.await_count == 1
+    mock_engine.submit_batch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_partition_mode_defers_cross_key_route_batching_for_now(mock_engine, tp):
+    wm, tracker = _setup_wm(mock_engine, tp, OrderingMode.PARTITION, max_in_flight=10)
+    wm._route_batch_size = 3
+
+    await wm.submit_message(tp, 0, 1, b"key-A", b"payload-0")
+    await wm.submit_message(tp, 1, 1, b"key-B", b"payload-1")
+
+    await wm.schedule()
+
+    assert mock_engine.submit.await_count == 1
+    mock_engine.submit_batch.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_key_hash_blocks_same_key_concurrent(mock_engine, tp):
     """KEY_HASH: second item with same key must NOT be submitted while first is in-flight."""

--- a/tests/unit/control_plane/test_work_manager_ordering.py
+++ b/tests/unit/control_plane/test_work_manager_ordering.py
@@ -70,6 +70,46 @@ class _PartiallyFailingBatchEngine(BaseExecutionEngine):
         return None
 
 
+class _OrderedRouteBatchEngine(BaseExecutionEngine):
+    def __init__(self) -> None:
+        self.submitted_offsets: list[int] = []
+        self.submitted_batches: list[list[int]] = []
+
+    @property
+    def supports_ordered_route_batch(self) -> bool:
+        return True
+
+    async def submit(self, work_item) -> None:
+        self.submitted_offsets.append(work_item.offset)
+
+    async def submit_batch(self, work_items) -> None:
+        self.submitted_batches.append([item.offset for item in work_items])
+
+    async def poll_completed_events(self, batch_limit: int = 1000):
+        return []
+
+    async def wait_for_completion(self, timeout_seconds=None) -> bool:
+        return True
+
+    def get_in_flight_count(self) -> int:
+        return 0
+
+    async def shutdown(self) -> None:
+        return None
+
+
+class _ScriptedOrderedRouteBatchEngine(_OrderedRouteBatchEngine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.completion_batches: list[list[CompletionEvent]] = []
+
+    async def poll_completed_events(self, batch_limit: int = 1000):
+        del batch_limit
+        if not self.completion_batches:
+            return []
+        return self.completion_batches.pop(0)
+
+
 @pytest.mark.asyncio
 async def test_key_hash_route_batching_is_deferred_until_engine_batches_are_ordering_safe(
     mock_engine, tp
@@ -94,6 +134,134 @@ async def test_key_hash_route_batching_is_deferred_until_engine_batches_are_orde
     assert submitted_item.offset == 0
     assert wm.get_total_in_flight_count() == 1
     assert wm.get_total_queued_messages() == 2
+
+
+@pytest.mark.asyncio
+async def test_partition_route_batching_is_deferred_without_engine_capability(
+    mock_engine, tp
+):
+    wm, tracker = _setup_wm(
+        mock_engine,
+        tp,
+        OrderingMode.PARTITION,
+        max_in_flight=10,
+    )
+    wm._route_batch_size = 3
+
+    await wm.submit_message(tp, 0, 1, b"key-A", b"payload-0")
+    await wm.submit_message(tp, 1, 1, b"key-A", b"payload-1")
+    await wm.submit_message(tp, 2, 1, b"key-A", b"payload-2")
+
+    await wm.schedule()
+
+    assert mock_engine.submit.await_count == 1
+    mock_engine.submit_batch.assert_not_awaited()
+    submitted_item = mock_engine.submit.await_args.args[0]
+    assert submitted_item.offset == 0
+    assert wm.get_total_in_flight_count() == 1
+    assert wm.get_total_queued_messages() == 2
+
+
+@pytest.mark.asyncio
+async def test_key_hash_supported_engine_batches_to_route_size_and_capacity(tp):
+    engine = _OrderedRouteBatchEngine()
+    wm, tracker = _setup_wm(engine, tp, OrderingMode.KEY_HASH, max_in_flight=2)
+    wm._route_batch_size = 3
+
+    await wm.submit_message(tp, 0, 1, b"key-A", b"payload-0")
+    await wm.submit_message(tp, 1, 1, b"key-A", b"payload-1")
+    await wm.submit_message(tp, 2, 1, b"key-A", b"payload-2")
+
+    await wm.schedule()
+
+    assert engine.submitted_offsets == []
+    assert engine.submitted_batches == [[0, 1]]
+    assert wm.get_total_in_flight_count() == 2
+    assert wm.get_total_queued_messages() == 1
+
+
+@pytest.mark.asyncio
+async def test_partition_supported_engine_batches_to_route_size_and_capacity(tp):
+    engine = _OrderedRouteBatchEngine()
+    wm, tracker = _setup_wm(engine, tp, OrderingMode.PARTITION, max_in_flight=2)
+    wm._route_batch_size = 3
+
+    await wm.submit_message(tp, 0, 1, b"key-A", b"payload-0")
+    await wm.submit_message(tp, 1, 1, b"key-A", b"payload-1")
+    await wm.submit_message(tp, 2, 1, b"key-A", b"payload-2")
+
+    await wm.schedule()
+
+    assert engine.submitted_offsets == []
+    assert engine.submitted_batches == [[0, 1]]
+    assert wm.get_total_in_flight_count() == 2
+    assert wm.get_total_queued_messages() == 1
+
+
+@pytest.mark.asyncio
+async def test_key_hash_route_batch_tail_completion_releases_ordering_lock(tp):
+    engine = _ScriptedOrderedRouteBatchEngine()
+    wm, tracker = _setup_wm(engine, tp, OrderingMode.KEY_HASH, max_in_flight=3)
+    wm._route_batch_size = 3
+
+    await wm.submit_message(tp, 0, 1, b"key-A", b"payload-0")
+    await wm.submit_message(tp, 1, 1, b"key-A", b"payload-1")
+    await wm.submit_message(tp, 2, 1, b"key-A", b"payload-2")
+    await wm.submit_message(tp, 3, 1, b"key-A", b"payload-3")
+
+    await wm.schedule()
+    submitted_batch = list(wm._in_flight_work_items.values())
+    by_offset = {item.offset: item for item in submitted_batch}
+
+    engine.completion_batches.append(
+        [
+            CompletionEvent(
+                id=by_offset[0].id,
+                tp=tp,
+                offset=0,
+                epoch=1,
+                status=CompletionStatus.SUCCESS,
+                error=None,
+                attempt=1,
+            ),
+            CompletionEvent(
+                id=by_offset[1].id,
+                tp=tp,
+                offset=1,
+                epoch=1,
+                status=CompletionStatus.FAILURE,
+                error="boom",
+                attempt=1,
+            ),
+        ]
+    )
+
+    await wm.poll_completed_events()
+
+    assert engine.submitted_batches == [[0, 1, 2]]
+    assert wm.get_total_in_flight_count() == 1
+    assert wm.get_total_queued_messages() == 1
+
+    engine.completion_batches.append(
+        [
+            CompletionEvent(
+                id=by_offset[2].id,
+                tp=tp,
+                offset=2,
+                epoch=1,
+                status=CompletionStatus.SUCCESS,
+                error=None,
+                attempt=1,
+            )
+        ]
+    )
+
+    await wm.poll_completed_events()
+
+    assert engine.submitted_batches == [[0, 1, 2]]
+    assert engine.submitted_offsets == [3]
+    assert wm.get_total_in_flight_count() == 1
+    assert wm.get_total_queued_messages() == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/control_plane/test_work_queue_topology.py
+++ b/tests/unit/control_plane/test_work_queue_topology.py
@@ -1,11 +1,24 @@
 """Tests for WorkManager queue topology extraction."""
 
 
+import asyncio
+
 import pytest
 
 from pyrallel_consumer.dto import OffsetRange
 from pyrallel_consumer.dto import TopicPartition as DtoTopicPartition
 from pyrallel_consumer.dto import WorkItem
+
+
+class _FailingAfterLimitQueue:
+    def __init__(self, items: list[WorkItem], limit: int) -> None:
+        self._items = items
+        self._limit = limit
+
+    def __getitem__(self, index: int) -> WorkItem:
+        if index >= self._limit:
+            raise AssertionError("peek_queue_batch should not read past limit")
+        return self._items[index]
 
 
 def _make_item(tp: DtoTopicPartition, offset: int, key: object) -> WorkItem:
@@ -41,6 +54,23 @@ async def test_topology_enqueue_batch_tracks_head_and_active_queue_key() -> None
     assert topology.head_queue_keys_by_offset[(tp, 7)] == queue_key
     assert queue_key in topology.active_runnable_queue_keys
     assert topology.runnable_queue_keys.count(queue_key) == 1
+
+
+def test_topology_peek_queue_batch_only_reads_to_limit() -> None:
+    from pyrallel_consumer.control_plane.work_queue_topology import WorkQueueTopology
+
+    tp = DtoTopicPartition(topic="test-topic", partition=0)
+    items = [
+        _make_item(tp, 1, b"key-a"),
+        _make_item(tp, 2, b"key-a"),
+        _make_item(tp, 3, b"key-a"),
+    ]
+    queue = object.__new__(asyncio.Queue)
+    queue._queue = _FailingAfterLimitQueue(items, limit=2)  # type: ignore[attr-defined]
+
+    batch = WorkQueueTopology.peek_queue_batch(queue, 2)
+
+    assert [item.offset for item in batch] == [1, 2]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/execution_plane/test_base_execution_engine.py
+++ b/tests/unit/execution_plane/test_base_execution_engine.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 
 from pyrallel_consumer.dto import CompletionEvent, TopicPartition, WorkItem
-from pyrallel_consumer.execution_plane.base import BaseExecutionEngine
+from pyrallel_consumer.execution_plane.base import BaseExecutionEngine, BatchSubmitError
 
 
 class ConcreteExecutionEngine(BaseExecutionEngine):
@@ -26,6 +26,17 @@ class ConcreteExecutionEngine(BaseExecutionEngine):
 
     async def shutdown(self) -> None:
         pass
+
+
+class FailingSecondSubmitEngine(ConcreteExecutionEngine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.original_error = RuntimeError("submit-two-failed")
+
+    async def submit(self, work_item: WorkItem) -> None:
+        if len(self.submitted_work_items) == 1:
+            raise self.original_error
+        await super().submit(work_item)
 
 
 class IncompleteExecutionEngine(BaseExecutionEngine):
@@ -74,6 +85,12 @@ def test_base_execution_engine_min_inflight_offset_defaults_to_none():
     )
 
 
+def test_base_execution_engine_ordered_route_batch_capability_defaults_to_false():
+    engine = ConcreteExecutionEngine()
+
+    assert engine.supports_ordered_route_batch is False
+
+
 @pytest.mark.asyncio
 async def test_submit_batch_fallback_submits_each_work_item_in_order():
     engine = ConcreteExecutionEngine()
@@ -97,3 +114,62 @@ async def test_submit_batch_fallback_submits_each_work_item_in_order():
     await engine.submit_batch([first, second])
 
     assert engine.submitted_work_items == [first, second]
+
+
+@pytest.mark.asyncio
+async def test_submit_batch_fallback_atomic_or_batch_submit_error_reports_accepted_prefix():
+    engine = FailingSecondSubmitEngine()
+    first = WorkItem(
+        id="work-1",
+        tp=TopicPartition(topic="test", partition=0),
+        offset=1,
+        epoch=0,
+        key="key-1",
+        payload=b"payload-1",
+    )
+    second = WorkItem(
+        id="work-2",
+        tp=TopicPartition(topic="test", partition=0),
+        offset=2,
+        epoch=0,
+        key="key-1",
+        payload=b"payload-2",
+    )
+
+    with pytest.raises(BatchSubmitError) as excinfo:
+        await engine.submit_batch([first, second])
+
+    assert excinfo.value.accepted_count == 1
+    assert engine.submitted_work_items == [first]
+
+
+@pytest.mark.asyncio
+async def test_batch_submit_error_preserves_original_exception():
+    engine = FailingSecondSubmitEngine()
+    first = WorkItem(
+        id="work-1",
+        tp=TopicPartition(topic="test", partition=0),
+        offset=1,
+        epoch=0,
+        key="key-1",
+        payload=b"payload-1",
+    )
+    second = WorkItem(
+        id="work-2",
+        tp=TopicPartition(topic="test", partition=0),
+        offset=2,
+        epoch=0,
+        key="key-1",
+        payload=b"payload-2",
+    )
+
+    with pytest.raises(BatchSubmitError) as excinfo:
+        await engine.submit_batch([first, second])
+
+    assert excinfo.value.original_error is engine.original_error
+
+
+def test_submit_batch_docstring_names_atomic_or_batch_submit_error_contract():
+    assert BaseExecutionEngine.submit_batch.__doc__ is not None
+    assert "atomic" in BaseExecutionEngine.submit_batch.__doc__
+    assert "BatchSubmitError" in BaseExecutionEngine.submit_batch.__doc__

--- a/tests/unit/execution_plane/test_base_execution_engine.py
+++ b/tests/unit/execution_plane/test_base_execution_engine.py
@@ -7,8 +7,11 @@ from pyrallel_consumer.execution_plane.base import BaseExecutionEngine
 
 
 class ConcreteExecutionEngine(BaseExecutionEngine):
+    def __init__(self) -> None:
+        self.submitted_work_items: list[WorkItem] = []
+
     async def submit(self, work_item: WorkItem) -> None:
-        pass
+        self.submitted_work_items.append(work_item)
 
     async def poll_completed_events(
         self, batch_limit: int = 1000
@@ -40,9 +43,13 @@ class IncompleteExecutionEngine(BaseExecutionEngine):
     # get_in_flight_count and shutdown are intentionally not implemented
 
 
+def _instantiate_engine(engine_type: type[object]) -> object:
+    return engine_type()
+
+
 def test_incomplete_execution_engine_raises_type_error():
     with pytest.raises(TypeError) as excinfo:
-        IncompleteExecutionEngine()
+        _instantiate_engine(IncompleteExecutionEngine)
     assert (
         "Can't instantiate abstract class IncompleteExecutionEngine without an "
         "implementation for abstract methods 'get_in_flight_count', 'shutdown'"
@@ -65,3 +72,28 @@ def test_base_execution_engine_min_inflight_offset_defaults_to_none():
         engine.get_min_inflight_offset(TopicPartition(topic="test", partition=0))
         is None
     )
+
+
+@pytest.mark.asyncio
+async def test_submit_batch_fallback_submits_each_work_item_in_order():
+    engine = ConcreteExecutionEngine()
+    first = WorkItem(
+        id="work-1",
+        tp=TopicPartition(topic="test", partition=0),
+        offset=1,
+        epoch=0,
+        key="key-1",
+        payload=b"payload-1",
+    )
+    second = WorkItem(
+        id="work-2",
+        tp=TopicPartition(topic="test", partition=0),
+        offset=2,
+        epoch=0,
+        key="key-1",
+        payload=b"payload-2",
+    )
+
+    await engine.submit_batch([first, second])
+
+    assert engine.submitted_work_items == [first, second]

--- a/tests/unit/execution_plane/test_execution_engine_contract.py
+++ b/tests/unit/execution_plane/test_execution_engine_contract.py
@@ -13,6 +13,7 @@ from pyrallel_consumer.execution_plane.base import BaseExecutionEngine
 
 ALLOWED_ENGINE_CONTRACT_METHODS = {
     "submit",
+    "submit_batch",
     "poll_completed_events",
     "wait_for_completion",
     "get_in_flight_count",

--- a/tests/unit/execution_plane/test_process_engine_batching.py
+++ b/tests/unit/execution_plane/test_process_engine_batching.py
@@ -24,8 +24,12 @@ from pyrallel_consumer.execution_plane import process_engine
 from pyrallel_consumer.execution_plane.process_codec import (
     batch_completion_from_dict,
     batch_completion_to_dict,
+    decode_batch_completion_payload,
+    decode_worker_pipe_payload,
     route_batch_from_dict,
     route_batch_to_dict,
+    serialize_batch_completion_payload,
+    serialize_worker_pipe_payload,
 )
 from pyrallel_consumer.execution_plane.process_engine import (
     ProcessExecutionEngine,
@@ -60,6 +64,74 @@ def _make_work_item(offset: int, partition: int = 0, topic: str = "test") -> Wor
     )
 
 
+def _make_completion_event(
+    offset: int,
+    *,
+    status: CompletionStatus = CompletionStatus.SUCCESS,
+    error: str | None = None,
+    attempt: int = 1,
+    partition: int = 0,
+    topic: str = "test",
+) -> CompletionEvent:
+    return CompletionEvent(
+        id=f"wi-{offset}",
+        tp=TopicPartition(topic, partition),
+        offset=offset,
+        epoch=1,
+        status=status,
+        error=error,
+        attempt=attempt,
+    )
+
+
+def _make_unstarted_process_engine(raw_events: list[bytes]) -> ProcessExecutionEngine:
+    engine = cast(
+        ProcessExecutionEngine,
+        ProcessExecutionEngine.__new__(ProcessExecutionEngine),
+    )
+    completion_queue: queue.Queue[bytes] = queue.Queue()
+    for raw_event in raw_events:
+        completion_queue.put_nowait(raw_event)
+    engine._workers = []
+    engine._prefetched_completion_events = deque()
+    engine._completion_queue = cast(Any, completion_queue)
+    engine._registry_event_queue = cast(Any, None)
+    engine._in_flight_lock = threading.Lock()
+    engine._in_flight_count = 0
+    engine._in_flight_registry = {}
+    engine._config = ExecutionConfig(
+        mode="process",
+        process_config=ProcessConfig(process_count=1, queue_size=16),
+    )
+    engine._is_shutdown = False
+
+    def _noop_ensure_workers_alive(force: bool = False) -> None:
+        del force
+
+    def _noop_drain_registry_events() -> None:
+        return None
+
+    engine._ensure_workers_alive = _noop_ensure_workers_alive  # type: ignore[method-assign]
+    engine._drain_registry_events = _noop_drain_registry_events  # type: ignore[method-assign]
+    return engine
+
+
+def _make_decode_only_process_engine(max_bytes: int) -> ProcessExecutionEngine:
+    engine = cast(
+        ProcessExecutionEngine,
+        ProcessExecutionEngine.__new__(ProcessExecutionEngine),
+    )
+    engine._config = ExecutionConfig(
+        mode="process",
+        process_config=ProcessConfig(
+            process_count=1,
+            queue_size=16,
+            msgpack_max_bytes=max_bytes,
+        ),
+    )
+    return engine
+
+
 def test_route_batch_wire_contract_preserves_identity_and_item_order() -> None:
     route_batch = RouteBatch(
         batch_id="batch-1",
@@ -80,6 +152,54 @@ def test_route_batch_wire_contract_preserves_identity_and_item_order() -> None:
         ("test", 0, 0),
         ("test", 0, 1),
     ]
+
+
+@pytest.mark.parametrize("missing_field", ["batch_id", "route_identity", "items"])
+def test_route_batch_from_dict_rejects_missing_required_fields(
+    missing_field: str,
+) -> None:
+    payload = route_batch_to_dict(
+        RouteBatch(
+            batch_id="batch-required",
+            route_identity=("test", 0, b"key-a"),
+            worker_index=1,
+            items=[_make_work_item(0)],
+        )
+    )
+    payload.pop(missing_field)
+
+    with pytest.raises(ValueError, match="invalid_route_batch"):
+        route_batch_from_dict(payload)
+
+
+def test_route_batch_from_dict_rejects_non_list_items() -> None:
+    payload = route_batch_to_dict(
+        RouteBatch(
+            batch_id="batch-items",
+            route_identity=("test", 0, b"key-a"),
+            worker_index=1,
+            items=[_make_work_item(0)],
+        )
+    )
+    payload["items"] = {"offset": 0}
+
+    with pytest.raises(ValueError, match="invalid_route_batch"):
+        route_batch_from_dict(payload)
+
+
+def test_route_batch_from_dict_rejects_empty_items() -> None:
+    payload = route_batch_to_dict(
+        RouteBatch(
+            batch_id="batch-empty",
+            route_identity=("test", 0, b"key-a"),
+            worker_index=1,
+            items=[_make_work_item(0)],
+        )
+    )
+    payload["items"] = []
+
+    with pytest.raises(ValueError, match="invalid_route_batch"):
+        route_batch_from_dict(payload)
 
 
 def test_batch_completion_wire_contract_preserves_item_results() -> None:
@@ -119,6 +239,349 @@ def test_batch_completion_wire_contract_preserves_item_results() -> None:
     ]
     assert decoded.results[1].error == "boom"
     assert decoded.results[1].attempt == 3
+
+
+@pytest.mark.parametrize("missing_field", ["batch_id", "route_identity", "results"])
+def test_batch_completion_from_dict_rejects_missing_required_fields(
+    missing_field: str,
+) -> None:
+    payload = batch_completion_to_dict(
+        BatchCompletion(
+            batch_id="batch-required",
+            route_identity=("test", 0, b"key-a"),
+            results=[_make_completion_event(0)],
+        )
+    )
+    payload.pop(missing_field)
+
+    with pytest.raises(ValueError, match="invalid_batch_completion"):
+        batch_completion_from_dict(payload)
+
+
+def test_batch_completion_from_dict_rejects_non_list_results() -> None:
+    payload = batch_completion_to_dict(
+        BatchCompletion(
+            batch_id="batch-results",
+            route_identity=("test", 0, b"key-a"),
+            results=[_make_completion_event(0)],
+        )
+    )
+    payload["results"] = {"offset": 0}
+
+    with pytest.raises(ValueError, match="invalid_batch_completion"):
+        batch_completion_from_dict(payload)
+
+
+def test_batch_completion_from_dict_rejects_empty_results() -> None:
+    payload = batch_completion_to_dict(
+        BatchCompletion(
+            batch_id="batch-empty",
+            route_identity=("test", 0, b"key-a"),
+            results=[_make_completion_event(0)],
+        )
+    )
+    payload["results"] = []
+
+    with pytest.raises(ValueError, match="invalid_batch_completion"):
+        batch_completion_from_dict(payload)
+
+
+def test_batch_completion_envelope_roundtrip_preserves_prefix_result_order() -> None:
+    completion = BatchCompletion(
+        batch_id="batch-envelope",
+        route_identity=("topic", 0, b"key-a"),
+        results=[
+            CompletionEvent(
+                id="wi-0",
+                tp=TopicPartition("test", 0),
+                offset=0,
+                epoch=1,
+                status=CompletionStatus.SUCCESS,
+                error=None,
+                attempt=1,
+            ),
+            CompletionEvent(
+                id="wi-1",
+                tp=TopicPartition("test", 0),
+                offset=1,
+                epoch=1,
+                status=CompletionStatus.FAILURE,
+                error="boom",
+                attempt=2,
+            ),
+        ],
+    )
+
+    decoded_payload = decode_batch_completion_payload(
+        serialize_batch_completion_payload(completion, completion_enqueued_at=4.5),
+        max_bytes=4096,
+    )
+    decoded = batch_completion_from_dict(decoded_payload["completion"])
+
+    assert decoded_payload["kind"] == "batch_completion"
+    assert decoded_payload["timing"] == {"completion_enqueued_at": 4.5}
+    assert decoded.batch_id == "batch-envelope"
+    assert decoded.route_identity == ("topic", 0, b"key-a")
+    assert [
+        (event.id, event.offset, event.status, event.error, event.attempt)
+        for event in decoded.results
+    ] == [
+        ("wi-0", 0, CompletionStatus.SUCCESS, None, 1),
+        ("wi-1", 1, CompletionStatus.FAILURE, "boom", 2),
+    ]
+
+
+def test_decode_completion_queue_item_events_rejects_oversized_raw_bytes_before_unpack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _make_decode_only_process_engine(max_bytes=2)
+
+    def fail_unpack(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("msgpack.unpackb should not run for oversized bytes")
+
+    monkeypatch.setattr(process_engine.msgpack, "unpackb", fail_unpack)
+
+    with pytest.raises(ValueError, match="payload_too_large"):
+        engine._decode_completion_queue_item_events(b"012345")
+
+
+def test_decode_completion_queue_item_events_rejects_oversized_item_completion_bytes() -> (
+    None
+):
+    event = _make_completion_event(7)
+    raw_event = msgpack.packb(_completion_event_to_dict(event), use_bin_type=True)
+    engine = _make_decode_only_process_engine(max_bytes=len(raw_event) - 1)
+
+    with pytest.raises(ValueError, match="payload_too_large"):
+        engine._decode_completion_queue_item_events(raw_event)
+
+
+def test_decode_completion_queue_item_events_rejects_oversized_batch_completion_bytes() -> (
+    None
+):
+    completion = BatchCompletion(
+        batch_id="batch-too-large",
+        route_identity=("test", 0, b"key-a"),
+        results=[_make_completion_event(0)],
+    )
+    raw_event = serialize_batch_completion_payload(
+        completion,
+        completion_enqueued_at=1.0,
+    )
+    engine = _make_decode_only_process_engine(max_bytes=len(raw_event) - 1)
+
+    with pytest.raises(ValueError, match="payload_too_large"):
+        engine._decode_completion_queue_item_events(raw_event)
+
+
+@pytest.mark.asyncio
+async def test_parent_poll_expands_batch_completion_to_item_events() -> None:
+    batch_completion = BatchCompletion(
+        batch_id="batch-parent",
+        route_identity=("test", 0, b"key-a"),
+        results=[_make_completion_event(0), _make_completion_event(1)],
+    )
+    engine = _make_unstarted_process_engine(
+        [
+            serialize_batch_completion_payload(
+                batch_completion, completion_enqueued_at=1.0
+            )
+        ]
+    )
+    engine._in_flight_count = 2
+
+    events = await engine.poll_completed_events()
+
+    assert [(event.id, event.offset, event.status) for event in events] == [
+        ("wi-0", 0, CompletionStatus.SUCCESS),
+        ("wi-1", 1, CompletionStatus.SUCCESS),
+    ]
+    assert engine.get_in_flight_count() == 0
+    runtime_metrics = engine.get_runtime_metrics()
+    assert runtime_metrics is not None
+    assert runtime_metrics.process is not None
+    process_metrics = runtime_metrics.process.batch_metrics
+    assert process_metrics.completion_batch_payload_count == 1
+    assert process_metrics.completion_item_payload_count == 0
+    assert process_metrics.items_per_completion_ipc == 2.0
+
+
+@pytest.mark.asyncio
+async def test_parent_poll_preserves_batch_completion_failure_result_fields() -> None:
+    batch_completion = BatchCompletion(
+        batch_id="batch-parent-failure",
+        route_identity=("test", 0, b"key-a"),
+        results=[
+            _make_completion_event(0),
+            _make_completion_event(
+                1,
+                status=CompletionStatus.FAILURE,
+                error="qa-fail",
+                attempt=3,
+            ),
+        ],
+    )
+    engine = _make_unstarted_process_engine(
+        [
+            serialize_batch_completion_payload(
+                batch_completion, completion_enqueued_at=1.0
+            )
+        ]
+    )
+    engine._in_flight_count = 2
+
+    events = await engine.poll_completed_events()
+
+    assert [
+        (event.offset, event.status, event.error, event.attempt) for event in events
+    ] == [
+        (0, CompletionStatus.SUCCESS, None, 1),
+        (1, CompletionStatus.FAILURE, "qa-fail", 3),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_parent_poll_batch_limit_counts_expanded_item_events() -> None:
+    batch_completion = BatchCompletion(
+        batch_id="batch-parent-limit",
+        route_identity=("test", 0, b"key-a"),
+        results=[_make_completion_event(0), _make_completion_event(1)],
+    )
+    engine = _make_unstarted_process_engine(
+        [
+            serialize_batch_completion_payload(
+                batch_completion, completion_enqueued_at=1.0
+            )
+        ]
+    )
+    engine._in_flight_count = 2
+
+    first_poll = await engine.poll_completed_events(batch_limit=1)
+    second_poll = await engine.poll_completed_events(batch_limit=1)
+
+    assert [event.offset for event in first_poll] == [0]
+    assert [event.offset for event in second_poll] == [1]
+    assert engine.get_in_flight_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_parent_poll_suppresses_duplicate_item_completion_after_batch_envelope() -> (
+    None
+):
+    duplicate_event = _make_completion_event(0)
+    batch_completion = BatchCompletion(
+        batch_id="batch-parent-dedupe",
+        route_identity=("test", 0, b"key-a"),
+        results=[duplicate_event],
+    )
+    engine = _make_unstarted_process_engine(
+        [
+            serialize_batch_completion_payload(
+                batch_completion, completion_enqueued_at=1.0
+            ),
+            msgpack.packb(
+                _completion_event_to_dict(duplicate_event), use_bin_type=True
+            ),
+        ]
+    )
+    engine._in_flight_count = 1
+
+    events = await engine.poll_completed_events()
+
+    assert [(event.id, event.offset) for event in events] == [("wi-0", 0)]
+    assert engine.get_in_flight_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_parent_poll_does_not_invent_completion_for_skipped_batch_tail() -> None:
+    batch_completion = BatchCompletion(
+        batch_id="batch-parent-prefix",
+        route_identity=("test", 0, b"key-a"),
+        results=[_make_completion_event(0), _make_completion_event(1)],
+    )
+    engine = _make_unstarted_process_engine(
+        [
+            serialize_batch_completion_payload(
+                batch_completion, completion_enqueued_at=1.0
+            )
+        ]
+    )
+    engine._in_flight_count = 2
+
+    events = await engine.poll_completed_events()
+
+    assert [event.offset for event in events] == [0, 1]
+    assert 2 not in [event.offset for event in events]
+
+
+@pytest.mark.asyncio
+async def test_parent_poll_keeps_existing_item_level_completion_path() -> None:
+    event = _make_completion_event(7)
+    engine = _make_unstarted_process_engine(
+        [msgpack.packb(_completion_event_to_dict(event), use_bin_type=True)]
+    )
+    engine._in_flight_count = 1
+
+    events = await engine.poll_completed_events()
+
+    assert events == [event]
+    assert engine.get_in_flight_count() == 0
+    runtime_metrics = engine.get_runtime_metrics()
+    assert runtime_metrics is not None
+    assert runtime_metrics.process is not None
+    process_metrics = runtime_metrics.process.batch_metrics
+    assert process_metrics.completion_item_payload_count == 1
+    assert process_metrics.completion_batch_payload_count == 0
+    assert process_metrics.items_per_completion_ipc == 1.0
+
+
+def test_worker_pipe_payload_codec_distinguishes_single_item_and_route_batch() -> None:
+    single_payload = serialize_worker_pipe_payload([_make_work_item(0)], 1.5)
+    batch_payload = serialize_worker_pipe_payload(
+        RouteBatch(
+            batch_id="batch-1",
+            route_identity=("test", 0, b"key-a"),
+            worker_index=1,
+            items=[_make_work_item(0), _make_work_item(1)],
+        ),
+        2.5,
+    )
+
+    decoded_single = decode_worker_pipe_payload(single_payload, max_bytes=4096)
+    decoded_batch = decode_worker_pipe_payload(batch_payload, max_bytes=4096)
+
+    assert decoded_single["kind"] == "work_items"
+    assert decoded_batch["kind"] == "route_batch"
+    assert [item["offset"] for item in decoded_single["items"]] == [0]
+    assert [item["offset"] for item in decoded_batch["batch"]["items"]] == [0, 1]
+
+
+def test_worker_pipe_route_batch_payload_roundtrip_preserves_identity_and_order() -> (
+    None
+):
+    route_batch = RouteBatch(
+        batch_id="batch-ordered",
+        route_identity=("test", 0, b"key-a"),
+        worker_index=3,
+        items=[_make_work_item(2), _make_work_item(3)],
+    )
+
+    packed = serialize_worker_pipe_payload(route_batch, 3.5)
+    decoded_payload = decode_worker_pipe_payload(packed, max_bytes=4096)
+    decoded_batch = route_batch_from_dict(decoded_payload["batch"])
+
+    assert decoded_payload["kind"] == "route_batch"
+    assert decoded_batch.batch_id == "batch-ordered"
+    assert decoded_batch.route_identity == ("test", 0, b"key-a")
+    assert decoded_batch.worker_index == 3
+    assert [item.offset for item in decoded_batch.items] == [2, 3]
+
+
+def test_worker_pipe_payload_codec_rejects_unknown_payload_kind() -> None:
+    packed = msgpack.packb({"kind": "mystery", "items": []}, use_bin_type=True)
+
+    with pytest.raises(ValueError, match="unknown_worker_pipe_payload_kind:mystery"):
+        decode_worker_pipe_payload(packed, max_bytes=4096)
 
 
 def _sync_worker(item: WorkItem) -> None:

--- a/tests/unit/execution_plane/test_process_engine_batching.py
+++ b/tests/unit/execution_plane/test_process_engine_batching.py
@@ -12,13 +12,21 @@ import pytest
 
 from pyrallel_consumer.config import ExecutionConfig, ProcessConfig
 from pyrallel_consumer.dto import (
+    BatchCompletion,
     CompletionEvent,
     CompletionStatus,
     EngineRuntimeDiagnostics,
+    RouteBatch,
     TopicPartition,
     WorkItem,
 )
 from pyrallel_consumer.execution_plane import process_engine
+from pyrallel_consumer.execution_plane.process_codec import (
+    batch_completion_from_dict,
+    batch_completion_to_dict,
+    route_batch_from_dict,
+    route_batch_to_dict,
+)
 from pyrallel_consumer.execution_plane.process_engine import (
     ProcessExecutionEngine,
     _BatchAccumulator,
@@ -50,6 +58,67 @@ def _make_work_item(offset: int, partition: int = 0, topic: str = "test") -> Wor
         key=f"key-{offset}".encode(),
         payload=f"payload-{offset}".encode(),
     )
+
+
+def test_route_batch_wire_contract_preserves_identity_and_item_order() -> None:
+    route_batch = RouteBatch(
+        batch_id="batch-1",
+        route_identity=("topic", 0, b"key-a"),
+        worker_index=2,
+        items=[_make_work_item(0), _make_work_item(1)],
+    )
+
+    decoded = route_batch_from_dict(route_batch_to_dict(route_batch))
+
+    assert decoded.batch_id == "batch-1"
+    assert decoded.route_identity == ("topic", 0, b"key-a")
+    assert decoded.worker_index == 2
+    assert [item.id for item in decoded.items] == ["wi-0", "wi-1"]
+    assert [
+        (item.tp.topic, item.tp.partition, item.offset) for item in decoded.items
+    ] == [
+        ("test", 0, 0),
+        ("test", 0, 1),
+    ]
+
+
+def test_batch_completion_wire_contract_preserves_item_results() -> None:
+    completion = BatchCompletion(
+        batch_id="batch-1",
+        route_identity=("topic", 0, b"key-a"),
+        results=[
+            CompletionEvent(
+                id="wi-0",
+                tp=TopicPartition("test", 0),
+                offset=0,
+                epoch=1,
+                status=CompletionStatus.SUCCESS,
+                error=None,
+                attempt=1,
+            ),
+            CompletionEvent(
+                id="wi-1",
+                tp=TopicPartition("test", 0),
+                offset=1,
+                epoch=1,
+                status=CompletionStatus.FAILURE,
+                error="boom",
+                attempt=3,
+            ),
+        ],
+    )
+
+    decoded = batch_completion_from_dict(batch_completion_to_dict(completion))
+
+    assert decoded.batch_id == "batch-1"
+    assert decoded.route_identity == ("topic", 0, b"key-a")
+    assert [event.id for event in decoded.results] == ["wi-0", "wi-1"]
+    assert [event.status for event in decoded.results] == [
+        CompletionStatus.SUCCESS,
+        CompletionStatus.FAILURE,
+    ]
+    assert decoded.results[1].error == "boom"
+    assert decoded.results[1].attempt == 3
 
 
 def _sync_worker(item: WorkItem) -> None:

--- a/tests/unit/execution_plane/test_process_engine_batching.py
+++ b/tests/unit/execution_plane/test_process_engine_batching.py
@@ -331,6 +331,44 @@ def test_batch_completion_envelope_roundtrip_preserves_prefix_result_order() -> 
     ]
 
 
+def test_decode_completion_queue_item_events_uses_existing_config_without_instantiating_execution_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event = _make_completion_event(7)
+    raw_event = msgpack.packb(_completion_event_to_dict(event), use_bin_type=True)
+    engine = _make_decode_only_process_engine(max_bytes=len(raw_event) + 1)
+
+    def fail_execution_config(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("ExecutionConfig must not be constructed on decode path")
+
+    monkeypatch.setattr(process_engine, "ExecutionConfig", fail_execution_config)
+
+    decoded = engine._decode_completion_queue_item_events(raw_event)
+
+    assert [item.id for item in decoded] == ["wi-7"]
+
+
+def test_decode_completion_queue_item_events_uses_constant_fallback_without_instantiating_execution_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event = _make_completion_event(8)
+    raw_event = msgpack.packb(_completion_event_to_dict(event), use_bin_type=True)
+    engine = cast(
+        ProcessExecutionEngine,
+        ProcessExecutionEngine.__new__(ProcessExecutionEngine),
+    )
+    cast(Any, engine)._config = object()
+
+    def fail_execution_config(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("ExecutionConfig must not be constructed on decode path")
+
+    monkeypatch.setattr(process_engine, "ExecutionConfig", fail_execution_config)
+
+    decoded = engine._decode_completion_queue_item_events(raw_event)
+
+    assert [item.id for item in decoded] == ["wi-8"]
+
+
 def test_decode_completion_queue_item_events_rejects_oversized_raw_bytes_before_unpack(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/execution_plane/test_process_engine_batching.py
+++ b/tests/unit/execution_plane/test_process_engine_batching.py
@@ -394,6 +394,14 @@ def test_decode_completion_queue_item_events_rejects_oversized_item_completion_b
         engine._decode_completion_queue_item_events(raw_event)
 
 
+def test_decode_completion_queue_item_events_rejects_non_dict_payload() -> None:
+    raw_event = msgpack.packb(["not", "a", "dict"], use_bin_type=True)
+    engine = _make_decode_only_process_engine(max_bytes=len(raw_event) + 1)
+
+    with pytest.raises(ValueError, match="invalid_completion_payload_type"):
+        engine._decode_completion_queue_item_events(raw_event)
+
+
 def test_decode_completion_queue_item_events_rejects_oversized_batch_completion_bytes() -> (
     None
 ):
@@ -410,6 +418,21 @@ def test_decode_completion_queue_item_events_rejects_oversized_batch_completion_
 
     with pytest.raises(ValueError, match="payload_too_large"):
         engine._decode_completion_queue_item_events(raw_event)
+
+
+def test_completion_identity_cache_evicts_oldest_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _make_decode_only_process_engine(max_bytes=1024)
+    monkeypatch.setattr(process_engine, "_MAX_SEEN_COMPLETION_IDENTITIES", 2)
+
+    assert engine._is_duplicate_completion_event(_make_completion_event(0)) is False
+    assert engine._is_duplicate_completion_event(_make_completion_event(1)) is False
+    assert engine._is_duplicate_completion_event(_make_completion_event(2)) is False
+
+    assert len(engine._seen_completion_identities) == 2
+    assert engine._is_duplicate_completion_event(_make_completion_event(1)) is True
+    assert engine._is_duplicate_completion_event(_make_completion_event(0)) is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -890,6 +890,52 @@ def test_worker_pipe_submit_batch_send_failure_rolls_back_pending_and_slot() -> 
     assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
 
 
+def test_worker_pipe_route_batch_slot_acquire_uses_representative_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sender = _PipeSender()
+    transport = WorkerPipesProcessTransport(
+        process_count=1,
+        queue_size=1,
+        max_payload_bytes=4096,
+        serialize_work_item=_work_item_to_dict,
+        serialize_batch_payload=_serialize_batch_payload,
+        work_item_from_dict=_work_item_from_dict,
+        get_worker_pipe_senders=lambda: [sender],
+        increment_in_flight=lambda: None,
+        pipe_sentinel=b"sentinel",
+    )
+    item = WorkItem(
+        id="work-a",
+        tp=TopicPartition("topic", 1),
+        offset=42,
+        epoch=7,
+        key=b"same-key",
+        payload=b"a",
+    )
+    acquired_payloads: list[dict[str, Any]] = []
+    original_acquire = transport._acquire_worker_pipe_queue_slot
+
+    def capture_acquire(worker_idx: int, payload: dict[str, Any]) -> None:
+        acquired_payloads.append(payload)
+        original_acquire(worker_idx=worker_idx, payload=payload)
+
+    monkeypatch.setattr(transport, "_acquire_worker_pipe_queue_slot", capture_acquire)
+
+    transport.dispatch_route_batch(
+        RouteBatch(
+            batch_id="batch-representative",
+            route_identity=("topic", 1, b"same-key"),
+            worker_index=None,
+            items=[item],
+        ),
+        route_identity=RouteIdentity("topic", 1, b"same-key"),
+        count_in_flight=False,
+    )
+
+    assert acquired_payloads == [_work_item_to_dict(item)]
+
+
 def test_worker_pipe_route_batch_start_keeps_unstarted_tail_recoverable() -> None:
     sender = _PipeSender()
     transport = WorkerPipesProcessTransport(

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -1093,6 +1093,151 @@ def test_process_engine_not_started_requeues_tail_without_new_in_flight_count() 
     assert engine.get_in_flight_count() == 2
 
 
+def test_process_engine_not_started_requeues_tail_still_pending_in_worker_pipes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sender = _PipeSender()
+    transport = WorkerPipesProcessTransport(
+        process_count=1,
+        queue_size=1,
+        max_payload_bytes=4096,
+        serialize_work_item=_work_item_to_dict,
+        serialize_batch_payload=_serialize_batch_payload,
+        work_item_from_dict=_work_item_from_dict,
+        get_worker_pipe_senders=lambda: [sender],
+        increment_in_flight=lambda: None,
+        pipe_sentinel=b"sentinel",
+    )
+    first_item = WorkItem(
+        id="work-a",
+        tp=TopicPartition("topic", 1),
+        offset=42,
+        epoch=7,
+        key=b"same-key",
+        payload=b"a",
+    )
+    tail_item = WorkItem(
+        id="work-b",
+        tp=TopicPartition("topic", 1),
+        offset=43,
+        epoch=7,
+        key=b"same-key",
+        payload=b"b",
+    )
+    first_payload = _work_item_to_dict(first_item)
+    tail_payload = _work_item_to_dict(tail_item)
+    transport.dispatch_route_batch(
+        RouteBatch(
+            batch_id="batch-tail",
+            route_identity=("topic", 1, b"same-key"),
+            worker_index=None,
+            items=[first_item, tail_item],
+        ),
+        route_identity=RouteIdentity("topic", 1, b"same-key"),
+        count_in_flight=False,
+    )
+    transport.handle_registry_event(
+        {
+            "kind": "start",
+            "key": (0, "topic", 1, 42),
+            "payload": first_payload,
+        }
+    )
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    engine_any._transport = transport
+    engine_any._in_flight_registry = {}
+    engine_any._in_flight_lock = threading.Lock()
+    engine_any._in_flight_count = 2
+    requeued: list[list[dict[str, Any]]] = []
+    monkeypatch.setattr(engine, "_requeue_recovered_payloads", requeued.append)
+
+    engine._apply_registry_event(
+        {
+            "kind": "not_started",
+            "reason": "ordered_batch_failure",
+            "batch_id": "batch-tail",
+            "payloads": [tail_payload],
+        }
+    )
+
+    assert requeued == [[tail_payload]]
+    assert transport._pending_dispatch == {}
+
+
+def test_process_engine_ignores_stale_not_started_tail_after_pending_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sender = _PipeSender()
+    transport = WorkerPipesProcessTransport(
+        process_count=1,
+        queue_size=1,
+        max_payload_bytes=4096,
+        serialize_work_item=_work_item_to_dict,
+        serialize_batch_payload=_serialize_batch_payload,
+        work_item_from_dict=_work_item_from_dict,
+        get_worker_pipe_senders=lambda: [sender],
+        increment_in_flight=lambda: None,
+        pipe_sentinel=b"sentinel",
+    )
+    first_item = WorkItem(
+        id="work-a",
+        tp=TopicPartition("topic", 1),
+        offset=42,
+        epoch=7,
+        key=b"same-key",
+        payload=b"a",
+    )
+    tail_item = WorkItem(
+        id="work-b",
+        tp=TopicPartition("topic", 1),
+        offset=43,
+        epoch=7,
+        key=b"same-key",
+        payload=b"b",
+    )
+    first_payload = _work_item_to_dict(first_item)
+    tail_payload = _work_item_to_dict(tail_item)
+    transport.dispatch_route_batch(
+        RouteBatch(
+            batch_id="batch-tail",
+            route_identity=("topic", 1, b"same-key"),
+            worker_index=None,
+            items=[first_item, tail_item],
+        ),
+        route_identity=RouteIdentity("topic", 1, b"same-key"),
+        count_in_flight=False,
+    )
+    transport.handle_registry_event(
+        {
+            "kind": "start",
+            "key": (0, "topic", 1, 42),
+            "payload": first_payload,
+        }
+    )
+    recovered = transport.recover_pending_dispatches(0)
+    assert [entry.payload for entry in recovered] == [tail_payload]
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    engine_any._transport = transport
+    engine_any._in_flight_registry = {}
+    engine_any._in_flight_lock = threading.Lock()
+    engine_any._in_flight_count = 2
+    requeued: list[list[dict[str, Any]]] = []
+    monkeypatch.setattr(engine, "_requeue_recovered_payloads", requeued.append)
+
+    engine._apply_registry_event(
+        {
+            "kind": "not_started",
+            "reason": "ordered_batch_failure",
+            "batch_id": "batch-tail",
+            "payloads": [tail_payload],
+        }
+    )
+
+    assert requeued == []
+
+
 @pytest.mark.asyncio
 async def test_shared_queue_submit_batch_keeps_base_fallback_behavior() -> None:
     engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -1912,6 +1912,59 @@ def test_worker_runtime_route_batch_emits_only_batch_completion_envelope() -> No
     assert raw_payloads[0]["kind"] == "batch_completion"
 
 
+def test_worker_runtime_defers_route_batch_done_until_completion_flush(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task_source: queue.Queue[object] = queue.Queue()
+    completion_queue: queue.Queue[object] = queue.Queue()
+    registry_event_queue: queue.Queue[object] = queue.Queue()
+    item = WorkItem("work-1", TopicPartition("topic", 1), 1, 7, b"key", b"")
+    task_source.put(
+        _serialize_batch_payload(
+            RouteBatch("batch-done-after-flush", ("topic", 1, b"key"), 0, [item]),
+            1.0,
+        )
+    )
+    task_source.put(None)
+    original_flush = worker_runtime_module._flush_route_batch_completion
+    seen_done_before_flush: list[dict[str, Any]] = []
+
+    def capture_flush(**kwargs: Any) -> None:
+        queue_ref = cast(queue.Queue[object], kwargs["registry_event_queue"])
+        seen_done_before_flush.extend(
+            cast(dict[str, Any], event)
+            for event in list(queue_ref.queue)
+            if isinstance(event, dict) and event.get("kind") == "done"
+        )
+        original_flush(**kwargs)
+
+    monkeypatch.setattr(
+        worker_runtime_module,
+        "_flush_route_batch_completion",
+        capture_flush,
+    )
+
+    _worker_loop(
+        task_source,
+        completion_queue,  # type: ignore[arg-type]
+        registry_event_queue,  # type: ignore[arg-type]
+        lambda _item: None,
+        0,
+        ExecutionConfig(
+            mode=ExecutionMode.PROCESS,
+            max_retries=1,
+            process_config=ProcessConfig(process_count=1),
+        ),
+    )
+
+    assert seen_done_before_flush == []
+    registry_events = [
+        cast(dict[str, Any], registry_event_queue.get_nowait())
+        for _ in range(registry_event_queue.qsize())
+    ]
+    assert [event.get("kind") for event in registry_events].count("done") == 1
+
+
 def test_worker_runtime_fatal_route_batch_flushes_prefix_completion_before_exit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/execution_plane/test_process_execution_engine.py
+++ b/tests/unit/execution_plane/test_process_execution_engine.py
@@ -18,10 +18,22 @@ from pyrallel_consumer.dto import (
     CompletionEvent,
     CompletionStatus,
     ExecutionMode,
+    RouteBatch,
     TopicPartition,
     WorkItem,
 )
 from pyrallel_consumer.execution_plane import process_engine as process_engine_module
+from pyrallel_consumer.execution_plane import (
+    process_transport_worker_pipes as worker_pipes_module,
+)
+from pyrallel_consumer.execution_plane import (
+    process_worker_runtime as worker_runtime_module,
+)
+from pyrallel_consumer.execution_plane.process_codec import (
+    batch_completion_from_dict,
+    decode_worker_pipe_payload,
+    route_batch_from_dict,
+)
 from pyrallel_consumer.execution_plane.process_engine import (
     ProcessExecutionEngine,
     _completion_event_from_dict,
@@ -36,6 +48,7 @@ from pyrallel_consumer.execution_plane.process_transport import (
     RouteIdentity,
     WorkerExecutionIdentity,
     logical_work_identity_from_payload,
+    stable_worker_index_for_route,
 )
 from pyrallel_consumer.execution_plane.process_transport_shared_queue import (
     SharedQueueProcessTransport,
@@ -643,6 +656,430 @@ async def test_submit_routes_matching_identities_to_same_worker_pipe(
         await engine.shutdown()
 
 
+@pytest.mark.asyncio
+async def test_worker_pipes_submit_batch_sends_one_route_batch_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ProcessExecutionEngine, "_start_workers", lambda self: None)
+
+    config = ExecutionConfig(
+        mode=ExecutionMode.PROCESS,
+        process_config=ProcessConfig(
+            process_count=2,
+            queue_size=4,
+            transport_mode="worker_pipes",
+            batch_size=1,
+            max_batch_wait_ms=0,
+        ),
+    )
+    engine = ProcessExecutionEngine(config=config, worker_fn=_sync_worker)
+    senders = [_PipeSender(), _PipeSender()]
+    engine_any = cast(Any, engine)
+    engine_any._worker_pipe_senders.clear()
+    engine_any._worker_pipe_senders.extend(senders)
+    items = [
+        WorkItem(
+            id="work-a",
+            tp=TopicPartition("topic", 0),
+            offset=1,
+            epoch=1,
+            key=b"same-key",
+            payload=b"a",
+        ),
+        WorkItem(
+            id="work-b",
+            tp=TopicPartition("topic", 0),
+            offset=2,
+            epoch=1,
+            key=b"same-key",
+            payload=b"b",
+        ),
+    ]
+    route_identity = RouteIdentity("topic", 0, b"same-key")
+    expected_worker_idx = stable_worker_index_for_route(route_identity, 2)
+
+    try:
+        await engine.submit_batch(items)
+
+        assert [len(sender.payloads) for sender in senders].count(1) == 1
+        assert senders[expected_worker_idx].payloads
+        decoded_payload = decode_worker_pipe_payload(
+            senders[expected_worker_idx].payloads[0],
+            max_bytes=4096,
+        )
+        decoded_batch = route_batch_from_dict(decoded_payload["batch"])
+        assert decoded_payload["kind"] == "route_batch"
+        assert decoded_batch.worker_index == expected_worker_idx
+        assert decoded_batch.route_identity == ("topic", 0, b"same-key")
+        assert [item.id for item in decoded_batch.items] == ["work-a", "work-b"]
+        assert engine.get_in_flight_count() == 2
+        runtime_metrics = engine.get_runtime_metrics()
+        assert runtime_metrics is not None
+        assert runtime_metrics.process is not None
+        process_metrics = runtime_metrics.process.batch_metrics
+        assert process_metrics.route_batch_count == 1
+        assert process_metrics.route_batch_item_count == 2
+        assert process_metrics.items_per_input_ipc == 2.0
+    finally:
+        await engine.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_worker_pipes_route_batch_metrics_calculate_size_distribution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ProcessExecutionEngine, "_start_workers", lambda self: None)
+    config = ExecutionConfig(
+        mode=ExecutionMode.PROCESS,
+        process_config=ProcessConfig(
+            process_count=1,
+            queue_size=4,
+            transport_mode="worker_pipes",
+            batch_size=1,
+            max_batch_wait_ms=0,
+        ),
+    )
+    engine = ProcessExecutionEngine(config=config, worker_fn=_sync_worker)
+    sender = _PipeSender()
+    engine_any = cast(Any, engine)
+    engine_any._worker_pipe_senders.clear()
+    engine_any._worker_pipe_senders.append(sender)
+    try:
+        await engine.submit_batch(
+            [
+                WorkItem("work-a", TopicPartition("topic", 0), 1, 1, b"same", b"a"),
+                WorkItem("work-b", TopicPartition("topic", 0), 2, 1, b"same", b"b"),
+            ]
+        )
+        await engine.submit_batch(
+            [
+                WorkItem("work-c", TopicPartition("topic", 0), 3, 1, b"same", b"c"),
+                WorkItem("work-d", TopicPartition("topic", 0), 4, 1, b"same", b"d"),
+                WorkItem("work-e", TopicPartition("topic", 0), 5, 1, b"same", b"e"),
+            ]
+        )
+
+        runtime_metrics = engine.get_runtime_metrics()
+        assert runtime_metrics is not None
+        assert runtime_metrics.process is not None
+        process_metrics = runtime_metrics.process.batch_metrics
+        assert process_metrics.route_batch_count == 2
+        assert process_metrics.route_batch_item_count == 5
+        assert process_metrics.route_batch_size_avg == 2.5
+        assert process_metrics.route_batch_size_max == 3
+        assert process_metrics.items_per_input_ipc == 2.5
+    finally:
+        await engine.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_worker_pipes_submit_batch_hashes_route_once_and_records_pending_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ProcessExecutionEngine, "_start_workers", lambda self: None)
+    hash_calls: list[RouteIdentity] = []
+
+    def fake_stable_worker_index(
+        route_identity: RouteIdentity,
+        process_count: int,
+    ) -> int:
+        assert process_count == 2
+        hash_calls.append(route_identity)
+        return 1
+
+    monkeypatch.setattr(
+        worker_pipes_module,
+        "stable_worker_index_for_route",
+        fake_stable_worker_index,
+    )
+    config = ExecutionConfig(
+        mode=ExecutionMode.PROCESS,
+        process_config=ProcessConfig(
+            process_count=2,
+            queue_size=4,
+            transport_mode="worker_pipes",
+            batch_size=1,
+            max_batch_wait_ms=0,
+        ),
+    )
+    engine = ProcessExecutionEngine(config=config, worker_fn=_sync_worker)
+    senders = [_PipeSender(), _PipeSender()]
+    engine_any = cast(Any, engine)
+    engine_any._worker_pipe_senders.clear()
+    engine_any._worker_pipe_senders.extend(senders)
+    items = [
+        WorkItem(
+            id="work-a",
+            tp=TopicPartition("topic", 3),
+            offset=10,
+            epoch=5,
+            key=b"same-key",
+            payload=b"a",
+        ),
+        WorkItem(
+            id="work-b",
+            tp=TopicPartition("topic", 3),
+            offset=11,
+            epoch=5,
+            key=b"same-key",
+            payload=b"b",
+        ),
+    ]
+
+    try:
+        await engine.submit_batch(items)
+
+        assert hash_calls == [RouteIdentity("topic", 3, b"same-key")]
+        transport = cast(Any, engine)._transport
+        pending_batches = list(transport._pending_dispatch.values())
+        assert len(pending_batches) == 1
+        pending_batch = pending_batches[0]
+        assert pending_batch["batch_id"]
+        assert [item["id"] for item in pending_batch["items"]] == ["work-a", "work-b"]
+        assert [item["offset"] for item in pending_batch["items"]] == [10, 11]
+    finally:
+        await engine.shutdown()
+
+
+def test_worker_pipe_submit_batch_send_failure_rolls_back_pending_and_slot() -> None:
+    transport = WorkerPipesProcessTransport(
+        process_count=1,
+        queue_size=1,
+        max_payload_bytes=4096,
+        serialize_work_item=_work_item_to_dict,
+        serialize_batch_payload=_serialize_batch_payload,
+        work_item_from_dict=_work_item_from_dict,
+        get_worker_pipe_senders=lambda: [_BrokenPipeSender()],
+        increment_in_flight=lambda: None,
+        pipe_sentinel=b"sentinel",
+    )
+    route_batch = RouteBatch(
+        batch_id="batch-failure",
+        route_identity=("topic", 1, b"same-key"),
+        worker_index=None,
+        items=[
+            WorkItem(
+                id="work-a",
+                tp=TopicPartition("topic", 1),
+                offset=42,
+                epoch=7,
+                key=b"same-key",
+                payload=b"a",
+            ),
+            WorkItem(
+                id="work-b",
+                tp=TopicPartition("topic", 1),
+                offset=43,
+                epoch=7,
+                key=b"same-key",
+                payload=b"b",
+            ),
+        ],
+    )
+
+    with pytest.raises(
+        RuntimeError, match="Failed to dispatch worker pipe route batch"
+    ):
+        transport.dispatch_route_batch(
+            route_batch,
+            route_identity=RouteIdentity("topic", 1, b"same-key"),
+            count_in_flight=True,
+        )
+
+    assert transport._pending_dispatch == {}
+    assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
+
+
+def test_worker_pipe_route_batch_start_keeps_unstarted_tail_recoverable() -> None:
+    sender = _PipeSender()
+    transport = WorkerPipesProcessTransport(
+        process_count=1,
+        queue_size=1,
+        max_payload_bytes=4096,
+        serialize_work_item=_work_item_to_dict,
+        serialize_batch_payload=_serialize_batch_payload,
+        work_item_from_dict=_work_item_from_dict,
+        get_worker_pipe_senders=lambda: [sender],
+        increment_in_flight=lambda: None,
+        pipe_sentinel=b"sentinel",
+    )
+    first_item = WorkItem(
+        id="work-a",
+        tp=TopicPartition("topic", 1),
+        offset=42,
+        epoch=7,
+        key=b"same-key",
+        payload=b"a",
+    )
+    tail_item = WorkItem(
+        id="work-b",
+        tp=TopicPartition("topic", 1),
+        offset=43,
+        epoch=7,
+        key=b"same-key",
+        payload=b"b",
+    )
+    transport.dispatch_route_batch(
+        RouteBatch(
+            batch_id="batch-tail",
+            route_identity=("topic", 1, b"same-key"),
+            worker_index=None,
+            items=[first_item, tail_item],
+        ),
+        route_identity=RouteIdentity("topic", 1, b"same-key"),
+        count_in_flight=False,
+    )
+    first_payload = _work_item_to_dict(first_item)
+    tail_payload = _work_item_to_dict(tail_item)
+
+    transport.handle_registry_event(
+        {
+            "kind": "start",
+            "key": (0, "topic", 1, 42),
+            "payload": first_payload,
+        }
+    )
+
+    assert transport._worker_pipe_queue_slots.acquire(blocking=False) is True
+    recovered = transport.recover_pending_dispatches(0)
+    assert recovered == [
+        PendingDispatchRecovery(
+            identity=WorkerExecutionIdentity(
+                worker_index=0,
+                work=logical_work_identity_from_payload(tail_payload),
+            ),
+            payload=tail_payload,
+        )
+    ]
+    assert transport._pending_dispatch == {}
+
+
+def test_worker_pipe_not_started_event_clears_pending_route_batch_tail() -> None:
+    sender = _PipeSender()
+    transport = WorkerPipesProcessTransport(
+        process_count=1,
+        queue_size=1,
+        max_payload_bytes=4096,
+        serialize_work_item=_work_item_to_dict,
+        serialize_batch_payload=_serialize_batch_payload,
+        work_item_from_dict=_work_item_from_dict,
+        get_worker_pipe_senders=lambda: [sender],
+        increment_in_flight=lambda: None,
+        pipe_sentinel=b"sentinel",
+    )
+    first_item = WorkItem(
+        id="work-a",
+        tp=TopicPartition("topic", 1),
+        offset=42,
+        epoch=7,
+        key=b"same-key",
+        payload=b"a",
+    )
+    tail_item = WorkItem(
+        id="work-b",
+        tp=TopicPartition("topic", 1),
+        offset=43,
+        epoch=7,
+        key=b"same-key",
+        payload=b"b",
+    )
+    transport.dispatch_route_batch(
+        RouteBatch(
+            batch_id="batch-tail",
+            route_identity=("topic", 1, b"same-key"),
+            worker_index=None,
+            items=[first_item, tail_item],
+        ),
+        route_identity=RouteIdentity("topic", 1, b"same-key"),
+        count_in_flight=False,
+    )
+    first_payload = _work_item_to_dict(first_item)
+    tail_payload = _work_item_to_dict(tail_item)
+    transport.handle_registry_event(
+        {
+            "kind": "start",
+            "key": (0, "topic", 1, 42),
+            "payload": first_payload,
+        }
+    )
+
+    transport.handle_registry_event(
+        {
+            "kind": "not_started",
+            "reason": "ordered_batch_failure",
+            "batch_id": "batch-tail",
+            "payloads": [tail_payload],
+        }
+    )
+
+    assert transport._pending_dispatch == {}
+
+
+def test_process_engine_not_started_requeues_tail_without_new_in_flight_count() -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    transport = _RequeueRecordingTransport()
+    tail_payload = {
+        "id": "work-b",
+        "topic": "topic",
+        "partition": 1,
+        "offset": 43,
+        "epoch": 7,
+        "key": b"same-key",
+        "payload": b"b",
+        "requeue_attempts": 0,
+    }
+    engine_any._transport = transport
+    engine_any._in_flight_registry = {}
+    engine_any._in_flight_lock = threading.Lock()
+    engine_any._in_flight_count = 2
+
+    engine._apply_registry_event(
+        {
+            "kind": "not_started",
+            "reason": "ordered_batch_failure",
+            "batch_id": "batch-tail",
+            "payloads": [tail_payload],
+        }
+    )
+
+    assert transport.requeued_payloads == [[tail_payload]]
+    assert engine.get_in_flight_count() == 2
+
+
+@pytest.mark.asyncio
+async def test_shared_queue_submit_batch_keeps_base_fallback_behavior() -> None:
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    submitted: list[WorkItem] = []
+
+    async def record_submit(work_item: WorkItem) -> None:
+        submitted.append(work_item)
+
+    engine.submit = record_submit  # type: ignore[method-assign]
+    items = [
+        WorkItem(
+            id="work-a",
+            tp=TopicPartition("topic", 0),
+            offset=1,
+            epoch=1,
+            key=b"same-key",
+            payload=b"a",
+        ),
+        WorkItem(
+            id="work-b",
+            tp=TopicPartition("topic", 0),
+            offset=2,
+            epoch=1,
+            key=b"same-key",
+            payload=b"b",
+        ),
+    ]
+
+    await engine.submit_batch(items)
+
+    assert submitted == items
+
+
 def test_worker_pipe_start_event_releases_pending_dispatch_capacity() -> None:
     engine = cast(
         ProcessExecutionEngine,
@@ -1042,6 +1479,587 @@ def test_worker_done_registry_event_uses_identity_payload_only() -> None:
     }
     assert "key" not in done_events[0]["payload"]
     assert "payload" not in done_events[0]["payload"]
+
+
+def test_worker_runtime_executes_route_batch_items_in_order() -> None:
+    task_source: queue.Queue[object] = queue.Queue()
+    completion_queue: queue.Queue[object] = queue.Queue()
+    registry_event_queue: queue.Queue[object] = queue.Queue()
+    items = [
+        WorkItem(f"work-{offset}", TopicPartition("topic", 1), offset, 7, b"key", b"")
+        for offset in (1, 2, 3)
+    ]
+    task_source.put(
+        _serialize_batch_payload(
+            RouteBatch("batch-ordered", ("topic", 1, b"key"), 0, items),
+            1.0,
+        )
+    )
+    task_source.put(None)
+    executed_offsets: list[int] = []
+
+    def record_order(item: WorkItem) -> None:
+        executed_offsets.append(item.offset)
+
+    _worker_loop(
+        task_source,
+        completion_queue,  # type: ignore[arg-type]
+        registry_event_queue,  # type: ignore[arg-type]
+        record_order,
+        0,
+        ExecutionConfig(
+            mode=ExecutionMode.PROCESS,
+            max_retries=1,
+            process_config=ProcessConfig(process_count=1),
+        ),
+    )
+
+    assert executed_offsets == [1, 2, 3]
+
+
+def test_worker_runtime_stops_route_batch_after_first_failure() -> None:
+    task_source: queue.Queue[object] = queue.Queue()
+    completion_queue: queue.Queue[object] = queue.Queue()
+    registry_event_queue: queue.Queue[object] = queue.Queue()
+    items = [
+        WorkItem(f"work-{offset}", TopicPartition("topic", 1), offset, 7, b"key", b"")
+        for offset in (1, 2, 3)
+    ]
+    task_source.put(
+        _serialize_batch_payload(
+            RouteBatch("batch-fail", ("topic", 1, b"key"), 0, items),
+            1.0,
+        )
+    )
+    task_source.put(None)
+    executed_offsets: list[int] = []
+
+    def fail_second(item: WorkItem) -> None:
+        executed_offsets.append(item.offset)
+        if item.offset == 2:
+            raise RuntimeError("boom")
+
+    _worker_loop(
+        task_source,
+        completion_queue,  # type: ignore[arg-type]
+        registry_event_queue,  # type: ignore[arg-type]
+        fail_second,
+        0,
+        ExecutionConfig(
+            mode=ExecutionMode.PROCESS,
+            max_retries=1,
+            process_config=ProcessConfig(process_count=1),
+        ),
+    )
+
+    raw_payloads = []
+    while not completion_queue.empty():
+        raw_payloads.append(msgpack.unpackb(completion_queue.get_nowait(), raw=False))
+    completion = batch_completion_from_dict(
+        next(
+            payload
+            for payload in raw_payloads
+            if payload.get("kind") == "batch_completion"
+        )["completion"]
+    )
+    assert executed_offsets == [1, 2]
+    assert [(event.offset, event.status) for event in completion.results] == [
+        (1, CompletionStatus.SUCCESS),
+        (2, CompletionStatus.FAILURE),
+    ]
+    assert [payload for payload in raw_payloads if "id" in payload] == []
+
+
+def test_worker_runtime_emits_not_started_diagnostic_for_route_batch_remainder() -> (
+    None
+):
+    task_source: queue.Queue[object] = queue.Queue()
+    completion_queue: queue.Queue[object] = queue.Queue()
+    registry_event_queue: queue.Queue[object] = queue.Queue()
+    items = [
+        WorkItem(f"work-{offset}", TopicPartition("topic", 1), offset, 7, b"key", b"")
+        for offset in (1, 2, 3)
+    ]
+    task_source.put(
+        _serialize_batch_payload(
+            RouteBatch("batch-remainder", ("topic", 1, b"key"), 0, items),
+            1.0,
+        )
+    )
+    task_source.put(None)
+
+    def fail_second(item: WorkItem) -> None:
+        if item.offset == 2:
+            raise RuntimeError("boom")
+
+    _worker_loop(
+        task_source,
+        completion_queue,  # type: ignore[arg-type]
+        registry_event_queue,  # type: ignore[arg-type]
+        fail_second,
+        0,
+        ExecutionConfig(
+            mode=ExecutionMode.PROCESS,
+            max_retries=1,
+            process_config=ProcessConfig(process_count=1),
+        ),
+    )
+
+    registry_events = []
+    while not registry_event_queue.empty():
+        registry_events.append(cast(dict[str, Any], registry_event_queue.get_nowait()))
+    not_started_events = [
+        event for event in registry_events if event.get("kind") == "not_started"
+    ]
+    assert not_started_events == [
+        {
+            "kind": "not_started",
+            "reason": "ordered_batch_failure",
+            "batch_id": "batch-remainder",
+            "payloads": [_work_item_to_dict(items[2])],
+        }
+    ]
+
+
+def test_worker_runtime_non_route_batch_keeps_item_level_completion_surface() -> None:
+    task_source: queue.Queue[object] = queue.Queue()
+    completion_queue: queue.Queue[object] = queue.Queue()
+    registry_event_queue: queue.Queue[object] = queue.Queue()
+    item = WorkItem("work-1", TopicPartition("topic", 1), 1, 7, b"key", b"")
+    task_source.put([_work_item_to_dict(item)])
+    task_source.put(None)
+
+    _worker_loop(
+        task_source,
+        completion_queue,  # type: ignore[arg-type]
+        registry_event_queue,  # type: ignore[arg-type]
+        lambda _item: None,
+        0,
+        ExecutionConfig(
+            mode=ExecutionMode.PROCESS,
+            max_retries=1,
+            process_config=ProcessConfig(process_count=1),
+        ),
+    )
+
+    completion_payload = msgpack.unpackb(completion_queue.get_nowait(), raw=False)
+    assert completion_payload["id"] == "work-1"
+    assert "batch_id" not in completion_payload
+    assert "results" not in completion_payload
+
+
+def test_worker_runtime_emits_batch_completion_for_executed_route_batch_prefix() -> (
+    None
+):
+    task_source: queue.Queue[object] = queue.Queue()
+    completion_queue: queue.Queue[object] = queue.Queue()
+    registry_event_queue: queue.Queue[object] = queue.Queue()
+    items = [
+        WorkItem(f"work-{offset}", TopicPartition("topic", 1), offset, 7, b"key", b"")
+        for offset in (1, 2, 3)
+    ]
+    task_source.put(
+        _serialize_batch_payload(
+            RouteBatch("batch-prefix", ("topic", 1, b"key"), 0, items),
+            1.0,
+        )
+    )
+    task_source.put(None)
+
+    def fail_second(item: WorkItem) -> None:
+        if item.offset == 2:
+            raise RuntimeError("boom")
+
+    _worker_loop(
+        task_source,
+        completion_queue,  # type: ignore[arg-type]
+        registry_event_queue,  # type: ignore[arg-type]
+        fail_second,
+        0,
+        ExecutionConfig(
+            mode=ExecutionMode.PROCESS,
+            max_retries=1,
+            process_config=ProcessConfig(process_count=1),
+        ),
+    )
+
+    raw_payloads = [
+        msgpack.unpackb(completion_queue.get_nowait(), raw=False)
+        for _ in range(completion_queue.qsize())
+    ]
+    batch_payloads = [
+        payload for payload in raw_payloads if payload.get("kind") == "batch_completion"
+    ]
+    item_payloads = [payload for payload in raw_payloads if "id" in payload]
+    assert len(raw_payloads) == 1
+    assert len(batch_payloads) == 1
+    assert item_payloads == []
+    completion = batch_completion_from_dict(batch_payloads[0]["completion"])
+    assert completion.batch_id == "batch-prefix"
+    assert completion.route_identity == ("topic", 1, b"key")
+    assert [event.id for event in completion.results] == ["work-1", "work-2"]
+    assert [event.offset for event in completion.results] == [1, 2]
+    assert [event.status for event in completion.results] == [
+        CompletionStatus.SUCCESS,
+        CompletionStatus.FAILURE,
+    ]
+    assert completion.results[1].error == "boom"
+    assert completion.results[1].attempt == 1
+
+
+def test_worker_runtime_batch_completion_excludes_not_started_remainder() -> None:
+    task_source: queue.Queue[object] = queue.Queue()
+    completion_queue: queue.Queue[object] = queue.Queue()
+    registry_event_queue: queue.Queue[object] = queue.Queue()
+    items = [
+        WorkItem(f"work-{offset}", TopicPartition("topic", 1), offset, 7, b"key", b"")
+        for offset in (1, 2, 3)
+    ]
+    task_source.put(
+        _serialize_batch_payload(
+            RouteBatch("batch-skip", ("topic", 1, b"key"), 0, items),
+            1.0,
+        )
+    )
+    task_source.put(None)
+
+    def fail_second(item: WorkItem) -> None:
+        if item.offset == 2:
+            raise RuntimeError("boom")
+
+    _worker_loop(
+        task_source,
+        completion_queue,  # type: ignore[arg-type]
+        registry_event_queue,  # type: ignore[arg-type]
+        fail_second,
+        0,
+        ExecutionConfig(
+            mode=ExecutionMode.PROCESS,
+            max_retries=1,
+            process_config=ProcessConfig(process_count=1),
+        ),
+    )
+
+    raw_payloads = [
+        msgpack.unpackb(completion_queue.get_nowait(), raw=False)
+        for _ in range(completion_queue.qsize())
+    ]
+    batch_payload = next(
+        payload for payload in raw_payloads if payload.get("kind") == "batch_completion"
+    )
+    assert len(raw_payloads) == 1
+    assert [payload for payload in raw_payloads if "id" in payload] == []
+    completion = batch_completion_from_dict(batch_payload["completion"])
+    assert [event.id for event in completion.results] == ["work-1", "work-2"]
+
+    registry_events = [
+        cast(dict[str, Any], registry_event_queue.get_nowait())
+        for _ in range(registry_event_queue.qsize())
+    ]
+    not_started_events = [
+        event for event in registry_events if event.get("kind") == "not_started"
+    ]
+    assert not_started_events == [
+        {
+            "kind": "not_started",
+            "reason": "ordered_batch_failure",
+            "batch_id": "batch-skip",
+            "payloads": [_work_item_to_dict(items[2])],
+        }
+    ]
+
+
+def test_worker_runtime_batch_completion_send_failure_is_diagnostic() -> None:
+    class ExplodingCompletionQueue:
+        def __init__(self) -> None:
+            self.payloads: list[object] = []
+
+        def put(self, payload: object) -> None:
+            decoded = msgpack.unpackb(cast(bytes, payload), raw=False)
+            if decoded.get("kind") == "batch_completion":
+                raise RuntimeError("batch-wire-down")
+            self.payloads.append(payload)
+
+    task_source: queue.Queue[object] = queue.Queue()
+    registry_event_queue: queue.Queue[object] = queue.Queue()
+    completion_queue = ExplodingCompletionQueue()
+    item = WorkItem("work-1", TopicPartition("topic", 1), 1, 7, b"key", b"")
+    task_source.put(
+        _serialize_batch_payload(
+            RouteBatch("batch-send-failure", ("topic", 1, b"key"), 0, [item]),
+            1.0,
+        )
+    )
+    task_source.put(None)
+
+    _worker_loop(
+        task_source,
+        cast(Any, completion_queue),
+        registry_event_queue,  # type: ignore[arg-type]
+        lambda _item: None,
+        0,
+        ExecutionConfig(
+            mode=ExecutionMode.PROCESS,
+            max_retries=1,
+            process_config=ProcessConfig(process_count=1),
+        ),
+    )
+
+    registry_events = [
+        cast(dict[str, Any], registry_event_queue.get_nowait())
+        for _ in range(registry_event_queue.qsize())
+    ]
+    diagnostics = [
+        event
+        for event in registry_events
+        if event.get("kind") == "batch_completion_send_failed"
+    ]
+    assert diagnostics == [
+        {
+            "kind": "batch_completion_send_failed",
+            "batch_id": "batch-send-failure",
+            "error": "batch-wire-down",
+        }
+    ]
+    fallback_payloads = [
+        msgpack.unpackb(cast(bytes, payload), raw=False)
+        for payload in completion_queue.payloads
+    ]
+    assert [
+        (payload["id"], payload["offset"], payload["status"])
+        for payload in fallback_payloads
+    ] == [("work-1", 1, "success")]
+
+
+def test_worker_runtime_route_batch_emits_only_batch_completion_envelope() -> None:
+    task_source: queue.Queue[object] = queue.Queue()
+    completion_queue: queue.Queue[object] = queue.Queue()
+    registry_event_queue: queue.Queue[object] = queue.Queue()
+    item = WorkItem("work-1", TopicPartition("topic", 1), 1, 7, b"key", b"")
+    task_source.put(
+        _serialize_batch_payload(
+            RouteBatch("batch-item-level", ("topic", 1, b"key"), 0, [item]),
+            1.0,
+        )
+    )
+    task_source.put(None)
+
+    _worker_loop(
+        task_source,
+        completion_queue,  # type: ignore[arg-type]
+        registry_event_queue,  # type: ignore[arg-type]
+        lambda _item: None,
+        0,
+        ExecutionConfig(
+            mode=ExecutionMode.PROCESS,
+            max_retries=1,
+            process_config=ProcessConfig(process_count=1),
+        ),
+    )
+
+    raw_payloads = [
+        msgpack.unpackb(completion_queue.get_nowait(), raw=False)
+        for _ in range(completion_queue.qsize())
+    ]
+    assert len(raw_payloads) == 1
+    assert [payload for payload in raw_payloads if "id" in payload] == []
+    assert raw_payloads[0]["kind"] == "batch_completion"
+
+
+def test_worker_runtime_fatal_route_batch_flushes_prefix_completion_before_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task_source: queue.Queue[object] = queue.Queue()
+    completion_queue: queue.Queue[object] = queue.Queue()
+    registry_event_queue: queue.Queue[object] = queue.Queue()
+    items = [
+        WorkItem(f"work-{offset}", TopicPartition("topic", 1), offset, 7, b"key", b"")
+        for offset in (1, 2, 3)
+    ]
+    task_source.put(
+        _serialize_batch_payload(
+            RouteBatch("batch-fatal-prefix", ("topic", 1, b"key"), 0, items),
+            1.0,
+        )
+    )
+    task_source.put(None)
+
+    def fake_exit(code: int) -> None:
+        raise SystemExit(code)
+
+    def timeout_second(item: WorkItem) -> None:
+        if item.offset == 2:
+            raise TimeoutError("fatal-timeout")
+
+    monkeypatch.setattr(worker_runtime_module.os, "_exit", fake_exit)
+
+    with pytest.raises(SystemExit):
+        _worker_loop(
+            task_source,
+            completion_queue,  # type: ignore[arg-type]
+            registry_event_queue,  # type: ignore[arg-type]
+            timeout_second,
+            0,
+            ExecutionConfig(
+                mode=ExecutionMode.PROCESS,
+                max_retries=1,
+                process_config=ProcessConfig(process_count=1),
+            ),
+        )
+
+    raw_payloads = [
+        msgpack.unpackb(completion_queue.get_nowait(), raw=False)
+        for _ in range(completion_queue.qsize())
+    ]
+    assert len(raw_payloads) == 1
+    assert raw_payloads[0]["kind"] == "batch_completion"
+    completion = batch_completion_from_dict(raw_payloads[0]["completion"])
+    assert [(event.id, event.offset, event.status) for event in completion.results] == [
+        ("work-1", 1, CompletionStatus.SUCCESS)
+    ]
+
+    registry_events = [
+        cast(dict[str, Any], registry_event_queue.get_nowait())
+        for _ in range(registry_event_queue.qsize())
+    ]
+    assert [event for event in registry_events if event.get("kind") == "timeout"]
+    assert [
+        event for event in registry_events if event.get("kind") == "not_started"
+    ] == []
+
+
+def test_parent_expands_fatal_route_batch_prefix_batch_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task_source: queue.Queue[object] = queue.Queue()
+    completion_queue: queue.Queue[object] = queue.Queue()
+    registry_event_queue: queue.Queue[object] = queue.Queue()
+    items = [
+        WorkItem(f"work-{offset}", TopicPartition("topic", 1), offset, 7, b"key", b"")
+        for offset in (1, 2, 3)
+    ]
+    task_source.put(
+        _serialize_batch_payload(
+            RouteBatch("batch-fatal-parent", ("topic", 1, b"key"), 0, items),
+            1.0,
+        )
+    )
+    task_source.put(None)
+
+    def fake_exit(code: int) -> None:
+        raise SystemExit(code)
+
+    def timeout_second(item: WorkItem) -> None:
+        if item.offset == 2:
+            raise TimeoutError("fatal-timeout")
+
+    monkeypatch.setattr(worker_runtime_module.os, "_exit", fake_exit)
+
+    with pytest.raises(SystemExit):
+        _worker_loop(
+            task_source,
+            completion_queue,  # type: ignore[arg-type]
+            registry_event_queue,  # type: ignore[arg-type]
+            timeout_second,
+            0,
+            ExecutionConfig(
+                mode=ExecutionMode.PROCESS,
+                max_retries=1,
+                process_config=ProcessConfig(process_count=1),
+            ),
+        )
+
+    engine = ProcessExecutionEngine.__new__(ProcessExecutionEngine)
+    engine_any = cast(Any, engine)
+    engine_any._config = ExecutionConfig(
+        mode=ExecutionMode.PROCESS,
+        process_config=ProcessConfig(process_count=1),
+    )
+    engine._initialize_runtime_timing_state()
+
+    events = engine._decode_completion_queue_item_events(completion_queue.get_nowait())
+
+    assert [(event.id, event.offset, event.status) for event in events] == [
+        ("work-1", 1, CompletionStatus.SUCCESS)
+    ]
+    assert engine_any._completion_batch_payload_count == 1
+    assert engine_any._completion_item_payload_count == 0
+
+
+def test_worker_runtime_fatal_route_batch_prefix_flush_falls_back_to_item_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ExplodingBatchCompletionQueue:
+        def __init__(self) -> None:
+            self.payloads: list[object] = []
+
+        def put(self, payload: object) -> None:
+            decoded = msgpack.unpackb(cast(bytes, payload), raw=False)
+            if decoded.get("kind") == "batch_completion":
+                raise RuntimeError("fatal-batch-wire-down")
+            self.payloads.append(payload)
+
+    task_source: queue.Queue[object] = queue.Queue()
+    completion_queue = ExplodingBatchCompletionQueue()
+    registry_event_queue: queue.Queue[object] = queue.Queue()
+    items = [
+        WorkItem(f"work-{offset}", TopicPartition("topic", 1), offset, 7, b"key", b"")
+        for offset in (1, 2, 3)
+    ]
+    task_source.put(
+        _serialize_batch_payload(
+            RouteBatch("batch-fatal-fallback", ("topic", 1, b"key"), 0, items),
+            1.0,
+        )
+    )
+    task_source.put(None)
+
+    def fake_exit(code: int) -> None:
+        raise SystemExit(code)
+
+    def timeout_second(item: WorkItem) -> None:
+        if item.offset == 2:
+            raise TimeoutError("fatal-timeout")
+
+    monkeypatch.setattr(worker_runtime_module.os, "_exit", fake_exit)
+
+    with pytest.raises(SystemExit):
+        _worker_loop(
+            task_source,
+            cast(Any, completion_queue),
+            registry_event_queue,  # type: ignore[arg-type]
+            timeout_second,
+            0,
+            ExecutionConfig(
+                mode=ExecutionMode.PROCESS,
+                max_retries=1,
+                process_config=ProcessConfig(process_count=1),
+            ),
+        )
+
+    fallback_payloads = [
+        msgpack.unpackb(cast(bytes, payload), raw=False)
+        for payload in completion_queue.payloads
+    ]
+    assert [
+        (payload["id"], payload["offset"], payload["status"])
+        for payload in fallback_payloads
+    ] == [("work-1", 1, "success")]
+    diagnostics = [
+        cast(dict[str, Any], registry_event_queue.get_nowait())
+        for _ in range(registry_event_queue.qsize())
+    ]
+    assert [
+        event
+        for event in diagnostics
+        if event.get("kind") == "batch_completion_send_failed"
+    ] == [
+        {
+            "kind": "batch_completion_send_failed",
+            "batch_id": "batch-fatal-fallback",
+            "error": "fatal-batch-wire-down",
+        }
+    ]
 
 
 def test_registry_start_event_ignores_older_identity_when_identity_differs() -> None:
@@ -1690,7 +2708,7 @@ def test_shared_queue_transport_declares_no_pending_dispatch_recovery() -> None:
 
 
 def test_shared_queue_requeue_payloads_fails_fast_when_queue_is_full() -> None:
-    task_queue: queue.Queue[bytes] = queue.Queue(maxsize=1)
+    task_queue = cast(Any, queue.Queue(maxsize=1))
     task_queue.put_nowait(b"busy")
     transport = SharedQueueProcessTransport(
         task_queue=cast(Any, task_queue),
@@ -2007,7 +3025,7 @@ def test_publish_recovered_worker_payloads_emits_failure_when_shared_queue_is_fu
     )
     engine_any._completion_queue = queue.Queue()
     engine_any._logger = logging.getLogger(__name__)
-    task_queue: queue.Queue[bytes] = queue.Queue(maxsize=1)
+    task_queue = cast(Any, queue.Queue(maxsize=1))
     task_queue.put(b"occupied")
     engine_any._transport = SharedQueueProcessTransport(
         task_queue=task_queue,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -108,6 +108,31 @@ def test_execution_config_shutdown_policy_env_override(
     monkeypatch.delenv("EXECUTION_SHUTDOWN_DRAIN_TIMEOUT_MS", raising=False)
 
 
+def test_execution_config_route_batch_size_defaults_to_one() -> None:
+    config = ExecutionConfig()
+
+    assert config.route_batch_size == 1
+
+
+def test_execution_config_route_batch_size_env_override(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXECUTION_ROUTE_BATCH_SIZE", "64")
+
+    config = ExecutionConfig()
+
+    assert config.route_batch_size == 64
+
+    monkeypatch.delenv("EXECUTION_ROUTE_BATCH_SIZE", raising=False)
+
+
+def test_execution_config_rejects_invalid_route_batch_size() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        ExecutionConfig(route_batch_size=0)
+
+    assert "route_batch_size" in str(excinfo.value)
+
+
 def test_process_config_transport_mode_defaults_to_shared_queue() -> None:
     config = ProcessConfig()
 

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -4,7 +4,7 @@ from typing import cast
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
-from pyrallel_consumer.config import KafkaConfig
+from pyrallel_consumer.config import KafkaConfig, ParallelConsumerConfig
 from pyrallel_consumer.consumer import PyrallelConsumer
 from pyrallel_consumer.dto import (
     OrderingMode,
@@ -51,6 +51,7 @@ class _DummyWorkManager:
         ordering_mode=None,
         max_revoke_grace_ms=None,
         poison_message_circuit=None,
+        route_batch_size=None,
     ):
         self.execution_engine = execution_engine
         self.max_in_flight_messages = max_in_flight_messages
@@ -58,6 +59,7 @@ class _DummyWorkManager:
         self.ordering_mode = ordering_mode
         self.max_revoke_grace_ms = max_revoke_grace_ms
         self.poison_message_circuit = poison_message_circuit
+        self.route_batch_size = route_batch_size
 
     def set_metrics_exporter(self, metrics_exporter) -> None:
         self.metrics_exporter = metrics_exporter
@@ -153,6 +155,7 @@ async def test_pyrallel_consumer_starts_and_stops(monkeypatch: MonkeyPatch):
         ordering_mode=None,
         max_revoke_grace_ms=None,
         poison_message_circuit=None,
+        **_kwargs,
     ):
         nonlocal dummy_work_manager
         dummy_work_manager = _DummyWorkManager(
@@ -231,6 +234,7 @@ def test_pyrallel_consumer_wires_poison_message_circuit(
         ordering_mode=None,
         max_revoke_grace_ms=None,
         poison_message_circuit=None,
+        **_kwargs,
     ):
         nonlocal dummy_work_manager
         dummy_work_manager = _DummyWorkManager(
@@ -273,6 +277,56 @@ def test_pyrallel_consumer_wires_poison_message_circuit(
     assert circuit.cooldown_ms == 7500
 
 
+def test_pyrallel_consumer_wires_route_batch_size_to_work_manager(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    dummy_engine = _DummyEngine()
+
+    def _create_engine(execution_config, worker):  # noqa: ARG001
+        return dummy_engine
+
+    created_work_managers: list[_DummyWorkManager] = []
+
+    def _create_work_manager(
+        *,
+        execution_engine,
+        max_in_flight_messages,
+        metrics_exporter=None,
+        ordering_mode=None,
+        max_revoke_grace_ms=None,
+        poison_message_circuit=None,
+        route_batch_size=None,
+    ):
+        work_manager = _DummyWorkManager(
+            execution_engine=execution_engine,
+            max_in_flight_messages=max_in_flight_messages,
+            metrics_exporter=metrics_exporter,
+            ordering_mode=ordering_mode,
+            max_revoke_grace_ms=max_revoke_grace_ms,
+            poison_message_circuit=poison_message_circuit,
+            route_batch_size=route_batch_size,
+        )
+        created_work_managers.append(work_manager)
+        return work_manager
+
+    monkeypatch.setattr(
+        "pyrallel_consumer.consumer.create_execution_engine", _create_engine
+    )
+    monkeypatch.setattr("pyrallel_consumer.consumer.WorkManager", _create_work_manager)
+    monkeypatch.setattr("pyrallel_consumer.consumer.BrokerPoller", _DummyPoller)
+
+    parallel_config = ParallelConsumerConfig()
+    parallel_config.execution.route_batch_size = 7
+    config = cast(
+        KafkaConfig,
+        cast(object, SimpleNamespace(parallel_consumer=parallel_config)),
+    )
+
+    PyrallelConsumer(config=config, worker=lambda _: None, topic="demo")
+
+    assert created_work_managers[0].route_batch_size == 7
+
+
 @pytest.mark.asyncio
 async def test_pyrallel_consumer_auto_wires_metrics_exporter_when_enabled(
     monkeypatch: MonkeyPatch,
@@ -292,6 +346,7 @@ async def test_pyrallel_consumer_auto_wires_metrics_exporter_when_enabled(
         max_revoke_grace_ms=None,
         metrics_exporter=None,
         poison_message_circuit=None,
+        **_kwargs,
     ):
         nonlocal dummy_work_manager
         dummy_work_manager = _DummyWorkManager(
@@ -368,6 +423,7 @@ async def test_pyrallel_consumer_publishes_resource_signal_snapshot(
         max_revoke_grace_ms=None,
         metrics_exporter=None,
         poison_message_circuit=None,
+        **_kwargs,
     ):
         return _DummyWorkManager(
             execution_engine=execution_engine,
@@ -436,6 +492,7 @@ async def test_pyrallel_consumer_fails_open_when_resource_signal_provider_raises
         max_revoke_grace_ms=None,
         metrics_exporter=None,
         poison_message_circuit=None,
+        **_kwargs,
     ):
         return _DummyWorkManager(
             execution_engine=execution_engine,
@@ -508,6 +565,7 @@ async def test_pyrallel_consumer_creates_exporter_on_start_not_init(
         max_revoke_grace_ms=None,
         metrics_exporter=None,
         poison_message_circuit=None,
+        **_kwargs,
     ):
         return _DummyWorkManager(
             execution_engine=execution_engine,
@@ -571,6 +629,7 @@ async def test_pyrallel_consumer_metrics_cleanup_on_start_failure(
         max_revoke_grace_ms=None,
         metrics_exporter=None,
         poison_message_circuit=None,
+        **_kwargs,
     ):
         manager = _DummyWorkManager(
             execution_engine=execution_engine,
@@ -634,6 +693,7 @@ async def test_pyrallel_consumer_stop_updates_metrics_even_when_poller_stop_fail
         max_revoke_grace_ms=None,
         metrics_exporter=None,
         poison_message_circuit=None,
+        **_kwargs,
     ):
         nonlocal dummy_work_manager
         dummy_work_manager = _DummyWorkManager(
@@ -701,6 +761,7 @@ async def test_pyrallel_consumer_uses_configured_ordering_mode(
         ordering_mode=None,
         max_revoke_grace_ms=None,
         poison_message_circuit=None,
+        **_kwargs,
     ):
         nonlocal dummy_work_manager
         dummy_work_manager = _DummyWorkManager(
@@ -754,6 +815,7 @@ async def test_pyrallel_consumer_stop_still_shuts_down_engine_on_poller_failure(
         ordering_mode=None,
         max_revoke_grace_ms=None,
         poison_message_circuit=None,
+        **_kwargs,
     ):
         nonlocal dummy_work_manager
         dummy_work_manager = _DummyWorkManager(
@@ -809,6 +871,7 @@ async def test_pyrallel_consumer_wait_closed_is_passive(monkeypatch: MonkeyPatch
         ordering_mode=None,
         max_revoke_grace_ms=None,
         poison_message_circuit=None,
+        **_kwargs,
     ):
         nonlocal dummy_work_manager
         dummy_work_manager = _DummyWorkManager(


### PR DESCRIPTION
## Summary
- Adds route-batch execution contracts, ordered capability gating, and WorkManager route-batch leasing.
- Enables worker_pipes route-batch dispatch, sequential worker execution, BatchCompletion expansion, recovery handling, and msgpack hardening.
- Exposes route-batch benchmark controls and runtime IPC metrics for process transport analysis.

## Acceptance Gate
- Artifact: /private/tmp/pyrallel-route-batch-bench-results/gate/current-engines-rb64-keyhash-partition-baseline.json
- key_hash baseline: 784.88 TPS
- key_hash async: 5992.88 TPS, 7.64x baseline, PASS
- key_hash process worker_pipes rb64: 2583.74 TPS, 3.29x baseline, PASS
- partition baseline: 784.96 TPS
- partition async: 1607.05 TPS, 2.05x baseline, PASS
- partition process worker_pipes rb64: 1314.96 TPS, 1.68x baseline, PASS

## Correctness
- All acceptance runs processed 12000 messages.
- final_lag=0 and final_gap_count=0 for async and process key_hash and partition runs.
- Console validation reported PASS for key_hash and partition ordering in both async and process runs.

## Route-Batch IPC Evidence
- process key_hash rb64: items_per_input_ipc=20.87 and items_per_completion_ipc=20.87.
- process partition rb64: items_per_input_ipc=62.5 and items_per_completion_ipc=62.5.
- shared_queue rb1 current is equivalent to develop shared_queue after the hot-path decode fix: 2834.23 TPS vs 2828.15 TPS.

## Test Plan
- uv run pytest tests/unit/control_plane/test_work_manager.py tests/unit/control_plane/test_work_manager_ordering.py tests/unit/control_plane/test_broker_dispatch_support.py tests/unit/control_plane/test_transport_invariants.py
- uv run pytest tests/unit/execution_plane/test_base_execution_engine.py tests/unit/execution_plane/test_process_engine_batching.py tests/unit/execution_plane/test_process_execution_engine.py
- uv run pytest tests/unit/benchmarks/test_benchmark_runtime.py tests/unit/benchmarks/test_run_parallel_benchmark_tui.py tests/unit/benchmarks/test_stats.py
- uv run ruff check .

## Caveats
- p99 completion-to-refill latency is still a dedicated measurement gap. Current JSON has processing latency fields, but not a distinct completion-to-refill metric.
- worker_pipes rb1 remains a non-target item-mode comparison path and is slower than develop worker_pipes item mode in the latest comparison.