### PR TITLE
feat(tui): expose process route batch options

### DIFF
--- a/benchmarks/tui/option_help.py
+++ b/benchmarks/tui/option_help.py
@@ -53,6 +53,26 @@ OPTION_HELP = {
         label="Worker IO sleep (ms)",
         description="Delay each simulated IO workload by this many milliseconds.",
     ),
+    "process-count": OptionHelp(
+        label="Process count",
+        description="Override the number of process-mode worker processes.",
+    ),
+    "process-transport": OptionHelp(
+        label="Process transport",
+        description="Select how process-mode work is delivered to workers.",
+    ),
+    "process-batch-size": OptionHelp(
+        label="Process batch size",
+        description="Override process-mode worker micro-batch size.",
+    ),
+    "process-max-batch-wait-ms": OptionHelp(
+        label="Process max batch wait (ms)",
+        description="Maximum time to wait while filling a process micro-batch.",
+    ),
+    "route-batch-size": OptionHelp(
+        label="Route batch size",
+        description="Lease up to this many same-route items per scheduling step.",
+    ),
     "metrics-port": OptionHelp(
         label="Metrics port",
         description="Expose benchmark Prometheus metrics on this host port. Use 0 to disable.",

--- a/benchmarks/tui/screens/options.py
+++ b/benchmarks/tui/screens/options.py
@@ -464,6 +464,8 @@ class OptionsScreen(Screen[None]):
             with Container(id="options-footer"):
                 yield Static("", id="form-error-summary")
                 yield Static(" ".join(state.to_argv()), id="argv-preview")
+                yield Button("Copy CLI command", id="copy-command-button")
+                yield Static("", id="copy-command-status")
                 with Container(id="options-actions"):
                     yield Button("Run benchmark", id="run-button", variant="primary")
                     yield Button("Quit", id="quit-button")
@@ -498,10 +500,20 @@ class OptionsScreen(Screen[None]):
         """Handle on button pressed within options."""
         if event.button.id == "run-button" and not event.button.disabled:
             self.app.push_screen(RunScreen(self._last_valid_state))
+        elif event.button.id == "copy-command-button":
+            self._copy_cli_command()
         elif event.button.id == "quit-button":
             self.app.exit()
         elif event.button.id is not None and event.button.id.startswith("browse-"):
             self._open_directory_picker(event.button.id.removeprefix("browse-"))
+
+    def _copy_cli_command(self) -> None:
+        """Copy the current benchmark command to the clipboard."""
+        command = self._cli_command(self._last_valid_state)
+        self.app.copy_to_clipboard(command)
+        self.query_one("#copy-command-status", Static).update(
+            "CLI command copied to clipboard."
+        )
 
     def _refresh_form_state(self) -> None:
         """Refresh form state for options."""
@@ -522,6 +534,13 @@ class OptionsScreen(Screen[None]):
             self.query_one("#argv-preview", Static).update(
                 " ".join(validation.state.to_argv())
             )
+
+    @staticmethod
+    def _cli_command(state: BenchmarkTuiState) -> str:
+        """Build the full CLI command for the current TUI state."""
+        return "uv run python -m benchmarks.run_parallel_benchmark %s" % " ".join(
+            state.to_argv()
+        )
 
     def _render_errors(self, errors: dict[str, str]) -> None:
         """Handle render errors within options."""

--- a/benchmarks/tui/screens/options.py
+++ b/benchmarks/tui/screens/options.py
@@ -42,11 +42,19 @@ class OptionsScreen(Screen[None]):
         "num-keys": 1,
         "num-partitions": 1,
         "timeout-sec": 1,
+        "route-batch-size": 1,
     }
     _NON_NEGATIVE_INT_FIELDS = {
         "metrics-port": 0,
         "worker-cpu-iterations": 0,
         "profile-top-n": 0,
+    }
+    _OPTIONAL_POSITIVE_INT_FIELDS = {
+        "process-count": 1,
+        "process-batch-size": 1,
+    }
+    _OPTIONAL_NON_NEGATIVE_INT_FIELDS = {
+        "process-max-batch-wait-ms": 0,
     }
     _NON_NEGATIVE_FLOAT_FIELDS = {
         "worker-sleep-ms": 0.0,
@@ -294,6 +302,51 @@ class OptionsScreen(Screen[None]):
                         widget_id="metrics-port",
                         placeholder="9091",
                     )
+                    yield from self._labeled_input(
+                        option_id="process-count",
+                        value=(
+                            ""
+                            if state.process_count is None
+                            else str(state.process_count)
+                        ),
+                        widget_id="process-count",
+                        placeholder="default",
+                    )
+                    yield from self._labeled_select(
+                        option_id="process-transport",
+                        options=[
+                            ("shared_queue", "shared_queue"),
+                            ("worker_pipes", "worker_pipes"),
+                        ],
+                        value=state.process_transport,
+                        widget_id="process-transport",
+                    )
+                    yield from self._labeled_input(
+                        option_id="process-batch-size",
+                        value=(
+                            ""
+                            if state.process_batch_size is None
+                            else str(state.process_batch_size)
+                        ),
+                        widget_id="process-batch-size",
+                        placeholder="default",
+                    )
+                    yield from self._labeled_input(
+                        option_id="process-max-batch-wait-ms",
+                        value=(
+                            ""
+                            if state.process_max_batch_wait_ms is None
+                            else str(state.process_max_batch_wait_ms)
+                        ),
+                        widget_id="process-max-batch-wait-ms",
+                        placeholder="default",
+                    )
+                    yield from self._labeled_input(
+                        option_id="route-batch-size",
+                        value=str(state.route_batch_size),
+                        widget_id="route-batch-size",
+                        placeholder="1",
+                    )
                     yield from self._switch_field(
                         option_id="skip-reset",
                         value=state.skip_reset,
@@ -493,6 +546,10 @@ class OptionsScreen(Screen[None]):
             if widget_id == "profile-top-n" and not profiling_enabled:
                 continue
             self._validate_int(widget_id, minimum, parsed_ints, errors)
+        for widget_id, minimum in self._OPTIONAL_POSITIVE_INT_FIELDS.items():
+            self._validate_optional_int(widget_id, minimum, parsed_ints, errors)
+        for widget_id, minimum in self._OPTIONAL_NON_NEGATIVE_INT_FIELDS.items():
+            self._validate_optional_int(widget_id, minimum, parsed_ints, errors)
         for widget_id, minimum_float in self._NON_NEGATIVE_FLOAT_FIELDS.items():
             self._validate_float(widget_id, minimum_float, parsed_floats, errors)
 
@@ -525,6 +582,11 @@ class OptionsScreen(Screen[None]):
             num_partitions=parsed_ints["num-partitions"],
             timeout_sec=parsed_ints["timeout-sec"],
             metrics_port=parsed_ints["metrics-port"],
+            process_count=parsed_ints.get("process-count"),
+            process_transport=str(self.query_one("#process-transport", Select).value),
+            process_batch_size=parsed_ints.get("process-batch-size"),
+            process_max_batch_wait_ms=parsed_ints.get("process-max-batch-wait-ms"),
+            route_batch_size=parsed_ints["route-batch-size"],
             topic_prefix=self.query_one("#topic-prefix", Input).value,
             workloads=workloads,
             ordering_modes=ordering_modes,
@@ -565,6 +627,27 @@ class OptionsScreen(Screen[None]):
         if value < minimum:
             comparator = ">="
             errors[widget_id] = "Enter a whole number %s %d." % (comparator, minimum)
+            return
+        parsed_values[widget_id] = value
+
+    def _validate_optional_int(
+        self,
+        widget_id: str,
+        minimum: int,
+        parsed_values: dict[str, int],
+        errors: dict[str, str],
+    ) -> None:
+        """Validate optional int for options."""
+        raw_value = self.query_one("#%s" % widget_id, Input).value.strip()
+        if not raw_value:
+            return
+        try:
+            value = int(raw_value)
+        except ValueError:
+            errors[widget_id] = "Enter a whole number or leave blank."
+            return
+        if value < minimum:
+            errors[widget_id] = "Enter a whole number >= %d or leave blank." % minimum
             return
         parsed_values[widget_id] = value
 

--- a/benchmarks/tui/screens/options.py
+++ b/benchmarks/tui/screens/options.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -538,8 +539,15 @@ class OptionsScreen(Screen[None]):
     @staticmethod
     def _cli_command(state: BenchmarkTuiState) -> str:
         """Build the full CLI command for the current TUI state."""
-        return "uv run python -m benchmarks.run_parallel_benchmark %s" % " ".join(
-            state.to_argv()
+        return shlex.join(
+            [
+                "uv",
+                "run",
+                "python",
+                "-m",
+                "benchmarks.run_parallel_benchmark",
+                *state.to_argv(),
+            ]
         )
 
     def _render_errors(self, errors: dict[str, str]) -> None:

--- a/benchmarks/tui/state.py
+++ b/benchmarks/tui/state.py
@@ -35,6 +35,11 @@ class BenchmarkTuiState:
     worker_sleep_ms: float = 0.5
     worker_cpu_iterations: int = 1000
     worker_io_sleep_ms: float = 0.5
+    process_count: int | None = 4
+    process_transport: str = "worker_pipes"
+    process_batch_size: int | None = 1
+    process_max_batch_wait_ms: int | None = 0
+    route_batch_size: int = 64
     metrics_port: int = 9091
     py_spy: bool = False
     py_spy_format: str = "flamegraph"
@@ -77,9 +82,21 @@ class BenchmarkTuiState:
             str(self.worker_cpu_iterations),
             "--worker-io-sleep-ms",
             str(self.worker_io_sleep_ms),
+            "--process-transport",
+            self.process_transport,
+            "--route-batch-size",
+            str(self.route_batch_size),
         ]
 
         argv.extend(["--metrics-port", str(self.metrics_port)])
+
+        for value, flag in (
+            (self.process_count, "--process-count"),
+            (self.process_batch_size, "--process-batch-size"),
+            (self.process_max_batch_wait_ms, "--process-max-batch-wait-ms"),
+        ):
+            if value is not None:
+                argv.extend([flag, str(value)])
 
         if self.profiling_enabled:
             argv.extend(

--- a/docs/blueprint/00-index.ko.md
+++ b/docs/blueprint/00-index.ko.md
@@ -34,14 +34,14 @@
 - [01-async-execution-engine](features/03-execution/01-async-execution-engine/00-index.ko.md)
   `asyncio` task 기반 실행, semaphore, timeout, graceful shutdown
 - [02-process-execution-engine](features/03-execution/02-process-execution-engine/00-index.ko.md)
-  multiprocessing, msgpack micro-batch, picklable worker, worker recycle
+  multiprocessing, worker-pipe route batch, msgpack payload, picklable worker, worker recycle
 
 ### `04-tooling`
 
 - [01-observability-metrics](features/04-tooling/01-observability-metrics/00-index.ko.md)
   `SystemMetrics`, Prometheus exporter, alert/tuning 관측 surface
 - [02-benchmark-runtime](features/04-tooling/02-benchmark-runtime/00-index.ko.md)
-  baseline/async/process 비교 벤치마크, TUI, profiling, 결과 해석
+  baseline/async/process 비교 벤치마크, route-batch 실험 옵션, TUI, profiling, 결과 해석
 
 ## 빠른 읽기 가이드
 

--- a/docs/blueprint/00-index.md
+++ b/docs/blueprint/00-index.md
@@ -34,14 +34,14 @@ For the preserved Korean source text, see [00-index.ko.md](./00-index.ko.md).
 - [01-async-execution-engine](./features/03-execution/01-async-execution-engine/00-index.md)
   `asyncio` task execution, semaphores, timeout handling, and graceful shutdown.
 - [02-process-execution-engine](./features/03-execution/02-process-execution-engine/00-index.md)
-  Multiprocessing workers, msgpack micro-batching, picklable workers, and worker recycle controls.
+  Multiprocessing workers, worker-pipe route batching, msgpack payloads, picklable workers, and worker recycle controls.
 
 ### `04-tooling`
 
 - [01-observability-metrics](./features/04-tooling/01-observability-metrics/00-index.md)
   `SystemMetrics`, Prometheus export, alerting signals, and operator-facing telemetry.
 - [02-benchmark-runtime](./features/04-tooling/02-benchmark-runtime/00-index.md)
-  Baseline vs async vs process benchmarking, profiling hooks, and result interpretation.
+  Baseline vs async vs process benchmarking, route-batch experiment knobs, profiling hooks, and result interpretation.
 
 ## Reading guide
 

--- a/docs/blueprint/features/03-execution/02-process-execution-engine/00-index.ko.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/00-index.ko.md
@@ -16,6 +16,8 @@
 - process engine도 장기적으로는 같은 철학을 따라야 한다.
 - 즉, `WorkManager`가 safe-to-run item을 고르면 process engine은 submit 순간
   route identity를 사용해 적절한 worker execution slot/channel로 보내야 한다.
+  이 경계는 단일 `submit(work_item)`과 route 단위
+  `submit_batch(work_items)`를 모두 포함한다.
 - 이 route identity는 process 전용 새 scheduling hint가 아니다. async path에서도
   `WorkManager`가 이미 사용하는 동일한 logical queue identity를 process IPC
   routing에 재사용하는 것이다.
@@ -67,8 +69,22 @@ queue를 process boundary 앞에서 다시 하나로 합치는 문제가 있다.
 | --- | --- |
 | [01-requirements.ko.md](./01-requirements.ko.md) | process engine 책임, transport mode, acceptance 기준 |
 | [02-architecture.ko.md](./02-architecture.ko.md) | shared queue topology와 target worker-affine topology 비교 |
-| [03-design.ko.md](./03-design.ko.md) | config, routing identity, batching/lifecycle/runtime contract |
-| [04-worker-pipe-transport-experiment.ko.md](./04-worker-pipe-transport-experiment.ko.md) | worker-affine topology를 bounded slice로 검증하는 실험 지시서 |
+| [03-design.ko.md](./03-design.ko.md) | config, routing identity, route batching/lifecycle/runtime contract |
+| [04-worker-pipe-transport-experiment.ko.md](./04-worker-pipe-transport-experiment.ko.md) | worker-pipe transport와 route-batch 실험 계약 |
+
+## 현재 route-batch 구현 상태
+
+- `shared_queue`는 여전히 기본 compatibility path다.
+- `ExecutionConfig.route_batch_size` 기본값은 `1`이며, `1`보다 큰 값은 명시적
+  실험/benchmark 옵션이다.
+- `WorkManager`는 engine이 `supports_ordered_route_batch=True`를 광고할 때만
+  ordered route에서 batch lease를 허용한다.
+- `worker_pipes`는 같은 route의 item 묶음을 하나의 route-batch payload로 보내고,
+  worker는 batch 내부 item을 순서대로 실행한다.
+- worker-to-parent completion은 정상 경로에서 하나의 internal `BatchCompletion`
+  envelope로 이동하고, parent가 기존 `CompletionEvent` 목록으로 펼친다.
+- registry, retry, commit, recovery accounting은 item 단위를 유지한다. batch는
+  transport envelope일 뿐 commit/retry 단위가 아니다.
 
 ## 빠른 읽기 분기
 

--- a/docs/blueprint/features/03-execution/02-process-execution-engine/00-index.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/00-index.md
@@ -17,7 +17,8 @@ The intended model is:
 - the async engine spreads safe-to-run work immediately via `create_task()`
   without re-merging it into one input queue,
 - the process engine should move toward the same shape by selecting the
-  appropriate worker execution channel at `submit(work_item)` time.
+  appropriate worker execution channel at `submit(work_item)` or
+  `submit_batch(work_items)` time.
 
 The route identity is not a process-only scheduling hint. It is the same logical
 queue identity that `WorkManager` already uses before async and process execution
@@ -25,7 +26,7 @@ diverge.
 
 ## Why this matters
 
-The current `shared_queue` process path places every submitted item into one
+The compatibility `shared_queue` process path places every submitted item into one
 shared `multiprocessing.Queue`, so all workers compete on the same input queue.
 That compatibility path remains important, but benchmark and py-spy evidence
 suggest it is a bottleneck for ordered partition workloads.
@@ -44,8 +45,8 @@ The evidence direction captured in these docs is:
 | --- | --- |
 | [01-requirements.md](./01-requirements.md) | Responsibilities, transport modes, and acceptance criteria |
 | [02-architecture.md](./02-architecture.md) | Current shared-queue topology vs target worker-affine topology |
-| [03-design.md](./03-design.md) | Config, routing identity, lifecycle, batching, and runtime contract |
-| [04-worker-pipe-transport-experiment.md](./04-worker-pipe-transport-experiment.md) | Bounded experiment blueprint for the worker-pipe direction |
+| [03-design.md](./03-design.md) | Config, routing identity, lifecycle, route batching, and runtime contract |
+| [04-worker-pipe-transport-experiment.md](./04-worker-pipe-transport-experiment.md) | Worker-pipe transport and route-batch experiment contract |
 
 ## Key principles
 
@@ -53,5 +54,26 @@ The evidence direction captured in these docs is:
 - `worker_pipes` is the ordering-preserving parallelism direction and an
   eventual default candidate, not a mandated immediate default.
 - `WorkManager` and `BrokerPoller` stay transport-agnostic.
-- `BaseExecutionEngine.submit(work_item)` stays unchanged.
+- `BaseExecutionEngine.submit(work_item)` stays unchanged, and
+  `submit_batch(work_items)` is an execution-engine contract with item-semantics
+  fallback.
+- ordered route batching is enabled only when the engine explicitly advertises
+  `supports_ordered_route_batch`.
 - ordered modes prefer sticky routing and affinity preservation over stealing.
+
+## Current route-batch status
+
+The implemented experiment keeps `shared_queue` as the default compatibility
+path and adds an explicit route-batch path for `worker_pipes`.
+
+- `ExecutionConfig.route_batch_size` defaults to `1`; values greater than `1`
+  are experimental and benchmark-controlled.
+- `WorkManager` may lease multiple items from one virtual queue, bounded by
+  remaining in-flight capacity and poison/force-fail guards.
+- `worker_pipes` can send one route-batch payload to the selected worker, which
+  executes the items sequentially.
+- Worker-to-parent route-batch completion is represented as one internal
+  `BatchCompletion` envelope and expanded back into item-level
+  `CompletionEvent` instances in the parent.
+- Registry, retry, commit, and recovery accounting remain item-level; the batch
+  is a transport envelope, not a commit or retry unit.

--- a/docs/blueprint/features/03-execution/02-process-execution-engine/01-requirements.ko.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/01-requirements.ko.md
@@ -80,7 +80,17 @@ process execution engine의 목표 모델은 다음과 같다.
 
 - `WorkManager`와 `BrokerPoller`는 transport mode를 몰라야 한다.
 - `BaseExecutionEngine.submit(work_item)` 계약은 유지해야 한다.
-- completion queue는 1차로 single aggregator를 유지해야 한다.
+- `BaseExecutionEngine.submit_batch(work_items)`는 engine 공통 계약이다. 기본
+  fallback은 기존 `submit()`을 item 순서대로 호출해야 한다.
+- partial batch acceptance는 명시적이어야 한다. engine은 batch 전체를 accept하거나,
+  일반 예외에서는 accepted count를 0으로 취급하거나, 일부 prefix만 accept했다면
+  `BatchSubmitError(accepted_count=...)`를 던져야 한다.
+- ordered route batch는 engine이 `supports_ordered_route_batch=True`를 명시할 때만
+  허용한다. 그렇지 않으면 `KEY_HASH`/`PARTITION`의 effective batch size는 `1`이다.
+- completion aggregation ownership은 parent/control plane에 남는다.
+  `worker_pipes`는 internal `BatchCompletion` envelope로 worker-to-parent IPC를
+  줄일 수 있지만, parent가 외부 surface를 기존 `CompletionEvent` 단위로 펼쳐야
+  한다.
 - process transport 변경이 commit / broker I/O / retry policy를 직접 바꿔서는 안
   된다.
 
@@ -100,6 +110,10 @@ process execution engine의 목표 모델은 다음과 같다.
 - picklable worker 검증이 설정으로 강제될 수 있어야 한다.
 - batching은 IPC 비용 절감 수단이어야 하며 ordering correctness 계층을 대체하면
   안 된다.
+- `ExecutionConfig.route_batch_size` 기본값은 `1`이며, `1`보다 큰 값은 명시적
+  실험/benchmark 옵션으로 다룬다.
+- route batch는 transport envelope일 뿐이다. registry, retry, DLQ, commit,
+  recovery accounting은 item 단위를 유지해야 한다.
 - `wait_for_completion()`은 transport별로 관측 가능한 의미가 동일해야 한다.
 - shutdown은 sentinel, join, terminate/kill escalation 순서를 유지해야 한다.
 - recycle semantics는 transport별로 유지하거나 명시적으로 reject해야 한다.
@@ -109,6 +123,8 @@ process execution engine의 목표 모델은 다음과 같다.
 - ordered partition workload에서 shared input queue 병목을 줄이는 방향이
   benchmark로 설명 가능해야 한다.
 - msgpack payload는 size guard를 가져야 한다.
+- malformed route-batch / batch-completion payload는 빈 work나 빈 completion으로
+  해석하지 말고 명시적으로 실패해야 한다.
 - 프로세스 누수가 없어야 한다.
 - crash/timeout이 consumer 전체 crash로 번지지 않아야 한다.
 - metrics / benchmark / release-gate evidence가 transport 차이를 해석할 수
@@ -154,3 +170,6 @@ process execution engine의 목표 모델은 다음과 같다.
   지목한다는 점이 드러나야 한다.
 - config, lifecycle, batching, `wait_for_completion()`, shutdown/recycle,
   metrics surface가 문서에서 빠지지 않아야 한다.
+- route-batch 구현은 같은 route만 묶고, worker 내부 순서 실행, 실패 후 tail
+  recovery, fatal exit 전 completed prefix flush, bounded duplicate suppression을
+  보장해야 한다.

--- a/docs/blueprint/features/03-execution/02-process-execution-engine/01-requirements.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/01-requirements.md
@@ -16,8 +16,9 @@ that `WorkManager` already computes before work crosses the process boundary.
   plus eligibility.
 - The async engine spreads safe-to-run work immediately via `create_task()`
   instead of re-merging all work into one input queue.
-- The current process engine still sends submitted work through one shared
-  `multiprocessing.Queue`, so all workers compete on the same input source.
+- The compatibility `shared_queue` process path sends submitted work through one
+  shared `multiprocessing.Queue`, so all workers compete on the same input
+  source.
 - Benchmark and py-spy evidence point at input dispatch topology as a higher
   priority improvement target than completion aggregation.
 
@@ -28,8 +29,39 @@ that `WorkManager` already computes before work crosses the process boundary.
   future default candidate.
 - `WorkManager` and `BrokerPoller` remain transport-agnostic.
 - `BaseExecutionEngine.submit(work_item)` remains unchanged.
+- `BaseExecutionEngine.submit_batch(work_items)` is part of the engine contract.
+  The fallback must preserve item semantics by calling `submit()` in order.
+- Partial batch acceptance must be explicit: an engine either accepts the whole
+  batch, accepts nothing for a generic exception, or raises `BatchSubmitError`
+  with the accepted prefix count.
+- Ordered route batching is allowed only for engines that advertise
+  `supports_ordered_route_batch=True`; otherwise `KEY_HASH` and `PARTITION`
+  modes use an effective route batch size of `1`.
+- `ExecutionConfig.route_batch_size` defaults to `1` and is an explicit
+  experiment/benchmark knob rather than a production default change.
 - The process engine chooses a worker channel internally by route identity.
 - Ordered modes favor sticky routing and affinity preservation over stealing.
-- Completion aggregation remains a single aggregator in the first step.
+- Completion aggregation remains parent-owned. `worker_pipes` may reduce
+  worker-to-parent IPC with internal `BatchCompletion` envelopes, but the public
+  completion surface remains item-level `CompletionEvent` instances.
+- Registry, retry, DLQ, commit, and recovery accounting remain item-level; route
+  batches are transport envelopes, not correctness units.
 - Config, batching, `wait_for_completion()`, shutdown, recycle, and metrics
   surface must be documented explicitly.
+
+## Route-batch acceptance requirements
+
+For the explicit `worker_pipes` route-batch path:
+
+- same-route batches must not mix route identities;
+- `PARTITION` routing groups by `(topic, partition)`;
+- `KEY_HASH` routing groups by `(topic, partition, key)`;
+- workers execute a route batch sequentially and stop after the first item
+  failure;
+- unstarted tail items must be surfaced for recovery or requeue, never silently
+  dropped;
+- fatal worker exits must flush the completed prefix before the worker exits;
+- duplicate item completions from mixed legacy/batch paths must be suppressed by
+  a bounded parent-side cache;
+- malformed or oversized msgpack payloads must fail visibly before they can be
+  interpreted as empty work.

--- a/docs/blueprint/features/03-execution/02-process-execution-engine/02-architecture.ko.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/02-architecture.ko.md
@@ -50,11 +50,13 @@ WorkManager virtual queues
 
 ```text
 WorkManager virtual queues
-  -> ProcessExecutionEngine.submit()
-  -> route identity resolution
+  -> ProcessExecutionEngine.submit() / submit_batch()
+  -> route identity resolution 또는 RouteBatch lease
   -> worker-affine execution slot/channel
   -> owner worker process
-  -> single completion queue
+  -> item CompletionEvent 또는 BatchCompletion envelope
+  -> parent-side CompletionEvent[] expansion
+  -> single completion queue surface
   -> single registry event queue
 ```
 
@@ -104,10 +106,33 @@ payload 수신/경쟁**에 더 가깝다는 뜻이다.
 
 - 역할: ordered parallelism 검증과 장기 방향의 first-class path
 - input: worker별 parent-to-worker channel
-- routing: `WorkItem` route identity 기반 sticky dispatch
-- completion: 기존 single aggregator 유지
+- routing: `WorkItem` route identity 또는 같은 route의 `RouteBatch` 기반 sticky dispatch
+- completion: 정상 route-batch path에서는 internal `BatchCompletion` envelope를 쓰고,
+  parent가 기존 item-level completion으로 펼침
 - 장점: ordered affinity preservation
-- 약점: batching/recycle/restart parity를 transport별로 더 명시해야 함
+- 약점: recycle/restart parity와 large in-flight pending lookup 비용은 transport별로
+  계속 명시해야 함
+
+### 6.3 route-batch path
+
+```mermaid
+flowchart LR
+    Poll["Kafka poll batch"]
+    WM["WorkManager virtual queues"]
+    Lease["same-route lease"]
+    Engine["submit_batch(items)"]
+    Pipe["worker_pipes route-batch payload"]
+    Worker["worker sequential loop"]
+    Done["BatchCompletion envelope"]
+    Expand["parent expands CompletionEvent[]"]
+    Commit["OffsetTracker / commit"]
+
+    Poll --> WM --> Lease --> Engine --> Pipe --> Worker --> Done --> Expand --> Commit
+```
+
+batch 경계는 control plane 아래에 있다. `WorkManager`는 여전히 safe-to-run item만
+고르고, parent-side recovery는 envelope 안의 개별 `WorkItem` identity를 기준으로
+동작한다.
 
 ## 7. route identity와 affinity
 
@@ -132,11 +157,12 @@ route_identity = (topic, partition, key)
 | 계층 | 유지할 계약 |
 | --- | --- |
 | input dispatch | transport mode별로 달라질 수 있음 |
-| completion aggregation | 1차로 single queue 유지 |
+| completion aggregation | parent-side item completion surface 유지. route-batch IPC는 internal envelope 사용 가능 |
 | registry event queue | parent-side in-flight/lifecycle accounting 유지 |
 | logging queue | worker log를 parent listener에 집계 |
 
-즉, 지금 바꾸려는 것은 “input topology”지 “completion topology”가 아니다.
+즉, route-batch가 바꾸는 것은 IPC envelope와 input topology다. commit/retry/DLQ
+correctness 단위는 여전히 item이다.
 
 ## 9. lifecycle / shutdown architecture
 

--- a/docs/blueprint/features/03-execution/02-process-execution-engine/02-architecture.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/02-architecture.md
@@ -20,11 +20,13 @@ The target direction is:
 
 ```text
 WorkManager virtual queues
-  -> submit()
-  -> route identity resolution
+  -> submit() / submit_batch()
+  -> route identity resolution or RouteBatch lease
   -> worker-affine execution channel
   -> owner worker process
-  -> single completion queue
+  -> item CompletionEvent or BatchCompletion envelope
+  -> parent expansion to item completions
+  -> single completion queue surface
 ```
 
 ## Architectural implications
@@ -34,8 +36,34 @@ WorkManager virtual queues
 - `shared_queue` remains the compatibility/default topology.
 - `worker_pipes` is the worker-affine topology used to validate and evolve the
   long-term direction.
-- Completion aggregation remains single-queue in the first step.
+- Completion ownership remains parent-side and item-level. `worker_pipes` can
+  use `BatchCompletion` as an internal IPC envelope, but parent polling still
+  returns item-level completions and `batch_limit` remains item-count based.
 - Ordered modes prefer affinity preservation, not stealing.
+- Route-batch recovery, retry, and commit accounting remain item-level.
+
+## Route-batch topology
+
+The implemented route-batch topology is:
+
+```mermaid
+flowchart LR
+    Poll["Kafka poll batch"]
+    WM["WorkManager virtual queues"]
+    Lease["same-route lease"]
+    Engine["submit_batch(items)"]
+    Pipe["worker_pipes route-batch payload"]
+    Worker["worker sequential loop"]
+    Done["BatchCompletion envelope"]
+    Expand["parent expands CompletionEvent[]"]
+    Commit["OffsetTracker / commit"]
+
+    Poll --> WM --> Lease --> Engine --> Pipe --> Worker --> Done --> Expand --> Commit
+```
+
+The batch boundary is intentionally below the control plane. `WorkManager` still
+chooses only safe-to-run items, and parent-side recovery still reasons about the
+individual `WorkItem` identities inside the envelope.
 
 ## Evidence-backed rationale
 

--- a/docs/blueprint/features/03-execution/02-process-execution-engine/03-design.ko.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/03-design.ko.md
@@ -27,11 +27,14 @@
 | `PROCESS_MSGPACK_MAX_BYTES` | decode safety limit | `1000000` |
 | `PROCESS_MAX_TASKS_PER_CHILD` | worker recycle threshold | `0` |
 | `PROCESS_RECYCLE_JITTER_MS` | recycle jitter | `0` |
+| `EXECUTION_ROUTE_BATCH_SIZE` | 같은 route에서 한 번에 lease할 item 수 | `1` |
 
 설계 원칙:
 
 - `transport_mode=shared_queue`는 기본값이다.
 - `transport_mode=worker_pipes`는 ordered affinity-preserving path다.
+- `route_batch_size=1`은 기존 item submission 의미를 유지한다.
+- `route_batch_size>1`은 명시적 실험/benchmark 옵션이다.
 - invalid transport 값은 config validation에서 즉시 실패해야 한다.
 
 ## 3. worker 계약
@@ -79,11 +82,13 @@ routing에 쓰지 않고 `create_task()`로 바로 실행한다.
 
 - submit 순간 worker channel을 선택한다.
 - parent는 worker별 input channel에 payload를 보낸다.
-- completion은 기존 single completion queue를 유지한다.
+- parent-facing completion surface는 기존 item-level completion queue 의미를
+  유지한다.
+- route-batch 정상 경로는 internal `BatchCompletion` envelope를 쓸 수 있다.
 - registry event queue도 parent-side 단일 drain 경로를 유지한다.
 
-즉 design 레벨에서 바꾸는 것은 input dispatch다. completion aggregation은 1차
-slice에서 바꾸지 않는다.
+즉 design 레벨에서 바꾸는 것은 input dispatch와 route-batch IPC envelope다.
+completion/retry/commit correctness 단위는 item으로 유지한다.
 
 ## 6. batching 계약
 
@@ -96,14 +101,25 @@ batching은 correctness layer가 아니라 IPC 비용 절감 수단이다.
 
 ### worker_pipes
 
-- 1차 slice에서는 `batch_size=1`, `max_batch_wait_ms=0` 중심으로 bounded support를
-  두는 것이 기본이다.
-- richer batching을 지원하지 못하면 silent fallback 대신 startup reject가
-  우선이다.
-- 아래 의미를 암묵적으로 바꾸면 안 된다.
-  - `size_or_timer`
-  - `demand`
-  - `demand_min_residence`
+- `ProcessConfig.batch_size`와 `ExecutionConfig.route_batch_size`는 별도 축이다.
+- `worker_pipes`의 ordered route batching은 `route_batch_size`로 제어한다.
+- `KEY_HASH`/`PARTITION` ordered route batch는 engine이
+  `supports_ordered_route_batch=True`를 명시할 때만 활성화한다.
+- batch payload는 같은 route의 item만 포함해야 하며, worker는 batch 내부 item을
+  순서대로 실행한다.
+- 정상 completion path는 executed prefix를 하나의 internal `BatchCompletion`
+  envelope로 보내고, parent가 기존 `CompletionEvent` 단위로 펼친다.
+- registry, retry, DLQ, commit accounting은 item 단위를 유지한다.
+- 기존 process micro-batch flush policy의 의미(`size_or_timer`, `demand`,
+  `demand_min_residence`)를 route batch 의미로 암묵적으로 재해석하면 안 된다.
+
+### `submit_batch()` contract
+
+- 기본 fallback은 `submit()`을 item 순서대로 호출한다.
+- 일부 prefix만 accept한 뒤 실패하면 `BatchSubmitError(accepted_count=...)`로
+  알려야 한다.
+- 일반 예외는 accepted count `0`으로 취급한다.
+- fallback 자체는 ordered same-route 실행을 보장하는 sequential executor가 아니다.
 
 ## 7. `wait_for_completion()` 계약
 
@@ -142,6 +158,10 @@ transport가 달라도 다음 의미를 유지해야 한다.
 
 - `get_runtime_metrics()`는 transport별 runtime 해석이 가능해야 한다.
 - benchmark metadata는 transport mode를 포함해야 한다.
+- route-batch path는 `items_per_input_ipc`, `items_per_completion_ipc`,
+  `route_batch_count`, `route_batch_item_count`, `route_batch_size_avg`,
+  `route_batch_size_max`, `completion_item_payload_count`,
+  `completion_batch_payload_count`를 통해 IPC amortization을 해석할 수 있어야 한다.
 - release-gate는 final lag / final gap / ordering evidence를 같은 기준으로
   평가해야 한다.
 - transport별 unsupported/rejected 조합도 로그 또는 runtime metadata로
@@ -156,3 +176,15 @@ transport가 달라도 다음 의미를 유지해야 한다.
 - `worker_pipes`는 ordered throughput 개선을 위한 direction path로 다룬다.
 - completion queue 분리, broker I/O bridge, work stealing, shared memory transport는
   이 design 범위에 포함하지 않는다.
+
+## 11. route-batch safety guard
+
+- poison/force-fail 대상이 batch 뒤쪽에 있으면 그 item 앞에서 batch를 끊는다.
+- worker death 전/후 아직 start되지 않은 batch tail은 recoverable해야 한다.
+- live-worker `not_started` tail은 diagnostic-only가 아니라 requeue/recovery 신호다.
+- fatal timeout/exit path는 worker가 죽기 전에 completed prefix
+  `BatchCompletion`을 flush해야 한다.
+- duplicate completion suppression은 장기 실행에서 메모리가 무한히 늘지 않도록
+  bounded cache여야 한다.
+- msgpack completion bytes는 unpack 전에 size guard를 거치고, malformed batch
+  payload는 빈 work/completion으로 해석하지 않는다.

--- a/docs/blueprint/features/03-execution/02-process-execution-engine/03-design.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/03-design.md
@@ -25,6 +25,8 @@ replaces, the item-level contract.
 - transport-specific input dispatch
 - internal `RouteBatch` and `BatchCompletion` worker-pipe envelopes
 - parent-side expansion back to item-level `CompletionEvent` instances
+- single completion aggregation remains parent-owned even when worker-pipe
+  route batches amortize worker-to-parent IPC
 - batching semantics and explicit unsupported combinations
 - `wait_for_completion()` parity
 - shutdown, recycle, restart, and runtime metrics semantics

--- a/docs/blueprint/features/03-execution/02-process-execution-engine/03-design.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/03-design.md
@@ -12,14 +12,19 @@ The process engine must document both:
 - `worker_pipes` as the worker-affine direction
 
 while keeping `BaseExecutionEngine.submit(work_item)` unchanged and keeping the
-control plane transport-agnostic.
+control plane transport-agnostic. Batched submission extends, rather than
+replaces, the item-level contract.
 
 ## Key design surfaces
 
 - `ProcessConfig.transport_mode`
+- `ExecutionConfig.route_batch_size`
+- `BaseExecutionEngine.submit_batch(work_items)`
+- `BaseExecutionEngine.supports_ordered_route_batch`
 - route identity based on `(topic, partition, key)`
 - transport-specific input dispatch
-- single completion aggregation in the first step
+- internal `RouteBatch` and `BatchCompletion` worker-pipe envelopes
+- parent-side expansion back to item-level `CompletionEvent` instances
 - batching semantics and explicit unsupported combinations
 - `wait_for_completion()` parity
 - shutdown, recycle, restart, and runtime metrics semantics
@@ -28,3 +33,53 @@ The route identity is not a new process-only scheduling hint. It reuses the same
 logical queue identity that `WorkManager` already uses to select safe-to-run
 work. Async execution ignores it because there is no IPC route; worker-pipe
 process execution hashes it to select the worker input channel.
+
+## Route-batch design contract
+
+Route batching is an explicit process-transport optimization:
+
+- `route_batch_size=1` is the default and preserves item-submission behavior.
+- `route_batch_size>1` may lease multiple items from one WorkManager virtual
+  queue only when the execution engine advertises
+  `supports_ordered_route_batch=True` for ordered modes.
+- The base `submit_batch()` fallback calls `submit()` in order. It is
+  item-semantics compatible but does not make ordered same-route execution
+  sequential by itself.
+- Engines that partially accept a batch must raise `BatchSubmitError` with the
+  accepted prefix count. A generic exception means zero accepted items.
+- `worker_pipes` sends route batches as one worker-pipe payload and chooses the
+  worker once from the batch route identity.
+- Worker execution inside a route batch is sequential. The worker stops after
+  the first item failure and reports the unstarted tail for recovery.
+- The normal worker-to-parent path sends one `BatchCompletion` envelope for the
+  executed prefix. Parent polling expands that envelope into item-level
+  completions and keeps `poll_completed_events(batch_limit)` item-count based.
+- Batch payloads are internal wire DTOs. Public retry, DLQ, commit, and registry
+  accounting stay item-level.
+
+## Route-batch safety requirements
+
+- Poison/force-fail checks must truncate a batch before the first force-fail
+  candidate.
+- Worker death before item start must keep the pending tail recoverable.
+- Live-worker `not_started` tails must requeue or otherwise recover; they are
+  not diagnostic-only.
+- Fatal timeout/exit must flush any completed prefix before process exit.
+- Duplicate suppression must be bounded to avoid unbounded memory growth during
+  long-running completion polling.
+- Msgpack completion bytes must be size-checked before unpacking, and malformed
+  batch payloads must be rejected instead of decoded as empty work.
+
+## Route-batch runtime metrics
+
+Process runtime metrics should expose enough signal to distinguish item IPC from
+route-batch IPC:
+
+- `items_per_input_ipc`
+- `items_per_completion_ipc`
+- `route_batch_count`
+- `route_batch_item_count`
+- `route_batch_size_avg`
+- `route_batch_size_max`
+- `completion_item_payload_count`
+- `completion_batch_payload_count`

--- a/docs/blueprint/features/03-execution/02-process-execution-engine/04-worker-pipe-transport-experiment.ko.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/04-worker-pipe-transport-experiment.ko.md
@@ -70,15 +70,17 @@ WorkManager virtual queues
 
 ```text
 WorkManager virtual queues
-  -> ProcessExecutionEngine.submit()
-  -> transport router
+  -> ProcessExecutionEngine.submit() / submit_batch()
+  -> transport router 또는 RouteBatch route lease
   -> worker-specific input Pipe
-  -> owner worker process
-  -> single completion queue
+  -> owner worker process sequential loop
+  -> item completion 또는 BatchCompletion envelope
+  -> parent-side item completion surface
 ```
 
-1차 실험에서 바꾸는 것은 input transport뿐이다. completion aggregation,
-control-plane commit 판단, worker function 실행 의미는 기존 위치를 유지한다.
+worker-pipe 1차 slice는 input transport를 바꿨다. route-batch slice는 route batch
+정상 경로의 worker-to-parent IPC envelope도 바꾼다. 다만 parent-facing completion
+surface, control-plane commit 판단, worker function 실행 의미는 기존 위치를 유지한다.
 
 ## py-spy / benchmark evidence
 
@@ -113,13 +115,17 @@ process_transport = shared_queue | worker_pipes
 
 기본값은 반드시 `shared_queue`다.
 
-### 1차 실험에 포함
+### 구현된 worker-pipe 범위
 
 - worker별 parent-to-worker 단방향 input pipe
 - `WorkItem` identity 기반 stable routing
+- 명시적으로 켜진 경우 같은 route `WorkItem` 묶음의 route-batch dispatch
+- internal `RouteBatch` / `BatchCompletion` wire envelope
+- parent-side item-level `CompletionEvent` expansion
 - 기존 single completion queue 재사용
 - parent-side registry / in-flight accounting 재사용
 - benchmark에서 transport 선택 가능
+- benchmark에서 `route_batch_size` 선택 가능
 - shared queue와 worker pipes 비교 matrix
 - 지원하지 않는 조합은 startup에서 명시적으로 reject
 
@@ -142,8 +148,9 @@ transport 실험이어도 control plane은 transport를 몰라야 한다.
 반드시 유지할 것:
 
 - `BrokerPoller`와 `WorkManager`는 `shared_queue`인지 `worker_pipes`인지 알지 못한다.
-- `BaseExecutionEngine` public surface는 그대로 유지한다.
+- `BaseExecutionEngine` public surface는 명시적이고 안정적으로 유지한다.
   - `submit(work_item)`
+  - `submit_batch(work_items)`
   - `poll_completed_events(batch_limit=1000)`
   - `wait_for_completion(timeout_seconds=None)`
   - `get_in_flight_count()`
@@ -151,6 +158,7 @@ transport 실험이어도 control plane은 transport를 몰라야 한다.
   - `shutdown()`
 - 실행 가능한 `WorkItem`을 고르는 책임은 계속 `WorkManager`에 있다.
 - completion aggregation과 offset commit 판단은 parent/control plane에 남는다.
+  `BatchCompletion`은 internal IPC envelope일 뿐 public commit 단위가 아니다.
 - commit clamp용 최소 in-flight offset은 control-plane `WorkManager`
   dispatch ledger에서 계산한다. engine-level `get_min_inflight_offset()`는
   있더라도 compatibility/private recovery state일 뿐 canonical source가 아니다.
@@ -159,7 +167,7 @@ transport 실험이어도 control plane은 transport를 몰라야 한다.
 
 ## Routing 계약
 
-1차 prototype은 기존 `WorkItem`이 이미 갖고 있는 logical identity를 재사용한다.
+transport는 기존 `WorkItem`이 이미 갖고 있는 logical identity를 재사용한다.
 
 ```text
 route_identity = (work_item.tp.topic, work_item.tp.partition, work_item.key)
@@ -179,6 +187,8 @@ Routing 규칙:
 - `unordered` mode는 다른 policy를 써도 되지만 문서와 benchmark 해석에 명시해야 한다.
 - crash 이후 ownership migration은 1차 범위가 아니다.
 - ordered mode의 기본 원칙은 stealing이 아니라 affinity preservation이다.
+- `PARTITION` route batch는 `(topic, partition)`을 route로 사용한다.
+- `KEY_HASH` route batch는 `(topic, partition, key)`를 route로 사용한다.
 
 ## Config / CLI 계약
 
@@ -186,6 +196,12 @@ Routing 규칙:
 
 ```python
 transport_mode: Literal["shared_queue", "worker_pipes"] = "shared_queue"
+```
+
+`ExecutionConfig`에는 route-batch 크기 selector가 있다.
+
+```python
+route_batch_size: int = 1
 ```
 
 Config 요구사항:
@@ -209,6 +225,7 @@ Benchmark CLI에도 같은 선택지를 노출한다.
 
 ```bash
 --process-transport shared_queue|worker_pipes
+--route-batch-size 1|8|32|64|128
 ```
 
 전달 경로는 명시적으로 유지한다.
@@ -217,37 +234,39 @@ Benchmark CLI에도 같은 선택지를 노출한다.
 benchmark CLI
   -> benchmark config builder
   -> KafkaConfig.parallel_consumer.execution.process_config.transport_mode
+  -> KafkaConfig.parallel_consumer.execution.route_batch_size
   -> ProcessExecutionEngine
 ```
 
-## 1차 실험 지원/비지원 매트릭스
+## 지원/비지원 매트릭스
 
 이 실험은 silent fallback보다 explicit rejection을 선호한다.
 
-| Surface | 1차 규칙 | 이유 |
+| Surface | 규칙 | 이유 |
 | --- | --- | --- |
 | `transport_mode=shared_queue` | fully supported | baseline 유지 |
-| `transport_mode=worker_pipes` + `batch_size=1` | supported | topology만 검증하는 최소 단위 |
-| `worker_pipes` + timer/demand batching | fully 구현 전에는 startup reject | batching 재설계와 transport 검증을 섞지 않기 위해 |
+| `transport_mode=worker_pipes` + `route_batch_size=1` | supported | unbatched worker-affine path |
+| `transport_mode=worker_pipes` + `route_batch_size>1` | engine이 ordered batch capability를 광고할 때 같은 route lease 지원 | IPC amortization 실험 |
+| ordered mode + `supports_ordered_route_batch=False` engine | effective route batch size `1` | fallback `submit_batch()`는 ordered sequential executor가 아님 |
+| `shared_queue` + `route_batch_size>1` | transport-specific 구현 없으면 item semantics fallback | compatibility path는 안전해야 함 |
+| process micro-batch flags | 기존 의미 유지 | `ProcessConfig.batch_size`와 `route_batch_size`를 분리하기 위해 |
 | `worker_pipes` + recycle semantics 미구현 | startup reject | silent disable은 benchmark 해석을 오염시킴 |
 | invalid transport value | config validation failure | 실험 범위 고정 |
 
 지원 범위가 넓어지면 표를 수정해야지, 삭제하면 안 된다.
 
-## Batching 방침
+## Route-batch 방침
 
-이 실험의 1순위는 input topology다. batching sophistication은 후순위다.
+route batching은 process micro-batching과 별도 축이다.
 
-권장 1차 설정:
+- `ProcessConfig.batch_size`는 기존 process payload accumulator 의미를 유지한다.
+- `ExecutionConfig.route_batch_size`는 `WorkManager`가 같은 route에서 한 번에 lease할
+  `WorkItem` 수를 제어한다.
+- `route_batch_size=1`은 compatibility default다.
+- `route_batch_size>1`은 parent-to-worker와 worker-to-parent IPC를 amortize하기
+  위한 명시적 실험 knob다.
 
-```text
-batch_size = 1
-max_batch_wait_ms = 0
-```
-
-이렇게 해야 timer flush나 residence policy 복잡도를 transport 실험과 분리할 수 있다.
-
-`worker_pipes`가 더 넓은 batching을 지원하게 되면 2차 slice로 분리해서 문서화한다. 아래 의미를 암묵적으로 바꾸면 안 된다.
+아래 의미를 route batch 의미로 암묵적으로 바꾸면 안 된다.
 
 - `flush_policy="size_or_timer"`
 - `flush_policy="demand"`
@@ -268,7 +287,9 @@ max_batch_wait_ms = 0
 
 - 각 worker는 자기 input channel에서 blocking receive
 - worker는 자신이 실행할 payload envelope를 decode
-- completion event는 기존 completion queue로 보냄
+- route-batch worker는 batch 내부 item을 순서대로 실행하고 첫 failure에서 멈춤
+- 정상 route-batch completion은 하나의 `BatchCompletion` envelope로 보내고 parent가
+  펼침
 - parent-side registry event는 여전히 in-flight accounting에 의미가 있어야 함
 
 ### Shutdown
@@ -282,6 +303,8 @@ max_batch_wait_ms = 0
 ### Crash / restart / recycle guardrail
 
 - 1차 실험은 ownership migration 없이 구현 가능한 현재 dead-worker recovery만 유지해도 된다.
+- worker start event 또는 live-worker failure 이후에도 아직 start되지 않은
+  route-batch tail은 recoverable해야 한다.
 - worker restart policy는 transport별로 문서화해야 한다.
 - `max_tasks_per_child`, `recycle_jitter_ms`는 의미를 유지하거나 `worker_pipes`에서 명시적으로 reject해야 한다.
 - 구현 증거 없이 “shared_queue와 동일하다”라고 과장하면 안 된다.
@@ -310,6 +333,8 @@ balancing 설계는 이 문서 범위가 아니다.
 - ordering validation evidence
 - release-gate가 같은 correctness 기준으로 GO/NO-GO를 판단했다는 증거
 - transport-specific benchmark metadata
+- `route_batch_size`, `items_per_input_ipc`, `items_per_completion_ipc`,
+  `route_batch_size_avg`, `route_batch_size_max` 같은 route-batch IPC metric
 - reject/skip된 transport-config 조합을 설명할 수 있는 로그나 runtime metadata
 - release-gate summary가 관측된 `process_transport_mode` 목록을 포함해 artifact 비교 시 어떤 transport가 평가되었는지 드러내야 함
 
@@ -335,8 +360,10 @@ Benchmark 보고서는 아래 질문에 바로 답할 수 있어야 한다.
 
 ### Performance gate
 
-- `partition` workload에서 width가 `process_count` 이상이면 `shared_queue` 대비 개선
-- `key_hash` workload에서 active-key width가 `process_count` 이상이면 `shared_queue` 대비 개선
+- `partition` workload는 baseline sequential consumer와 동급 이상이어야 하고,
+  이상적으로는 fixed-cost amortization으로 이를 넘어야 한다.
+- `key_hash` workload는 active-key width가 process count보다 충분히 클 때 baseline
+  sequential consumer를 큰 폭으로 넘어야 한다.
 - `p=1`, `k=1` 같은 narrow workload가 과도하게 악화되지 않음
 - improvement claim은 benchmark artifact를 인용함
 
@@ -346,20 +373,33 @@ Benchmark 보고서는 아래 질문에 바로 답할 수 있어야 한다.
 
 - `transport_mode` config와 benchmark CLI plumbing 추가
 - `shared_queue` path는 그대로 유지
-- `worker_pipes` startup + routing은 `batch_size=1` 기준으로만 구현
+- `worker_pipes` startup + item-level routing으로 unbatched path 구현
 - single completion queue 유지
 - unsupported 조합은 명시적으로 reject
 
 ### Slice 2 — evidence / operational hardening
 
-- benchmark/report metadata에 transport mode 노출
-- release-gate와 benchmark summary에서 transport mode 확인 가능하게 유지
-- restart/recycle limitation이 남으면 문서와 결과에 명시
-- py-spy / benchmark evidence를 문서 본문 또는 결과 요약에 연결
+- `submit_batch()`와 ordered batch capability gate 추가
+- `WorkManager` same-route lease 구현
+- engine capability가 없으면 ordered effective batch size를 `1`로 유지
 
-### Slice 3 — optional expansion
+### Slice 3 — worker-pipes route-batch dispatch
 
-- 1차 증거가 좋을 때만 richer batching, recycle parity, advanced routing을 검토
+- 선택된 worker pipe에 하나의 route-batch payload 전송
+- pending tail recoverability 유지
+- worker 내부 순서 실행 보장
+
+### Slice 4 — batch completion envelope
+
+- executed prefix를 `BatchCompletion`으로 전송
+- parent에서 item completion으로 expansion
+- bounded cache로 legacy/batch completion overlap dedupe
+
+### Slice 5 — benchmark / metric evidence
+
+- `--route-batch-size` 추가
+- benchmark JSON에 nullable route-batch IPC metric 노출
+- performance claim은 저장된 benchmark artifact에 연결
 
 ## Non-goal
 

--- a/docs/blueprint/features/03-execution/02-process-execution-engine/04-worker-pipe-transport-experiment.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/04-worker-pipe-transport-experiment.md
@@ -230,7 +230,7 @@ benchmark CLI
   -> ProcessExecutionEngine
 ```
 
-## Supported and unsupported matrix
+## Unsupported matrix for the first slice
 
 The experiment should prefer explicit rejection over silent fallback.
 

--- a/docs/blueprint/features/03-execution/02-process-execution-engine/04-worker-pipe-transport-experiment.md
+++ b/docs/blueprint/features/03-execution/02-process-execution-engine/04-worker-pipe-transport-experiment.md
@@ -51,16 +51,18 @@ Experimental runtime:
 
 ```text
 WorkManager virtual queues
-  -> ProcessExecutionEngine.submit()
-  -> transport router
+  -> ProcessExecutionEngine.submit() / submit_batch()
+  -> transport router or RouteBatch route lease
   -> worker-specific input Pipe
-  -> owner worker process
-  -> single completion queue
+  -> owner worker process sequential loop
+  -> item completion or BatchCompletion envelope
+  -> parent-side item completion surface
 ```
 
-Only the input transport changes in the first slice. Completion aggregation,
-control-plane commit decisions, and worker function execution stay where they
-already live today.
+The first worker-pipe slice changed input transport. The route-batch slice also
+changes the worker-to-parent IPC envelope for route batches, while preserving the
+parent-facing item completion surface. Control-plane commit decisions and
+worker function semantics stay where they already live today.
 
 ## Evidence behind the experiment
 
@@ -101,13 +103,17 @@ process_transport = shared_queue | worker_pipes
 
 The default must remain `shared_queue`.
 
-### Included in the first slice
+### Implemented worker-pipe scope
 
 - worker-specific parent-to-worker unidirectional input pipes,
 - stable routing from `WorkItem` identity to a worker channel,
+- route-batch dispatch for same-route `WorkItem` groups when explicitly enabled,
+- internal `RouteBatch` and `BatchCompletion` wire envelopes,
+- parent-side expansion back to item-level `CompletionEvent` instances,
 - reuse of the existing single completion queue,
 - reuse of parent-side registry and in-flight accounting,
 - benchmark support for selecting the transport,
+- benchmark support for selecting `route_batch_size`,
 - matrix comparison against the current shared-queue path,
 - explicit startup rejection for unsupported transport/config combinations.
 
@@ -131,8 +137,9 @@ The experiment must preserve these invariants:
 
 - `BrokerPoller` and `WorkManager` do not know whether process mode uses
   `shared_queue` or `worker_pipes`.
-- `BaseExecutionEngine` public surface stays unchanged:
+- `BaseExecutionEngine` public surface remains explicit and stable:
   - `submit(work_item)`
+  - `submit_batch(work_items)`
   - `poll_completed_events(batch_limit=1000)`
   - `wait_for_completion(timeout_seconds=None)`
   - `get_in_flight_count()`
@@ -140,7 +147,8 @@ The experiment must preserve these invariants:
   - `shutdown()`
 - `WorkManager` still decides which `WorkItem` instances are safe to execute.
 - completion aggregation and offset-commit decisions stay in the parent/control
-  plane.
+  plane. `BatchCompletion` is an internal IPC envelope, not a public commit
+  unit.
 - minimum in-flight offset for commit clamping is computed from the
   control-plane `WorkManager` dispatch ledger; any engine-level
   `get_min_inflight_offset()` hook is compatibility-only private state.
@@ -149,8 +157,8 @@ The experiment must preserve these invariants:
 
 ## Routing contract
 
-The first prototype should reuse the existing logical identity already carried
-by `WorkItem`:
+The transport reuses the existing logical identity already carried by
+`WorkItem`:
 
 ```text
 route_identity = (work_item.tp.topic, work_item.tp.partition, work_item.key)
@@ -171,6 +179,8 @@ Routing rules:
   documented and benchmark interpretation must call it out explicitly,
 - crash-time ownership migration is out of scope for the first slice.
 - ordered modes prefer sticky routing and affinity preservation, not stealing.
+- `PARTITION` route batches use `(topic, partition)`.
+- `KEY_HASH` route batches use `(topic, partition, key)`.
 
 ## Configuration and CLI contract
 
@@ -178,6 +188,12 @@ Add a transport selector to `ProcessConfig`:
 
 ```python
 transport_mode: Literal["shared_queue", "worker_pipes"] = "shared_queue"
+```
+
+Add a route-batch selector to `ExecutionConfig`:
+
+```python
+route_batch_size: int = 1
 ```
 
 Configuration requirements:
@@ -201,6 +217,7 @@ Benchmark CLI should expose the same choice:
 
 ```bash
 --process-transport shared_queue|worker_pipes
+--route-batch-size 1|8|32|64|128
 ```
 
 The propagation path should remain explicit:
@@ -209,45 +226,46 @@ The propagation path should remain explicit:
 benchmark CLI
   -> benchmark config builder
   -> KafkaConfig.parallel_consumer.execution.process_config.transport_mode
+  -> KafkaConfig.parallel_consumer.execution.route_batch_size
   -> ProcessExecutionEngine
 ```
 
-## Unsupported matrix for the first slice
+## Supported and unsupported matrix
 
 The experiment should prefer explicit rejection over silent fallback.
 
-| Surface | First-slice rule | Why |
+| Surface | Rule | Why |
 | --- | --- | --- |
 | `transport_mode=shared_queue` | fully supported | control baseline |
-| `transport_mode=worker_pipes` + `batch_size=1` | supported | smallest topology-only experiment |
-| `worker_pipes` + timer/demand batching | reject at startup unless fully implemented | avoid mixing batching redesign with transport validation |
+| `transport_mode=worker_pipes` + `route_batch_size=1` | supported | unbatched worker-affine path |
+| `transport_mode=worker_pipes` + `route_batch_size>1` | supported for same-route leases when the engine advertises ordered batch capability | IPC amortization experiment |
+| ordered mode + engine without `supports_ordered_route_batch` | effective route batch size `1` | fallback `submit_batch()` is not an ordered sequential executor |
+| `shared_queue` + `route_batch_size>1` | falls back to item semantics unless a transport-specific implementation exists | compatibility path must remain safe |
+| process micro-batch flags | keep existing meaning; do not reinterpret as route batching | keep `ProcessConfig.batch_size` distinct from `route_batch_size` |
 | `worker_pipes` + recycle semantics not implemented | reject at startup | silent disable would invalidate benchmark interpretation |
 | invalid transport value | config validation failure | keep experiment bounded and observable |
 
 If support widens later, the table should be updated rather than removed.
 
-## Batching stance for the experiment
+## Route-batch stance for the experiment
 
-The experiment is about input topology first, not batching sophistication.
+Route batching is deliberately separate from process micro-batching:
 
-The recommended first slice is:
+- `ProcessConfig.batch_size` controls the existing process payload accumulator
+  semantics.
+- `ExecutionConfig.route_batch_size` controls how many same-route `WorkItem`
+  instances `WorkManager` may lease for one execution-engine call.
+- `route_batch_size=1` is the compatibility default.
+- `route_batch_size>1` is an explicit experiment knob used to amortize
+  parent-to-worker and worker-to-parent IPC.
 
-```text
-batch_size = 1
-max_batch_wait_ms = 0
-```
-
-That choice keeps the transport question isolated from timer-flush and
-residence-policy complexity.
-
-If worker pipes later need richer batching, document it as a second slice. Do
-not quietly reinterpret:
+Do not quietly reinterpret:
 
 - `flush_policy="size_or_timer"`
 - `flush_policy="demand"`
 - `flush_policy="demand_min_residence"`
 
-unless the implementation clearly preserves their existing meaning.
+as route-batch semantics.
 
 ## Worker lifecycle and shutdown contract
 
@@ -265,7 +283,10 @@ process engine.
 
 - each worker blocks on its own input channel,
 - each worker decodes the same payload envelope shape it needs to execute,
-- completion events still flow to the existing completion queue,
+- route-batch workers execute batch items sequentially and stop at the first
+  item failure,
+- normal route-batch completions flow as one `BatchCompletion` envelope and are
+  expanded by the parent,
 - parent-side registry events remain meaningful for in-flight accounting.
 
 ### Shutdown
@@ -306,6 +327,8 @@ derived only from normal completion handling in the control plane.
 
 - the first slice may preserve current dead-worker recovery only when it is
   already implementable without ownership migration,
+- unstarted route-batch tails must remain recoverable after a worker start
+  event or live-worker failure,
 - worker restart policy must be documented per transport,
 - recycle semantics (`max_tasks_per_child`, `recycle_jitter_ms`) must either be
   preserved or rejected explicitly in `worker_pipes` mode,
@@ -334,6 +357,9 @@ At minimum, implementation and evaluation should preserve or produce:
 - release-gate evidence that still treats the run as GO/NO-GO on the same
   final correctness criteria,
 - transport-specific benchmark metadata so results can be grouped by transport,
+- route-batch metadata and IPC ratios (`route_batch_size`,
+  `items_per_input_ipc`, `items_per_completion_ipc`,
+  `route_batch_size_avg`, `route_batch_size_max`),
 - enough runtime metrics or logs to explain rejected/unsupported combinations.
 - release-gate summaries that surface the observed `process_transport_mode`
   values so artifact comparisons remain interpretable.
@@ -360,10 +386,10 @@ The experiment succeeds only if both performance and correctness stay visible.
 
 ### Performance gates
 
-- `partition` workloads with width at least `process_count` improve versus
-  `shared_queue`,
-- `key_hash` workloads with active-key width at least `process_count` improve
-  versus `shared_queue`,
+- `partition` workloads should remain at least comparable to the baseline
+  sequential consumer and ideally exceed it through fixed-cost amortization,
+- `key_hash` workloads with active-key width above process count should exceed
+  the baseline sequential consumer by a large margin,
 - narrow workloads such as `p=1` or `k=1` do not regress severely,
 - improvement claims cite benchmark artifacts rather than anecdotal logs.
 
@@ -373,20 +399,33 @@ The experiment succeeds only if both performance and correctness stay visible.
 
 - add `transport_mode` config and benchmark CLI plumbing,
 - keep `shared_queue` path unchanged,
-- add worker-pipe startup and routing for `batch_size=1`,
+- add worker-pipe startup and item-level routing for the unbatched path,
 - keep single completion queue,
 - reject unsupported combinations explicitly.
 
-### Slice 2 — evidence and operational hardening
+### Slice 2 — route-batch contract and lease
 
-- add benchmark/report metadata for transport selection,
-- ensure release-gate and benchmark summaries surface transport mode,
-- document any restart/recycle limitations that remain.
+- add `submit_batch()` and ordered batch capability gates,
+- lease same-route items from WorkManager when safe,
+- keep ordered modes at effective batch size `1` unless the engine is capable.
 
-### Slice 3 — optional expansion
+### Slice 3 — worker-pipes route-batch dispatch
 
-- only after evidence shows value, evaluate richer batching support, recycle
-  parity, or more advanced routing strategies.
+- send one route-batch payload over the selected worker pipe,
+- keep pending tails recoverable,
+- run batch items sequentially in the worker.
+
+### Slice 4 — batch completion envelope
+
+- emit `BatchCompletion` for the executed prefix,
+- expand to item completions in the parent,
+- dedupe legacy and batch completion overlap with a bounded cache.
+
+### Slice 5 — benchmark and metric evidence
+
+- add `--route-batch-size`,
+- expose nullable route-batch IPC metrics in benchmark JSON,
+- keep performance claims tied to stored benchmark artifacts.
 
 ## Non-goals
 

--- a/docs/blueprint/features/04-tooling/02-benchmark-runtime/00-index.ko.md
+++ b/docs/blueprint/features/04-tooling/02-benchmark-runtime/00-index.ko.md
@@ -9,6 +9,8 @@
 - CLI와 TUI는 어떻게 역할을 나누는가
 - profiling은 어떤 도구를 어떤 모드에서 쓰는가
 - TPS와 per-message latency는 어떻게 해석해야 하는가
+- route-batch 옵션과 IPC amortization metric은 process micro-batch 옵션과 어떻게
+  분리해서 해석해야 하는가
 
 ## 문서 역할
 
@@ -16,7 +18,7 @@
 | --- | --- |
 | [01-requirements.md](01-requirements.ko.md) | benchmark surface의 책임과 acceptance 기준 |
 | [02-architecture.md](02-architecture.ko.md) | runner, producer, baseline, pyrallel engine, stats, TUI 관계 |
-| [03-design.md](03-design.ko.md) | 핵심 CLI 옵션, workload semantics, outputs, 해석 규칙 |
+| [03-design.md](03-design.ko.md) | 핵심 CLI 옵션, route-batch knob, workload semantics, outputs, 해석 규칙 |
 | [04-throughput-experiment-blueprint.md](04-throughput-experiment-blueprint.ko.md) | 연구 프레임과 첫 common-path throughput experiment |
 
 ## 빠른 읽기 분기

--- a/docs/blueprint/features/04-tooling/02-benchmark-runtime/00-index.md
+++ b/docs/blueprint/features/04-tooling/02-benchmark-runtime/00-index.md
@@ -9,6 +9,8 @@ The English documents in this directory are the canonical contract; the preserve
 - How do the CLI runner, Textual TUI, producer, baseline consumer, and Pyrallel test harness divide responsibilities?
 - When are topics and consumer groups reset or lazily created during a run?
 - How should TPS, total runtime, per-message latency, profiling artifacts, and optional metrics exposure be interpreted together?
+- How should route-batch controls and IPC amortization metrics be interpreted
+  separately from process micro-batch controls?
 - How do JSON summaries feed the current release-gate evaluator without turning the benchmark harness itself into a release-policy engine?
 
 ## Document map
@@ -17,7 +19,7 @@ The English documents in this directory are the canonical contract; the preserve
 | --- | --- |
 | [01-requirements.md](./01-requirements.md) | Scope, responsibilities, inputs/outputs, and acceptance criteria for benchmark tooling |
 | [02-architecture.md](./02-architecture.md) | Runtime component boundaries between the runner, reset helpers, execution rounds, stats pipeline, and TUI |
-| [03-design.md](./03-design.md) | Concrete CLI/TUI options, workload semantics, artifact contracts, and result interpretation rules |
+| [03-design.md](./03-design.md) | Concrete CLI/TUI options, route-batch knobs, workload semantics, artifact contracts, and result interpretation rules |
 | [04-throughput-experiment-blueprint.md](./04-throughput-experiment-blueprint.md) | Research frame and first common-path throughput experiment |
 
 ## Quick reading guide

--- a/docs/blueprint/features/04-tooling/02-benchmark-runtime/01-requirements.ko.md
+++ b/docs/blueprint/features/04-tooling/02-benchmark-runtime/01-requirements.ko.md
@@ -11,18 +11,26 @@
 - CLI와 TUI 양쪽에서 benchmark를 실행할 수 있어야 한다.
 - JSON summary와 profiling artifact를 저장해야 한다.
 - workload와 ordering mode 차이를 결과 해석 규칙과 함께 설명해야 한다.
+- process route-batch 실험 옵션과 IPC amortization metric을 process micro-batch
+  옵션과 분리해서 기록해야 한다.
 
 ## 3. 기능 요구사항
 
 - `sleep`, `io`, `cpu` workload를 선택적으로 실행할 수 있어야 한다.
 - `key_hash`, `partition`, `unordered` ordering 모드를 비교할 수 있어야 한다.
 - baseline/async/process 라운드를 개별적으로 skip 할 수 있어야 한다.
+- process 라운드는 `route_batch_size`를 benchmark axis로 노출해야 하며,
+  `process_batch_size`와 혼동하면 안 된다.
 - profiling은 async/baseline과 process에서 각각 현실적인 도구 경로를 제공해야 한다.
 - topic/group reset을 통해 이전 실행 찌꺼기를 줄일 수 있어야 한다.
 
 ## 4. 비기능 요구사항
 
 - benchmark 결과는 재실행 가능한 CLI 옵션과 함께 남아야 한다.
+- JSON summary는 baseline/async row에는 해당 없는 route-batch metric을 `null`로
+  보존하고, process row에는 `items_per_input_ipc`,
+  `items_per_completion_ipc`, `route_batch_size_avg` 같은 route-batch evidence를
+  기록할 수 있어야 한다.
 - profiling overhead가 throughput 비교를 왜곡할 수 있다는 점이 문서에 드러나야 한다.
 - TUI는 CLI 기능을 숨기지 않고 discoverability를 높이는 보조 shell이어야 한다.
 
@@ -33,11 +41,14 @@
 - Kafka bootstrap servers
 - 메시지 수, key 수, partition 수
 - workload/order/profiling 옵션
+- benchmark-only process micro-batch override
+- benchmark-only route-batch override
 
 출력:
 
 - 콘솔 요약 표
 - JSON summary
+- route-batch 설정과 nullable IPC metric
 - `.prof` 또는 py-spy artifact
 - TUI 실행 상태
 
@@ -46,3 +57,5 @@
 - baseline/async/process가 같은 harness에서 비교된다는 점이 문서에 명확해야 한다.
 - TPS와 per-message latency가 다른 의미를 가진다는 점이 설명돼야 한다.
 - profiling이 benchmark 수치와 분리해서 해석돼야 한다는 경고가 포함돼야 한다.
+- `route_batch_size`와 route-batch IPC metric은 process transport evidence이며,
+  baseline/async engine metric이 아니라는 점이 명확해야 한다.

--- a/docs/blueprint/features/04-tooling/02-benchmark-runtime/01-requirements.md
+++ b/docs/blueprint/features/04-tooling/02-benchmark-runtime/01-requirements.md
@@ -25,6 +25,8 @@ The benchmark runtime must:
 - The baseline round, Pyrallel async round, and Pyrallel process round must be individually skippable.
 - Pyrallel rounds must support strict-completion-monitor A/B runs (`on`, `off`).
 - Pyrallel rounds must support adaptive-concurrency A/B runs (`off`, `on`).
+- Process rounds must expose `route_batch_size` as a benchmark axis without
+  conflating it with process micro-batch flags such as `process_batch_size`.
 
 ### 2.2 Environment preparation
 
@@ -46,6 +48,9 @@ The benchmark runtime must:
 - Every run must emit a console results table.
 - Every benchmark invocation must emit a JSON summary, defaulting to `benchmarks/results/<UTC timestamp>.json` when `--json-output` is omitted.
 - JSON summaries must preserve the machine-readable fields consumed by the current release-gate evaluator, including per-run metrics observations and derived performance-improvement sections when those are available.
+- JSON summaries must preserve route-batch controls and nullable route-batch IPC
+  metrics so baseline/async rows can remain comparable without inventing process
+  metrics for non-process modes.
 - Optional profiler outputs must be written beneath the configured profile directory.
 - The TUI must preserve discoverability of the same runtime options instead of inventing a separate benchmark contract.
 
@@ -66,12 +71,16 @@ The benchmark runtime must:
 - message count, key count, partition count, timeout, and skip flags
 - profiling and optional metrics-port settings
 - benchmark-only process micro-batch override flags
+- benchmark-only route-batch override flags
 
 ### Outputs
 
 - console status and summary table
 - JSON benchmark summary
 - machine-readable release-gate evidence embedded in the JSON summary (`metrics_observations`, run-level lag/gap snapshots, and comparison sections such as `performance_improvements`)
+- route-batch fields in process run summaries, including `route_batch_size`,
+  `items_per_input_ipc`, `items_per_completion_ipc`, and route-batch size
+  histograms where available
 - yappi `.prof` files and optional merged worker profiles
 - py-spy artifacts (`svg`, `json`, or `txt`, depending on format)
 - TUI progress, logs, and results rendering
@@ -86,3 +95,5 @@ This subfeature is acceptable only if:
 - the docs describe release-gate evidence as an output consumer of benchmark JSON rather than as ad-hoc console interpretation;
 - TPS, total runtime, average latency, and p99 latency are explained as different but complementary signals;
 - profiling outputs and non-profiled throughput comparisons are clearly separated.
+- `route_batch_size` and route-batch IPC metrics are documented as process
+  transport evidence, not as baseline or async engine metrics.

--- a/docs/blueprint/features/04-tooling/02-benchmark-runtime/02-architecture.ko.md
+++ b/docs/blueprint/features/04-tooling/02-benchmark-runtime/02-architecture.ko.md
@@ -45,8 +45,11 @@ flowchart LR
 2. runner가 producer를 통해 테스트 메시지를 준비한다.
 3. baseline, async, process 라운드를 순서대로 또는 선택적으로 실행한다.
 4. 각 라운드의 처리량과 지연을 `stats.py`가 요약한다.
-5. 결과는 콘솔 출력과 JSON artifact로 남는다.
-6. profiling 옵션이 켜져 있으면 해당 모드에 맞는 profiler artifact를 추가로 만든다.
+5. process route-batch 실험에서는 `route_batch_size`가 config와 direct
+   `WorkManager` 생성 경로 모두에 전달된다.
+6. 결과는 콘솔 출력과 JSON artifact로 남는다. route-batch IPC metric은
+   baseline/async에서는 `null`, process에서는 관측값으로 남을 수 있다.
+7. profiling 옵션이 켜져 있으면 해당 모드에 맞는 profiler artifact를 추가로 만든다.
 
 ## 5. 경계
 

--- a/docs/blueprint/features/04-tooling/02-benchmark-runtime/02-architecture.md
+++ b/docs/blueprint/features/04-tooling/02-benchmark-runtime/02-architecture.md
@@ -69,6 +69,12 @@ Pyrallel rounds add behavior that baseline rounds do not carry:
 - If `metrics_port` is not `None`, that config enables `KafkaConfig.metrics`, and the harness also acquires a cached `PrometheusMetricsExporter` for observer-side updates.
 - Strict-completion-monitor and adaptive-concurrency flags are expanded as matrix axes and encoded into run names, topics, and consumer groups.
 - Process-mode micro-batch overrides (`batch_size`, `max_batch_wait_ms`, `flush_policy`, `demand_flush_min_residence_ms`) are applied only to the benchmark harness configuration for that run.
+- Route-batch overrides (`route_batch_size`) are applied through
+  `KafkaConfig.parallel_consumer.execution.route_batch_size` and passed to the
+  direct `WorkManager` construction used by the benchmark harness.
+- Result summaries keep route-batch IPC metrics nullable so baseline and async
+  rows remain in the same schema without pretending to have process transport
+  counters.
 
 ## 5. Boundaries and invariants
 

--- a/docs/blueprint/features/04-tooling/02-benchmark-runtime/03-design.ko.md
+++ b/docs/blueprint/features/04-tooling/02-benchmark-runtime/03-design.ko.md
@@ -19,6 +19,8 @@
 | `--strict-completion-monitor` | completion monitor 비교 |
 | `--profile` | yappi profiling |
 | `--py-spy` | process worker 포함 profiling |
+| `--process-batch-size` | process micro-batch size override |
+| `--route-batch-size` | 같은 route lease size override. `process-batch-size`와 별도 축 |
 
 ## 3. workload 의미
 
@@ -34,6 +36,7 @@
 | --- | --- |
 | 콘솔 표 | 각 라운드 TPS/latency 요약 |
 | JSON summary | 재분석 가능한 구조화 결과 |
+| route-batch JSON fields | `route_batch_size`, `items_per_input_ipc`, `items_per_completion_ipc`, `route_batch_count`, `route_batch_item_count`, `route_batch_size_avg`, `route_batch_size_max`, `completion_item_payload_count`, `completion_batch_payload_count` |
 | `.prof` 파일 | yappi profile 결과 |
 | py-spy artifact | flamegraph/speedscope/chrometrace 등 |
 
@@ -44,3 +47,9 @@
 - profiling을 켠 실행은 overhead 때문에 non-profiled run과 직접 TPS 비교하면 안 된다.
 - async가 높은 TPS를 보여도 queueing latency가 함께 증가할 수 있다.
 - process는 CPU workload에서 유리할 수 있지만 IPC와 scheduling 비용 때문에 per-message latency가 높아질 수 있다.
+- `process_batch_size`와 `route_batch_size`는 다른 축이다. 전자는 process payload
+  accumulation이고, 후자는 same-route scheduling/IPC amortization이다.
+- route-batch IPC metric은 process transport 증거다. baseline/async row에서는 해당
+  없는 필드를 `null`로 둔다.
+- `items_per_input_ipc`와 `items_per_completion_ipc`는 실제로 IPC가 batch 단위로
+  amortize되었는지를 설명한다. TPS/correctness와 함께 읽어야 한다.

--- a/docs/blueprint/features/04-tooling/02-benchmark-runtime/03-design.md
+++ b/docs/blueprint/features/04-tooling/02-benchmark-runtime/03-design.md
@@ -29,6 +29,7 @@ For the preserved Korean source text, see [03-design.ko.md](./03-design.ko.md).
 | `--process-max-batch-wait-ms` | benchmark-only override for process micro-batch wait |
 | `--process-flush-policy` | benchmark-only override for process flush policy |
 | `--process-demand-flush-min-residence-ms` | benchmark-only override for the demand-min-residence guard |
+| `--route-batch-size` | benchmark-only override for same-route WorkManager lease size; distinct from process micro-batch size |
 | `--metrics-port` | exposes Prometheus metrics for Pyrallel runs on the chosen host port; `0` disables benchmark-side exposure |
 | `--profile` and related `--profile-*` flags | wrap each executed round in yappi profiling |
 | `--py-spy` and related `--py-spy-*` flags | relaunch under py-spy to capture process-mode activity, including subprocesses |
@@ -82,6 +83,7 @@ The workload selector changes only the worker function cost model; it does not a
 | Console logs | producer progress, reset notices, optional profiling notices, and the final table |
 | Final table | one row per executed run with run name, type, order, topic, processed message count, TPS, average ms, and p99 ms |
 | JSON summary | structured benchmark results plus the raw option map used for the invocation |
+| Route-batch JSON fields | `route_batch_size` plus nullable IPC fields such as `items_per_input_ipc`, `items_per_completion_ipc`, `route_batch_count`, `route_batch_item_count`, `route_batch_size_avg`, `route_batch_size_max`, `completion_item_payload_count`, and `completion_batch_payload_count` |
 | JSON release-gate evidence | the same JSON payload carries `metrics_observations`, final lag/gap fields, and `performance_improvements` so repeated artifacts can be evaluated by `benchmarks.release_gate` without scraping console output |
 | yappi artifacts | `.prof` files under the configured profile directory |
 | py-spy artifacts | format-specific files under the configured py-spy output directory |
@@ -100,3 +102,11 @@ The workload selector changes only the worker function cost model; it does not a
 - Adaptive backpressure is currently a runtime observability/configuration surface, while `adaptive-concurrency=on|off` is a distinct benchmark matrix axis for the control-plane live-limit policy.
 - Logging above `WARNING` can materially perturb throughput measurements and should be treated as a debugging mode, not a benchmark baseline.
 - Tiny process + partition benchmarks can be dominated by default batching; compare benchmark-only overrides before drawing conclusions about library defaults.
+- `process_batch_size` and `route_batch_size` are separate axes. The former is
+  process payload accumulation; the latter is same-route scheduling/IPC
+  amortization.
+- Route-batch IPC metrics apply to process transport evidence. Baseline and async
+  rows should carry `null` for fields that are not meaningful for those modes.
+- `items_per_input_ipc` and `items_per_completion_ipc` explain whether route
+  batching actually reduced IPC operations; they should be read with TPS and
+  correctness fields, not as standalone success criteria.

--- a/docs/blueprint/features/04-tooling/02-benchmark-runtime/04-throughput-experiment-blueprint.ko.md
+++ b/docs/blueprint/features/04-tooling/02-benchmark-runtime/04-throughput-experiment-blueprint.ko.md
@@ -8,6 +8,25 @@
 최근 benchmark에서는 작은 workload의 ordered scenario에서 async와 process가 모두 baseline보다 느려질 수 있다.
 따라서 첫 최적화 slice는 엔진별 병렬성 확장보다 모든 엔진과 ordering mode가 공유하는 control-plane 공통 경로를 먼저 줄인다.
 
+## Route-batch 후속 상태
+
+worker-pipe route-batch 작업은 이 문서의 data-movement 상한에 대한 process-specific
+후속 실험이다. 함께 읽을 문서는
+`features/03-execution/02-process-execution-engine/04-worker-pipe-transport-experiment.md`다.
+
+최신 acceptance-gate evidence에서 명시적
+`process_transport=worker_pipes`, `route_batch_size=64` 실험은 다음 결과를 보였다.
+
+- `key_hash`: baseline 784.88 TPS, async 5992.88 TPS(`7.64x`), process
+  2583.74 TPS(`3.29x`), final lag `0`, final gap `0`.
+- `partition`: baseline 784.96 TPS, async 1607.05 TPS(`2.05x`), process
+  1314.96 TPS(`1.68x`), final lag `0`, final gap `0`.
+- process IPC evidence: `items_per_input_ipc`와 `items_per_completion_ipc`는
+  `key_hash`에서 약 `20.87`, `partition`에서 약 `62.5`였다.
+
+이 결과를 production default 전환 주장으로 일반화하면 안 된다. 측정된 matrix에서
+명시적 route-batch worker-pipe path가 benchmark gate를 통과했다는 증거로 읽는다.
+
 ## 연구 프레임
 
 - **Span 상한:** completion ready부터 다음 refill까지의 공통 critical path를 줄인다. 즉시 의심할 지점은 `WorkManager`의 per-completion scheduling churn과 `BrokerPoller`의 post-drain scheduling pass다.

--- a/docs/blueprint/features/04-tooling/02-benchmark-runtime/04-throughput-experiment-blueprint.md
+++ b/docs/blueprint/features/04-tooling/02-benchmark-runtime/04-throughput-experiment-blueprint.md
@@ -11,6 +11,26 @@ baseline under small-workload ordered scenarios. The first optimization slice
 therefore targets the common control-plane path shared by all engines and
 ordering modes, before adding engine-specific parallelism.
 
+## Route-batch follow-up status
+
+The worker-pipe route-batch work is the process-specific follow-up to the
+data-movement bound in this document. It should be read with
+`features/03-execution/02-process-execution-engine/04-worker-pipe-transport-experiment.md`.
+
+Latest acceptance-gate evidence for the explicit
+`process_transport=worker_pipes`, `route_batch_size=64` experiment showed:
+
+- `key_hash`: baseline 784.88 TPS, async 5992.88 TPS (`7.64x`), process 2583.74
+  TPS (`3.29x`), with final lag `0` and final gap `0`.
+- `partition`: baseline 784.96 TPS, async 1607.05 TPS (`2.05x`), process
+  1314.96 TPS (`1.68x`), with final lag `0` and final gap `0`.
+- process IPC evidence: `items_per_input_ipc` and `items_per_completion_ipc`
+  were about `20.87` for `key_hash` and `62.5` for `partition`.
+
+Do not generalize this into a production-default claim. Treat it as evidence
+that the explicit route-batch worker-pipe path can pass the benchmark gates for
+the measured matrix.
+
 ## Research frame
 
 - **Span bound:** reduce the common critical path from completion readiness to

--- a/tests/unit/benchmarks/test_tui_app.py
+++ b/tests/unit/benchmarks/test_tui_app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import shlex
 import signal
 from pathlib import Path
 from typing import cast
@@ -354,10 +355,52 @@ async def test_options_screen_copies_full_cli_command(monkeypatch) -> None:
         status = app.screen.query_one("#copy-command-status", Static)
 
     assert copied_values == [
-        "uv run python -m benchmarks.run_parallel_benchmark "
-        + " ".join(BenchmarkTuiState().to_argv())
+        shlex.join(
+            [
+                "uv",
+                "run",
+                "python",
+                "-m",
+                "benchmarks.run_parallel_benchmark",
+                *BenchmarkTuiState().to_argv(),
+            ]
+        )
     ]
     assert str(status.content) == "CLI command copied to clipboard."
+
+
+@pytest.mark.asyncio
+async def test_options_screen_shell_quotes_copied_cli_command(monkeypatch) -> None:
+    state = BenchmarkTuiState(json_output="benchmarks/results/space path.json")
+    app = BenchmarkTuiApp()
+    copied_values: list[str] = []
+
+    def _record_clipboard(text: str) -> None:
+        copied_values.append(text)
+
+    monkeypatch.setattr(app, "copy_to_clipboard", _record_clipboard)
+
+    async with app.run_test() as pilot:
+        json_output = app.screen.query_one("#json-output", Input)
+        json_output.value = state.json_output
+        await pilot.pause()
+
+        await pilot.click("#copy-command-button")
+        await pilot.pause()
+
+    assert copied_values == [
+        shlex.join(
+            [
+                "uv",
+                "run",
+                "python",
+                "-m",
+                "benchmarks.run_parallel_benchmark",
+                *state.to_argv(),
+            ]
+        )
+    ]
+    assert "'benchmarks/results/space path.json'" in copied_values[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/benchmarks/test_tui_app.py
+++ b/tests/unit/benchmarks/test_tui_app.py
@@ -338,6 +338,29 @@ async def test_options_screen_updates_preview_with_process_route_batch_controls(
 
 
 @pytest.mark.asyncio
+async def test_options_screen_copies_full_cli_command(monkeypatch) -> None:
+    app = BenchmarkTuiApp()
+    copied_values: list[str] = []
+
+    def _record_clipboard(text: str) -> None:
+        copied_values.append(text)
+
+    monkeypatch.setattr(app, "copy_to_clipboard", _record_clipboard)
+
+    async with app.run_test() as pilot:
+        await pilot.click("#copy-command-button")
+        await pilot.pause()
+
+        status = app.screen.query_one("#copy-command-status", Static)
+
+    assert copied_values == [
+        "uv run python -m benchmarks.run_parallel_benchmark "
+        + " ".join(BenchmarkTuiState().to_argv())
+    ]
+    assert str(status.content) == "CLI command copied to clipboard."
+
+
+@pytest.mark.asyncio
 async def test_browse_button_opens_directory_picker_modal() -> None:
     app = BenchmarkTuiApp()
 

--- a/tests/unit/benchmarks/test_tui_app.py
+++ b/tests/unit/benchmarks/test_tui_app.py
@@ -14,6 +14,7 @@ from textual.widgets import (
     Label,
     LoadingIndicator,
     ProgressBar,
+    Select,
     SelectionList,
     Static,
     Switch,
@@ -163,6 +164,11 @@ async def test_options_screen_shows_human_readable_field_labels() -> None:
     assert "Timeout (sec)" in labels
     assert "Workloads" in labels
     assert "Ordering modes" in labels
+    assert "Process count" in labels
+    assert "Process transport" in labels
+    assert "Process batch size" in labels
+    assert "Process max batch wait (ms)" in labels
+    assert "Route batch size" in labels
 
 
 @pytest.mark.asyncio
@@ -222,6 +228,9 @@ async def test_options_screen_places_representative_fields_in_expected_sections(
         output_ancestors = _ancestor_ids(
             app.screen.query_one("#option-block-json-output")
         )
+        process_ancestors = _ancestor_ids(
+            app.screen.query_one("#option-block-process-transport")
+        )
         profiling_ancestors = _ancestor_ids(
             app.screen.query_one("#option-block-profiling-enabled")
         )
@@ -233,6 +242,7 @@ async def test_options_screen_places_representative_fields_in_expected_sections(
     assert "option-section-cluster-workload" in sleep_ancestors
     assert "option-section-cluster-workload" in ordering_ancestors
     assert "option-section-output-execution" in output_ancestors
+    assert "option-section-output-execution" in process_ancestors
     assert "option-section-profiling" in profiling_ancestors
     assert "option-section-advanced-options" in topic_prefix_ancestors
 
@@ -272,6 +282,59 @@ async def test_options_screen_exposes_output_path_fields_with_browse_buttons() -
         "browse-profile-dir": "Browse",
         "browse-py-spy-output": "Browse",
     }
+
+
+@pytest.mark.asyncio
+async def test_options_screen_exposes_process_route_batch_controls() -> None:
+    app = BenchmarkTuiApp()
+
+    async with app.run_test() as pilot:
+        del pilot
+        process_count = app.screen.query_one("#process-count", Input)
+        process_transport = app.screen.query_one("#process-transport", Select)
+        process_batch_size = app.screen.query_one("#process-batch-size", Input)
+        process_max_batch_wait_ms = app.screen.query_one(
+            "#process-max-batch-wait-ms", Input
+        )
+        route_batch_size = app.screen.query_one("#route-batch-size", Input)
+
+    assert process_count.value == "4"
+    assert process_transport.value == "worker_pipes"
+    assert process_batch_size.value == "1"
+    assert process_max_batch_wait_ms.value == "0"
+    assert route_batch_size.value == "64"
+
+
+@pytest.mark.asyncio
+async def test_options_screen_updates_preview_with_process_route_batch_controls() -> (
+    None
+):
+    app = BenchmarkTuiApp()
+
+    async with app.run_test() as pilot:
+        process_count = app.screen.query_one("#process-count", Input)
+        process_transport = app.screen.query_one("#process-transport", Select)
+        process_batch_size = app.screen.query_one("#process-batch-size", Input)
+        process_max_batch_wait_ms = app.screen.query_one(
+            "#process-max-batch-wait-ms", Input
+        )
+        route_batch_size = app.screen.query_one("#route-batch-size", Input)
+
+        process_count.value = "4"
+        process_transport.value = "worker_pipes"
+        process_batch_size.value = "1"
+        process_max_batch_wait_ms.value = "0"
+        route_batch_size.value = "64"
+        await pilot.pause()
+
+        preview = app.screen.query_one("#argv-preview", Static)
+
+    preview_text = str(preview.content)
+    assert "--process-count 4" in preview_text
+    assert "--process-transport worker_pipes" in preview_text
+    assert "--process-batch-size 1" in preview_text
+    assert "--process-max-batch-wait-ms 0" in preview_text
+    assert "--route-batch-size 64" in preview_text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/benchmarks/test_tui_state.py
+++ b/tests/unit/benchmarks/test_tui_state.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from benchmarks.tui.state import BenchmarkTuiState
 
 
-def test_tui_state_to_argv_uses_cli_defaults() -> None:
+def test_tui_state_to_argv_uses_tui_acceptance_defaults() -> None:
     state = BenchmarkTuiState()
 
     argv = state.to_argv()

--- a/tests/unit/benchmarks/test_tui_state.py
+++ b/tests/unit/benchmarks/test_tui_state.py
@@ -22,6 +22,14 @@ def test_tui_state_to_argv_uses_cli_defaults() -> None:
     assert "sleep" in argv
     assert "--order" in argv
     assert "key_hash" in argv
+    assert "--process-transport" in argv
+    assert "worker_pipes" in argv
+    assert "--route-batch-size" in argv
+    assert "64" in argv
+    assert "--process-count" in argv
+    assert "4" in argv
+    assert "--process-batch-size" in argv
+    assert "--process-max-batch-wait-ms" in argv
     assert "--metrics-port" in argv
     assert "9091" in argv
     assert "--skip-reset" not in argv
@@ -41,6 +49,11 @@ def test_tui_state_to_argv_includes_advanced_flags() -> None:
         py_spy_native=True,
         py_spy_idle=True,
         skip_process=True,
+        process_count=4,
+        process_transport="worker_pipes",
+        process_batch_size=1,
+        process_max_batch_wait_ms=0,
+        route_batch_size=64,
     )
 
     argv = state.to_argv()
@@ -59,6 +72,14 @@ def test_tui_state_to_argv_includes_advanced_flags() -> None:
     assert "--py-spy-native" in argv
     assert "--py-spy-idle" in argv
     assert "--skip-process" in argv
+    assert "--process-count" in argv
+    assert "4" in argv
+    assert "--process-transport" in argv
+    assert "worker_pipes" in argv
+    assert "--process-batch-size" in argv
+    assert "--process-max-batch-wait-ms" in argv
+    assert "--route-batch-size" in argv
+    assert "64" in argv
 
 
 def test_tui_state_to_argv_forwards_zero_metrics_port_when_disabled() -> None:
@@ -69,6 +90,20 @@ def test_tui_state_to_argv_forwards_zero_metrics_port_when_disabled() -> None:
     assert "--metrics-port" in argv
     metrics_index = argv.index("--metrics-port")
     assert argv[metrics_index + 1] == "0"
+
+
+def test_tui_state_to_argv_omits_blank_process_overrides() -> None:
+    state = BenchmarkTuiState(
+        process_count=None,
+        process_batch_size=None,
+        process_max_batch_wait_ms=None,
+    )
+
+    argv = state.to_argv()
+
+    assert "--process-count" not in argv
+    assert "--process-batch-size" not in argv
+    assert "--process-max-batch-wait-ms" not in argv
 
 
 def test_tui_state_to_argv_omits_profiling_flags_when_master_toggle_disabled() -> None:


### PR DESCRIPTION
## Summary

- Add TUI controls for process worker count, process transport, process micro-batch size, max batch wait, and route batch size.
- Pre-fill the TUI defaults with the acceptance path: worker_pipes, process count 4, process batch size 1, max batch wait 0, route batch size 64.
- Wire the new TUI state into argv preview and benchmark launch arguments, while still allowing optional process overrides to be blanked out.

## Validation

- `uv run pytest tests/unit/benchmarks/test_tui_state.py tests/unit/benchmarks/test_tui_app.py tests/unit/benchmarks/test_run_parallel_benchmark_tui.py`
- commit pre-checks passed except `pylint` and `bandit` hooks were skipped because those executables are unavailable in the local hook environment.

## Notes

- Base branch: `develop`
- Existing local `AGENTS.md` edits were left unstaged and are not included.