### PR TITLE
refactor(benchmarks): split benchmark orchestration helpers

### DIFF
--- a/benchmarks/baseline_consumer.py
+++ b/benchmarks/baseline_consumer.py
@@ -28,12 +28,6 @@ conf: Dict[str, Any] = {
 topic = "test_topic"
 
 
-def delivery_report(err, msg):
-    """Called once for each message produced to indicate delivery result."""
-    if err is not None:
-        print(f"Message delivery failed: {err}")
-
-
 def create_topic_if_not_exists(admin_conf, topic_name):
     """Ensures the Kafka topic exists using AdminClient."""
     admin_client = AdminClient(admin_conf)

--- a/benchmarks/pyrallel_consumer_test.py
+++ b/benchmarks/pyrallel_consumer_test.py
@@ -246,6 +246,184 @@ async def _wait_for_partition_assignment(
     )
 
 
+class BenchmarkMetricsObserver:
+    """Observe benchmark completions and stop runs when targets are reached."""
+
+    def __init__(
+        self,
+        benchmark_stats: Optional[BenchmarkStats],
+        cons_stats: ConsumptionStats,
+        completion_event: asyncio.Event,
+        completion_ordering_validator: Optional[OrderingValidator] = None,
+        prometheus_metrics_exporter: Optional[PrometheusMetricsExporter] = None,
+    ) -> None:
+        self._stats = benchmark_stats
+        self._consumption_stats = cons_stats
+        self._stop_event = completion_event
+        self._failure_error: Optional[str] = None
+        self._completion_ordering_validator = completion_ordering_validator
+        self._prometheus_metrics_exporter = prometheus_metrics_exporter
+
+    @property
+    def failure_error(self) -> Optional[str]:
+        """Return the first benchmark failure error, if any."""
+        return self._failure_error
+
+    def report_worker_failure(self, error: str) -> None:
+        """Record the first worker failure and request run shutdown."""
+        if self._failure_error is None:
+            self._failure_error = error
+        self._stop_event.set()
+
+    def observe_completion(self, tp, status, duration_seconds: float) -> None:
+        """Observe one partition completion."""
+        if status == CompletionStatus.FAILURE:
+            self.report_worker_failure(
+                "Benchmark worker failure on %s[%d]: completion failed"
+                % (tp.topic, tp.partition)
+            )
+            return
+        if self._prometheus_metrics_exporter is not None:
+            self._prometheus_metrics_exporter.observe_completion(
+                tp, status, duration_seconds
+            )
+        self._consumption_stats.record()
+        if self._stats:
+            self._stats.record(duration_seconds)
+        if self._stats and self._stats.completed_target():
+            self._stop_event.set()
+        elif self._consumption_stats.reached_target():
+            self._stop_event.set()
+
+    def observe_work_completion(
+        self,
+        event: Any,
+        work_item: WorkItem,
+        duration_seconds: float,
+    ) -> None:
+        """Observe one completed work item."""
+        if event.status == CompletionStatus.SUCCESS:
+            if self._completion_ordering_validator is not None:
+                try:
+                    self._completion_ordering_validator.observe(work_item)
+                except Exception as exc:  # noqa: BLE001
+                    self.report_worker_failure(str(exc))
+                    return
+        self.observe_completion(work_item.tp, event.status, duration_seconds)
+
+
+def _record_release_gate_metrics_from_snapshot(
+    stats: Optional[BenchmarkStats],
+    metrics: SystemMetrics,
+    *,
+    elapsed_sec: float,
+) -> None:
+    """Record release-gate metrics from one broker metrics snapshot."""
+    if stats is None:
+        return
+    stats.record_release_gate_observation(
+        elapsed_sec=elapsed_sec,
+        consumer_parallel_lag=sum(pm.true_lag for pm in metrics.partitions),
+        consumer_gap_count=sum(pm.gap_count for pm in metrics.partitions),
+    )
+
+
+async def _publish_metrics_until_stopped(
+    *,
+    stop_event: asyncio.Event,
+    broker_poller: BrokerPoller,
+    prometheus_exporter: PrometheusMetricsExporter,
+    interval_sec: float = 0.5,
+) -> None:
+    """Publish broker metrics snapshots until the run stops."""
+    while not stop_event.is_set():
+        prometheus_exporter.update_from_system_metrics(broker_poller.get_metrics())
+        await asyncio.sleep(interval_sec)
+
+
+async def _print_diagnostics_until_stopped(
+    *,
+    stop_event: asyncio.Event,
+    broker_poller: BrokerPoller,
+    consumption_stats: ConsumptionStats,
+    stats: Optional[BenchmarkStats],
+    metrics_start: float,
+    interval_sec: float = 5,
+) -> None:
+    """Print periodic benchmark diagnostics until the run stops."""
+    while not stop_event.is_set():
+        await asyncio.sleep(interval_sec)
+        if stop_event.is_set():
+            break
+        metrics = broker_poller.get_metrics()
+        _record_release_gate_metrics_from_snapshot(
+            stats,
+            metrics,
+            elapsed_sec=time.perf_counter() - metrics_start,
+        )
+        in_flight = metrics.total_in_flight
+        paused = metrics.is_paused
+        partitions_info = []
+        for pm in metrics.partitions:
+            partitions_info.append(
+                "%s-%d lag=%d gaps=%d queued=%d"
+                % (
+                    pm.tp.topic,
+                    pm.tp.partition,
+                    pm.true_lag,
+                    pm.gap_count,
+                    pm.queued_count,
+                )
+            )
+        partition_str = (
+            ", ".join(partitions_info) if partitions_info else "no partitions assigned"
+        )
+        print(
+            "[diag] processed=%d in_flight=%d paused=%s | %s"
+            % (consumption_stats.processed, in_flight, paused, partition_str),
+            flush=True,
+        )
+
+
+async def _cancel_background_task(task: Optional[asyncio.Task[None]]) -> None:
+    """Cancel and await one optional background task."""
+    if task is None:
+        return
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+async def _finalize_consumer_run(
+    *,
+    broker_poller: BrokerPoller,
+    engine: BaseExecutionEngine,
+    stats: Optional[BenchmarkStats],
+    prometheus_exporter: Optional[PrometheusMetricsExporter],
+    metrics_start: float,
+) -> None:
+    """Stop poller/engine and record final benchmark metrics."""
+    print("Stopping PyrallelConsumer...")
+    await broker_poller.stop()
+    final_metrics = broker_poller.get_metrics()
+    _record_release_gate_metrics_from_snapshot(
+        stats,
+        final_metrics,
+        elapsed_sec=time.perf_counter() - metrics_start,
+    )
+    if stats is not None:
+        stats.record_process_batch_metrics(
+            getattr(final_metrics, "process_batch_metrics", None)
+        )
+    if prometheus_exporter is not None:
+        prometheus_exporter.update_from_system_metrics(final_metrics)
+    await engine.shutdown()
+    if stats:
+        stats.stop()
+
+
 def build_kafka_config(
     *,
     bootstrap_servers: Optional[str] = None,
@@ -398,71 +576,6 @@ async def run_pyrallel_consumer_test(
         else None
     )
 
-    class BenchmarkMetricsObserver:
-        """Represent benchmark metrics observer data used by pyrallel consumer test."""
-
-        def __init__(
-            self,
-            benchmark_stats: Optional[BenchmarkStats],
-            cons_stats: ConsumptionStats,
-            completion_event: asyncio.Event,
-            completion_ordering_validator: Optional[OrderingValidator] = None,
-            prometheus_metrics_exporter: Optional[PrometheusMetricsExporter] = None,
-        ) -> None:
-            self._stats = benchmark_stats
-            self._consumption_stats = cons_stats
-            self._stop_event = completion_event
-            self._failure_error: Optional[str] = None
-            self._completion_ordering_validator = completion_ordering_validator
-            self._prometheus_metrics_exporter = prometheus_metrics_exporter
-
-        @property
-        def failure_error(self) -> Optional[str]:
-            """Handle failure error within pyrallel consumer test."""
-            return self._failure_error
-
-        def report_worker_failure(self, error: str) -> None:
-            """Handle report worker failure within pyrallel consumer test."""
-            if self._failure_error is None:
-                self._failure_error = error
-            self._stop_event.set()
-
-        def observe_completion(self, tp, status, duration_seconds: float) -> None:
-            """Observe completion for pyrallel consumer test."""
-            if status == CompletionStatus.FAILURE:
-                self.report_worker_failure(
-                    "Benchmark worker failure on %s[%d]: completion failed"
-                    % (tp.topic, tp.partition)
-                )
-                return
-            if self._prometheus_metrics_exporter is not None:
-                self._prometheus_metrics_exporter.observe_completion(
-                    tp, status, duration_seconds
-                )
-            self._consumption_stats.record()
-            if self._stats:
-                self._stats.record(duration_seconds)
-            if self._stats and self._stats.completed_target():
-                self._stop_event.set()
-            elif self._consumption_stats.reached_target():
-                self._stop_event.set()
-
-        def observe_work_completion(
-            self,
-            event: Any,
-            work_item: WorkItem,
-            duration_seconds: float,
-        ) -> None:
-            """Observe work completion for pyrallel consumer test."""
-            if event.status == CompletionStatus.SUCCESS:
-                if self._completion_ordering_validator is not None:
-                    try:
-                        self._completion_ordering_validator.observe(work_item)
-                    except Exception as exc:
-                        self.report_worker_failure(str(exc))
-                        return
-            self.observe_completion(work_item.tp, event.status, duration_seconds)
-
     ordering_validator: Optional[OrderingValidator] = None
     if (
         mode_value == ExecutionMode.ASYNC
@@ -551,79 +664,31 @@ async def run_pyrallel_consumer_test(
     run_completed = False
     metrics_start = time.perf_counter()
 
-    def _record_release_gate_metrics_from_snapshot(metrics: SystemMetrics) -> None:
-        """Build record release gate metrics from snapshot."""
-        if stats is None:
-            return
-        stats.record_release_gate_observation(
-            elapsed_sec=time.perf_counter() - metrics_start,
-            consumer_parallel_lag=sum(pm.true_lag for pm in metrics.partitions),
-            consumer_gap_count=sum(pm.gap_count for pm in metrics.partitions),
-        )
-
     try:
         await broker_poller.start()
         if prometheus_exporter is not None:
-
-            async def _publish_metrics() -> None:
-                """Publish metrics for pyrallel consumer test."""
-                while not stop_event.is_set():
-                    prometheus_exporter.update_from_system_metrics(
-                        broker_poller.get_metrics()
-                    )
-                    await asyncio.sleep(0.5)
-
-            metrics_task = asyncio.create_task(_publish_metrics())
+            metrics_task = asyncio.create_task(
+                _publish_metrics_until_stopped(
+                    stop_event=stop_event,
+                    broker_poller=broker_poller,
+                    prometheus_exporter=prometheus_exporter,
+                )
+            )
         assignment_timeout_sec = min(max(timeout_sec / 4, 1.0), 10.0)
         await _wait_for_partition_assignment(
             broker_poller,
             topic_name=effective_topic,
             timeout_sec=assignment_timeout_sec,
         )
-
-        async def _print_diagnostics() -> None:
-            """Handle print diagnostics within pyrallel consumer test."""
-            while not stop_event.is_set():
-                await asyncio.sleep(5)
-                if stop_event.is_set():
-                    break
-                metrics = broker_poller.get_metrics()
-                if stats is not None:
-                    stats.record_release_gate_observation(
-                        elapsed_sec=time.perf_counter() - metrics_start,
-                        consumer_parallel_lag=sum(
-                            pm.true_lag for pm in metrics.partitions
-                        ),
-                        consumer_gap_count=sum(
-                            pm.gap_count for pm in metrics.partitions
-                        ),
-                    )
-                in_flight = metrics.total_in_flight
-                paused = metrics.is_paused
-                partitions_info = []
-                for pm in metrics.partitions:
-                    partitions_info.append(
-                        "%s-%d lag=%d gaps=%d queued=%d"
-                        % (
-                            pm.tp.topic,
-                            pm.tp.partition,
-                            pm.true_lag,
-                            pm.gap_count,
-                            pm.queued_count,
-                        )
-                    )
-                partition_str = (
-                    ", ".join(partitions_info)
-                    if partitions_info
-                    else "no partitions assigned"
-                )
-                print(
-                    "[diag] processed=%d in_flight=%d paused=%s | %s"
-                    % (consumption_stats.processed, in_flight, paused, partition_str),
-                    flush=True,
-                )
-
-        diagnostics_task = asyncio.create_task(_print_diagnostics())
+        diagnostics_task = asyncio.create_task(
+            _print_diagnostics_until_stopped(
+                stop_event=stop_event,
+                broker_poller=broker_poller,
+                consumption_stats=consumption_stats,
+                stats=stats,
+                metrics_start=metrics_start,
+            )
+        )
 
         try:
             await asyncio.wait_for(stop_event.wait(), timeout=timeout_sec)
@@ -643,32 +708,15 @@ async def run_pyrallel_consumer_test(
         run_completed = True
     finally:
         stop_event.set()
-        if diagnostics_task is not None:
-            diagnostics_task.cancel()
-            try:
-                await diagnostics_task
-            except asyncio.CancelledError:
-                pass
-        if metrics_task is not None:
-            metrics_task.cancel()
-            try:
-                await metrics_task
-            except asyncio.CancelledError:
-                pass
-
-        print("Stopping PyrallelConsumer...")
-        await broker_poller.stop()
-        final_metrics = broker_poller.get_metrics()
-        _record_release_gate_metrics_from_snapshot(final_metrics)
-        if stats is not None:
-            stats.record_process_batch_metrics(
-                getattr(final_metrics, "process_batch_metrics", None)
-            )
-        if prometheus_exporter is not None:
-            prometheus_exporter.update_from_system_metrics(final_metrics)
-        await engine.shutdown()
-        if stats:
-            stats.stop()
+        await _cancel_background_task(diagnostics_task)
+        await _cancel_background_task(metrics_task)
+        await _finalize_consumer_run(
+            broker_poller=broker_poller,
+            engine=engine,
+            stats=stats,
+            prometheus_exporter=prometheus_exporter,
+            metrics_start=metrics_start,
+        )
 
         if metrics_observer.failure_error is not None:
             raise RuntimeError(metrics_observer.failure_error)

--- a/benchmarks/run_parallel_benchmark.py
+++ b/benchmarks/run_parallel_benchmark.py
@@ -6,9 +6,10 @@ import logging
 import socket
 import subprocess
 import sys
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Awaitable, Callable, List, Sequence, cast
+from typing import Awaitable, Callable, List, Literal, Sequence, cast
 
 if __package__ in {None, ""}:
     project_root = Path(__file__).resolve().parent.parent
@@ -40,6 +41,28 @@ from benchmarks.pyrallel_consumer_test import (
 from benchmarks.stats import BenchmarkResult, BenchmarkStats, write_results_json
 from benchmarks.workloads import select_workers as _select_workers
 from pyrallel_consumer.dto import WorkItem
+
+BenchmarkRunKind = Literal["baseline", "async", "process"]
+BenchmarkWorkerBundle = tuple[
+    Callable[[bytes], None],
+    Callable[[WorkItem], Awaitable[None]],
+    Callable[[WorkItem], None],
+]
+
+
+@dataclass(frozen=True)
+class BenchmarkRunPlan:
+    """Describe one benchmark run identity before side-effectful execution."""
+
+    kind: BenchmarkRunKind
+    workload: str
+    ordering: str
+    topic_name: str
+    run_name: str
+    group_id: str
+    strict_completion_monitor_enabled: bool
+    adaptive_concurrency_enabled: bool
+    workload_options: dict[str, dict[str, object]] | None
 
 
 def _normalize_metrics_port(metrics_port: int | None) -> int | None:
@@ -311,6 +334,379 @@ def _effective_sleep_ms(args: argparse.Namespace) -> float:
     return float(raw_sleep_ms)
 
 
+def _build_benchmark_run_plans(args: argparse.Namespace) -> list[BenchmarkRunPlan]:
+    """Build the benchmark run matrix without executing any benchmark work."""
+    plans: list[BenchmarkRunPlan] = []
+    workloads = list(args.workloads)
+    orderings = list(args.order)
+    strict_monitor_modes = list(args.strict_completion_monitor)
+    adaptive_concurrency_modes = list(args.adaptive_concurrency)
+
+    for workload in workloads:
+        workload_options = _workload_options_for(args.workload_options, workload)
+        for ordering in orderings:
+            suffix = "-%s-%s" % (workload, ordering)
+            run_prefix = "%s-%s" % (workload, ordering)
+
+            if not args.skip_baseline:
+                plans.append(
+                    BenchmarkRunPlan(
+                        kind="baseline",
+                        workload=workload,
+                        ordering=ordering,
+                        topic_name="%s%s-baseline" % (args.topic_prefix, suffix),
+                        run_name="%s-baseline" % run_prefix,
+                        group_id="%s%s" % (args.baseline_group, suffix),
+                        strict_completion_monitor_enabled=True,
+                        adaptive_concurrency_enabled=False,
+                        workload_options=workload_options,
+                    )
+                )
+
+            for strict_monitor_mode in strict_monitor_modes:
+                strict_completion_monitor_enabled = strict_monitor_mode == "on"
+                strict_suffix = ""
+                if len(strict_monitor_modes) > 1 or strict_monitor_mode != "on":
+                    strict_suffix = "-strict-%s" % strict_monitor_mode
+
+                for adaptive_concurrency_mode in adaptive_concurrency_modes:
+                    adaptive_concurrency_enabled = adaptive_concurrency_mode == "on"
+                    adaptive_suffix = ""
+                    if (
+                        len(adaptive_concurrency_modes) > 1
+                        or adaptive_concurrency_mode != "off"
+                    ):
+                        adaptive_suffix = "-adaptive-%s" % adaptive_concurrency_mode
+                    mode_suffix = "%s%s" % (strict_suffix, adaptive_suffix)
+
+                    if not args.skip_async:
+                        plans.append(
+                            BenchmarkRunPlan(
+                                kind="async",
+                                workload=workload,
+                                ordering=ordering,
+                                topic_name="%s%s-async%s"
+                                % (args.topic_prefix, suffix, mode_suffix),
+                                run_name="%s-pyrallel-async%s"
+                                % (run_prefix, mode_suffix),
+                                group_id="%s%s%s"
+                                % (args.async_group, suffix, mode_suffix),
+                                strict_completion_monitor_enabled=(
+                                    strict_completion_monitor_enabled
+                                ),
+                                adaptive_concurrency_enabled=(
+                                    adaptive_concurrency_enabled
+                                ),
+                                workload_options=workload_options,
+                            )
+                        )
+
+                    if not args.skip_process:
+                        plans.append(
+                            BenchmarkRunPlan(
+                                kind="process",
+                                workload=workload,
+                                ordering=ordering,
+                                topic_name="%s%s-process%s"
+                                % (args.topic_prefix, suffix, mode_suffix),
+                                run_name="%s-pyrallel-process%s"
+                                % (run_prefix, mode_suffix),
+                                group_id="%s%s%s"
+                                % (args.process_group, suffix, mode_suffix),
+                                strict_completion_monitor_enabled=(
+                                    strict_completion_monitor_enabled
+                                ),
+                                adaptive_concurrency_enabled=(
+                                    adaptive_concurrency_enabled
+                                ),
+                                workload_options=workload_options,
+                            )
+                        )
+    return plans
+
+
+def _group_benchmark_run_plans(
+    plans: Sequence[BenchmarkRunPlan],
+) -> list[list[BenchmarkRunPlan]]:
+    """Group prepared plans by the event-loop isolation boundary."""
+    grouped_plans: list[list[BenchmarkRunPlan]] = []
+    current_group: list[BenchmarkRunPlan] = []
+    current_key: tuple[str, str] | None = None
+
+    for plan in plans:
+        plan_key = (plan.workload, plan.ordering)
+        if current_key is not None and plan_key != current_key:
+            grouped_plans.append(current_group)
+            current_group = []
+        current_key = plan_key
+        current_group.append(plan)
+
+    if current_group:
+        grouped_plans.append(current_group)
+    return grouped_plans
+
+
+def _workers_for_plan(
+    args: argparse.Namespace,
+    *,
+    plan: BenchmarkRunPlan,
+    worker_bundles: dict[str, BenchmarkWorkerBundle],
+) -> BenchmarkWorkerBundle:
+    """Return cached workers for a workload plan."""
+    if plan.workload not in worker_bundles:
+        worker_bundles[plan.workload] = _select_workers(
+            workload=plan.workload,
+            sleep_ms=args.worker_sleep_ms,
+            cpu_iterations=args.worker_cpu_iterations,
+            io_sleep_ms=args.worker_io_sleep_ms,
+            workload_options=plan.workload_options,
+            validate_process_worker=not args.skip_process,
+        )
+    return worker_bundles[plan.workload]
+
+
+def _process_batching_for_plan(
+    args: argparse.Namespace,
+    *,
+    plan: BenchmarkRunPlan,
+    process_batching: dict[tuple[str, str, bool], tuple[int | None, int | None]],
+) -> tuple[int | None, int | None]:
+    """Resolve process batching once per workload/order/strict variant."""
+    key = (
+        plan.workload,
+        plan.ordering,
+        plan.strict_completion_monitor_enabled,
+    )
+    if key not in process_batching:
+        process_batching[key] = _resolve_effective_process_batching(
+            args,
+            strict_completion_monitor_enabled=(plan.strict_completion_monitor_enabled),
+        )
+    return process_batching[key]
+
+
+def _execute_baseline_run_plan(
+    args: argparse.Namespace,
+    *,
+    plan: BenchmarkRunPlan,
+    profile_dir: Path,
+    baseline_worker: Callable[[bytes], None],
+) -> BenchmarkResult:
+    """Execute one baseline benchmark plan."""
+    with _profile_session(
+        enabled=args.profile,
+        run_name=plan.run_name,
+        output_dir=profile_dir,
+        clock=args.profile_clock,
+        profile_threads=args.profile_threads,
+        profile_greenlets=args.profile_greenlets,
+        top_n=args.profile_top_n,
+    ):
+        if not args.skip_reset:
+            _reset_run_targets(
+                bootstrap_servers=args.bootstrap_servers,
+                topic_name=plan.topic_name,
+                group_id=plan.group_id,
+                num_partitions=args.num_partitions,
+            )
+        return _run_baseline_round(
+            run_name=plan.run_name,
+            topic_name=plan.topic_name,
+            num_messages=args.num_messages,
+            bootstrap_servers=args.bootstrap_servers,
+            num_partitions=args.num_partitions,
+            num_keys=args.num_keys,
+            group_id=plan.group_id,
+            worker_fn=baseline_worker,
+            workload=plan.workload,
+            ordering=plan.ordering,
+            ensure_topic_exists=args.skip_reset,
+        )
+
+
+async def _execute_async_benchmark_run_plans(
+    args: argparse.Namespace,
+    *,
+    plans: Sequence[BenchmarkRunPlan],
+    metrics_port: int | None,
+    profile_dir: Path,
+    worker_bundles: dict[str, BenchmarkWorkerBundle],
+    process_batching: dict[tuple[str, str, bool], tuple[int | None, int | None]],
+) -> List[BenchmarkResult]:
+    """Execute one workload/order async+process plan group."""
+    results: List[BenchmarkResult] = []
+
+    for plan in plans:
+        _, async_worker_fn, process_worker_fn = _workers_for_plan(
+            args,
+            plan=plan,
+            worker_bundles=worker_bundles,
+        )
+        (
+            effective_process_batch_size,
+            effective_process_max_batch_wait_ms,
+        ) = _process_batching_for_plan(
+            args,
+            plan=plan,
+            process_batching=process_batching,
+        )
+        if not args.skip_reset:
+            _reset_run_targets(
+                bootstrap_servers=args.bootstrap_servers,
+                topic_name=plan.topic_name,
+                group_id=plan.group_id,
+                num_partitions=args.num_partitions,
+            )
+
+        if plan.kind == "async":
+            with _profile_session(
+                enabled=args.profile,
+                run_name=plan.run_name,
+                output_dir=profile_dir,
+                clock=args.profile_clock,
+                profile_threads=args.profile_threads,
+                profile_greenlets=args.profile_greenlets,
+                top_n=args.profile_top_n,
+            ):
+                results.append(
+                    await _run_pyrparallel_round(
+                        topic_name=plan.topic_name,
+                        run_name=plan.run_name,
+                        mode=ExecutionMode.ASYNC,
+                        num_messages=args.num_messages,
+                        bootstrap_servers=args.bootstrap_servers,
+                        num_partitions=args.num_partitions,
+                        num_keys=args.num_keys,
+                        group_id=plan.group_id,
+                        timeout_sec=args.timeout_sec,
+                        async_worker_fn=async_worker_fn,
+                        process_worker_fn=process_worker_fn,
+                        workload=plan.workload,
+                        ordering=plan.ordering,
+                        ensure_topic_exists=args.skip_reset,
+                        strict_completion_monitor_enabled=(
+                            plan.strict_completion_monitor_enabled
+                        ),
+                        process_count=None,
+                        process_batch_size=effective_process_batch_size,
+                        process_max_batch_wait_ms=(effective_process_max_batch_wait_ms),
+                        process_flush_policy=args.process_flush_policy,
+                        process_demand_flush_min_residence_ms=(
+                            args.process_demand_flush_min_residence_ms
+                        ),
+                        process_transport_mode=None,
+                        route_batch_size=args.route_batch_size,
+                        metrics_port=metrics_port,
+                        adaptive_concurrency_enabled=(
+                            plan.adaptive_concurrency_enabled
+                        ),
+                    )
+                )
+            continue
+
+        prof_process_worker = process_worker_fn
+        if args.profile and args.profile_process_workers:
+            prof_process_worker = _wrap_process_worker_for_profile(
+                process_worker_fn,
+                output_dir=profile_dir,
+                run_name=plan.run_name,
+                clock=args.profile_clock,
+                profile_threads=args.profile_threads,
+                profile_greenlets=args.profile_greenlets,
+            )
+        results.append(
+            await _run_pyrparallel_round(
+                topic_name=plan.topic_name,
+                run_name=plan.run_name,
+                mode=ExecutionMode.PROCESS,
+                num_messages=args.num_messages,
+                bootstrap_servers=args.bootstrap_servers,
+                num_partitions=args.num_partitions,
+                num_keys=args.num_keys,
+                group_id=plan.group_id,
+                timeout_sec=args.timeout_sec,
+                async_worker_fn=async_worker_fn,
+                process_worker_fn=prof_process_worker,
+                workload=plan.workload,
+                ordering=plan.ordering,
+                ensure_topic_exists=args.skip_reset,
+                strict_completion_monitor_enabled=(
+                    plan.strict_completion_monitor_enabled
+                ),
+                process_count=args.process_count,
+                process_batch_size=effective_process_batch_size,
+                process_max_batch_wait_ms=effective_process_max_batch_wait_ms,
+                process_flush_policy=args.process_flush_policy,
+                process_demand_flush_min_residence_ms=(
+                    args.process_demand_flush_min_residence_ms
+                ),
+                process_transport_mode=cast(
+                    ProcessTransportMode, args.process_transport
+                ),
+                route_batch_size=args.route_batch_size,
+                metrics_port=metrics_port,
+                adaptive_concurrency_enabled=plan.adaptive_concurrency_enabled,
+            )
+        )
+        if args.profile and args.profile_process_workers:
+            _summarize_worker_profiles(
+                plan.run_name,
+                profile_dir=profile_dir,
+                top_n=args.profile_top_n,
+                clock=args.profile_clock,
+            )
+    return results
+
+
+def _execute_benchmark_run_plans(
+    args: argparse.Namespace,
+    *,
+    plans: Sequence[BenchmarkRunPlan],
+    metrics_port: int | None,
+    profile_dir: Path,
+) -> List[BenchmarkResult]:
+    """Execute prepared benchmark plans while preserving loop isolation."""
+    results: List[BenchmarkResult] = []
+    worker_bundles: dict[str, BenchmarkWorkerBundle] = {}
+    process_batching: dict[tuple[str, str, bool], tuple[int | None, int | None]] = {}
+
+    for plan_group in _group_benchmark_run_plans(plans):
+        async_plans: list[BenchmarkRunPlan] = []
+        for plan in plan_group:
+            if plan.kind != "baseline":
+                async_plans.append(plan)
+                continue
+            baseline_worker, _, _ = _workers_for_plan(
+                args,
+                plan=plan,
+                worker_bundles=worker_bundles,
+            )
+            results.append(
+                _execute_baseline_run_plan(
+                    args,
+                    plan=plan,
+                    profile_dir=profile_dir,
+                    baseline_worker=baseline_worker,
+                )
+            )
+
+        if async_plans:
+            results.extend(
+                asyncio.run(
+                    _execute_async_benchmark_run_plans(
+                        args,
+                        plans=async_plans,
+                        metrics_port=metrics_port,
+                        profile_dir=profile_dir,
+                        worker_bundles=worker_bundles,
+                        process_batching=process_batching,
+                    )
+                )
+            )
+
+    return results
+
+
 def run_benchmark(
     args: argparse.Namespace, raw_argv: Sequence[str] | None = None
 ) -> None:
@@ -334,243 +730,20 @@ def run_benchmark(
 
     _check_kafka_connection(args.bootstrap_servers)
     _ensure_metrics_port_available(metrics_port)
-
-    workloads = list(args.workloads)
-    orderings = list(args.order)
-    strict_monitor_modes = list(args.strict_completion_monitor)
-    adaptive_concurrency_modes = list(args.adaptive_concurrency)
     profile_dir = Path(args.profile_dir)
 
     _warn_on_tiny_partition_process_defaults(args)
 
-    results: List[BenchmarkResult] = []
-
-    has_runs = not (args.skip_baseline and args.skip_async and args.skip_process)
-    if not has_runs:
+    plans = _build_benchmark_run_plans(args)
+    if not plans:
         raise RuntimeError("All benchmark runs are skipped; nothing to execute")
 
-    for workload in workloads:
-        baseline_worker, async_worker_fn, process_worker_fn = _select_workers(
-            workload=workload,
-            sleep_ms=args.worker_sleep_ms,
-            cpu_iterations=args.worker_cpu_iterations,
-            io_sleep_ms=args.worker_io_sleep_ms,
-            workload_options=_workload_options_for(args.workload_options, workload),
-            validate_process_worker=not args.skip_process,
-        )
-
-        for ordering in orderings:
-            suffix = "-%s-%s" % (workload, ordering)
-            run_prefix = "%s-%s" % (workload, ordering)
-
-            if not args.skip_baseline:
-                topic_name = f"{args.topic_prefix}{suffix}-baseline"
-                run_name = f"{run_prefix}-baseline"
-                group_id = f"{args.baseline_group}{suffix}"
-                with _profile_session(
-                    enabled=args.profile,
-                    run_name=run_name,
-                    output_dir=profile_dir,
-                    clock=args.profile_clock,
-                    profile_threads=args.profile_threads,
-                    profile_greenlets=args.profile_greenlets,
-                    top_n=args.profile_top_n,
-                ):
-                    if not args.skip_reset:
-                        _reset_run_targets(
-                            bootstrap_servers=args.bootstrap_servers,
-                            topic_name=topic_name,
-                            group_id=group_id,
-                            num_partitions=args.num_partitions,
-                        )
-                    results.append(
-                        _run_baseline_round(
-                            run_name=run_name,
-                            topic_name=topic_name,
-                            num_messages=args.num_messages,
-                            bootstrap_servers=args.bootstrap_servers,
-                            num_partitions=args.num_partitions,
-                            num_keys=args.num_keys,
-                            group_id=group_id,
-                            worker_fn=baseline_worker,
-                            workload=workload,
-                            ordering=ordering,
-                            ensure_topic_exists=args.skip_reset,
-                        )
-                    )
-
-            async def run_async_rounds() -> List[BenchmarkResult]:
-                """Run async rounds for benchmark orchestration."""
-                async_results: List[BenchmarkResult] = []
-                for strict_monitor_mode in strict_monitor_modes:
-                    strict_completion_monitor_enabled = strict_monitor_mode == "on"
-                    (
-                        effective_process_batch_size,
-                        effective_process_max_batch_wait_ms,
-                    ) = _resolve_effective_process_batching(
-                        args,
-                        strict_completion_monitor_enabled=(
-                            strict_completion_monitor_enabled
-                        ),
-                    )
-                    strict_suffix = ""
-                    if len(strict_monitor_modes) > 1 or strict_monitor_mode != "on":
-                        strict_suffix = "-strict-%s" % strict_monitor_mode
-
-                    for adaptive_concurrency_mode in adaptive_concurrency_modes:
-                        adaptive_concurrency_enabled = adaptive_concurrency_mode == "on"
-                        adaptive_suffix = ""
-                        if (
-                            len(adaptive_concurrency_modes) > 1
-                            or adaptive_concurrency_mode != "off"
-                        ):
-                            adaptive_suffix = "-adaptive-%s" % adaptive_concurrency_mode
-
-                        if not args.skip_async:
-                            topic_name = (
-                                f"{args.topic_prefix}{suffix}-async"
-                                f"{strict_suffix}{adaptive_suffix}"
-                            )
-                            run_name = (
-                                f"{run_prefix}-pyrallel-async"
-                                f"{strict_suffix}{adaptive_suffix}"
-                            )
-                            group_id = (
-                                f"{args.async_group}{suffix}"
-                                f"{strict_suffix}{adaptive_suffix}"
-                            )
-                            if not args.skip_reset:
-                                _reset_run_targets(
-                                    bootstrap_servers=args.bootstrap_servers,
-                                    topic_name=topic_name,
-                                    group_id=group_id,
-                                    num_partitions=args.num_partitions,
-                                )
-                            with _profile_session(
-                                enabled=args.profile,
-                                run_name=run_name,
-                                output_dir=profile_dir,
-                                clock=args.profile_clock,
-                                profile_threads=args.profile_threads,
-                                profile_greenlets=args.profile_greenlets,
-                                top_n=args.profile_top_n,
-                            ):
-                                async_results.append(
-                                    await _run_pyrparallel_round(
-                                        topic_name=topic_name,
-                                        run_name=run_name,
-                                        mode=ExecutionMode.ASYNC,
-                                        num_messages=args.num_messages,
-                                        bootstrap_servers=args.bootstrap_servers,
-                                        num_partitions=args.num_partitions,
-                                        num_keys=args.num_keys,
-                                        group_id=group_id,
-                                        timeout_sec=args.timeout_sec,
-                                        async_worker_fn=async_worker_fn,
-                                        process_worker_fn=process_worker_fn,
-                                        workload=workload,
-                                        ordering=ordering,
-                                        ensure_topic_exists=args.skip_reset,
-                                        strict_completion_monitor_enabled=(
-                                            strict_completion_monitor_enabled
-                                        ),
-                                        process_count=None,
-                                        process_batch_size=(
-                                            effective_process_batch_size
-                                        ),
-                                        process_max_batch_wait_ms=(
-                                            effective_process_max_batch_wait_ms
-                                        ),
-                                        process_flush_policy=args.process_flush_policy,
-                                        process_demand_flush_min_residence_ms=(
-                                            args.process_demand_flush_min_residence_ms
-                                        ),
-                                        process_transport_mode=None,
-                                        route_batch_size=args.route_batch_size,
-                                        metrics_port=metrics_port,
-                                        adaptive_concurrency_enabled=(
-                                            adaptive_concurrency_enabled
-                                        ),
-                                    )
-                                )
-                        if not args.skip_process:
-                            topic_name = (
-                                f"{args.topic_prefix}{suffix}-process"
-                                f"{strict_suffix}{adaptive_suffix}"
-                            )
-                            run_name = (
-                                f"{run_prefix}-pyrallel-process"
-                                f"{strict_suffix}{adaptive_suffix}"
-                            )
-                            group_id = (
-                                f"{args.process_group}{suffix}"
-                                f"{strict_suffix}{adaptive_suffix}"
-                            )
-                            if not args.skip_reset:
-                                _reset_run_targets(
-                                    bootstrap_servers=args.bootstrap_servers,
-                                    topic_name=topic_name,
-                                    group_id=group_id,
-                                    num_partitions=args.num_partitions,
-                                )
-                            prof_process_worker = process_worker_fn
-                            if args.profile and args.profile_process_workers:
-                                prof_process_worker = _wrap_process_worker_for_profile(
-                                    process_worker_fn,
-                                    output_dir=profile_dir,
-                                    run_name=run_name,
-                                    clock=args.profile_clock,
-                                    profile_threads=args.profile_threads,
-                                    profile_greenlets=args.profile_greenlets,
-                                )
-                            async_results.append(
-                                await _run_pyrparallel_round(
-                                    topic_name=topic_name,
-                                    run_name=run_name,
-                                    mode=ExecutionMode.PROCESS,
-                                    num_messages=args.num_messages,
-                                    bootstrap_servers=args.bootstrap_servers,
-                                    num_partitions=args.num_partitions,
-                                    num_keys=args.num_keys,
-                                    group_id=group_id,
-                                    timeout_sec=args.timeout_sec,
-                                    async_worker_fn=async_worker_fn,
-                                    process_worker_fn=prof_process_worker,
-                                    workload=workload,
-                                    ordering=ordering,
-                                    ensure_topic_exists=args.skip_reset,
-                                    strict_completion_monitor_enabled=(
-                                        strict_completion_monitor_enabled
-                                    ),
-                                    process_count=args.process_count,
-                                    process_batch_size=effective_process_batch_size,
-                                    process_max_batch_wait_ms=(
-                                        effective_process_max_batch_wait_ms
-                                    ),
-                                    process_flush_policy=args.process_flush_policy,
-                                    process_demand_flush_min_residence_ms=(
-                                        args.process_demand_flush_min_residence_ms
-                                    ),
-                                    process_transport_mode=cast(
-                                        ProcessTransportMode, args.process_transport
-                                    ),
-                                    route_batch_size=args.route_batch_size,
-                                    metrics_port=metrics_port,
-                                    adaptive_concurrency_enabled=(
-                                        adaptive_concurrency_enabled
-                                    ),
-                                )
-                            )
-                            if args.profile and args.profile_process_workers:
-                                _summarize_worker_profiles(
-                                    run_name,
-                                    profile_dir=profile_dir,
-                                    top_n=args.profile_top_n,
-                                    clock=args.profile_clock,
-                                )
-                return async_results
-
-            results.extend(asyncio.run(run_async_rounds()))
+    results = _execute_benchmark_run_plans(
+        args,
+        plans=plans,
+        metrics_port=metrics_port,
+        profile_dir=profile_dir,
+    )
 
     _print_table(results)
     output_path = args.json_output

--- a/benchmarks/tui/app.py
+++ b/benchmarks/tui/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from textual.app import App
 
 from benchmarks.tui.controller import BenchmarkProcessController
+from benchmarks.tui.options_form import OptionsValidationResult
 from benchmarks.tui.results_modal import ResultsSummaryModalScreen
 from benchmarks.tui.screens.options import OptionsScreen, _ValidationResult
 from benchmarks.tui.screens.run import RunScreen, _format_elapsed
@@ -14,6 +15,7 @@ __all__ = [
     "ResultsSummaryModalScreen",
     "RunScreen",
     "_ValidationResult",
+    "OptionsValidationResult",
     "_format_elapsed",
 ]
 

--- a/benchmarks/tui/options_form.py
+++ b/benchmarks/tui/options_form.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from benchmarks.tui.state import BenchmarkTuiState
+from benchmarks.workloads import build_workload_options, describe_workload_options
+from benchmarks.workloads.base import BenchmarkWorkload
+
+
+@dataclass(slots=True)
+class OptionsFormDraft:
+    """Plain form values collected from the benchmark options screen."""
+
+    input_values: dict[str, str]
+    switch_values: dict[str, bool]
+    select_values: dict[str, str]
+    workloads: tuple[str, ...]
+    ordering_modes: tuple[str, ...]
+    workload_option_values: dict[str, dict[str, object]]
+
+
+@dataclass(slots=True)
+class OptionsValidationResult:
+    """Validated options form state or field errors."""
+
+    state: BenchmarkTuiState | None
+    errors: dict[str, str]
+
+
+POSITIVE_INT_FIELDS = {
+    "num-messages": 1,
+    "num-keys": 1,
+    "num-partitions": 1,
+    "timeout-sec": 1,
+    "route-batch-size": 1,
+}
+NON_NEGATIVE_INT_FIELDS = {
+    "metrics-port": 0,
+    "profile-top-n": 0,
+}
+OPTIONAL_POSITIVE_INT_FIELDS = {
+    "process-count": 1,
+    "process-batch-size": 1,
+}
+OPTIONAL_NON_NEGATIVE_INT_FIELDS = {
+    "process-max-batch-wait-ms": 0,
+}
+NON_NEGATIVE_FLOAT_FIELDS: dict[str, float] = {}
+
+
+def workload_option_widget_id(workload: str, field_name: str) -> str:
+    """Return the stable widget id for one workload option field."""
+    return "workload-option-%s-%s" % (workload, field_name)
+
+
+def validate_options_form(
+    draft: OptionsFormDraft,
+    *,
+    base_state: BenchmarkTuiState,
+    unavailable_workloads: dict[str, str],
+    workload_classes: dict[str, type[BenchmarkWorkload[object]]],
+) -> OptionsValidationResult:
+    """Validate raw TUI form values and build the next benchmark state."""
+    errors: dict[str, str] = {}
+    parsed_ints: dict[str, int] = {}
+    parsed_floats: dict[str, float] = {}
+
+    profiling_enabled = draft.switch_values["profiling-enabled"]
+
+    for widget_id, minimum in POSITIVE_INT_FIELDS.items():
+        _validate_int(draft, widget_id, minimum, parsed_ints, errors)
+    for widget_id, minimum in NON_NEGATIVE_INT_FIELDS.items():
+        if widget_id == "profile-top-n" and not profiling_enabled:
+            continue
+        _validate_int(draft, widget_id, minimum, parsed_ints, errors)
+    for widget_id, minimum in OPTIONAL_POSITIVE_INT_FIELDS.items():
+        _validate_optional_int(draft, widget_id, minimum, parsed_ints, errors)
+    for widget_id, minimum in OPTIONAL_NON_NEGATIVE_INT_FIELDS.items():
+        _validate_optional_int(draft, widget_id, minimum, parsed_ints, errors)
+    for widget_id, minimum_float in NON_NEGATIVE_FLOAT_FIELDS.items():
+        _validate_float(draft, widget_id, minimum_float, parsed_floats, errors)
+
+    if not draft.workloads:
+        errors["workloads"] = "Select at least one workload."
+    selected_unavailable = [
+        workload for workload in draft.workloads if workload in unavailable_workloads
+    ]
+    if selected_unavailable:
+        workload = selected_unavailable[0]
+        errors["workloads"] = "Workload %s is unavailable: %s" % (
+            workload,
+            unavailable_workloads[workload],
+        )
+
+    workload_options = _validate_workload_option_fields(
+        workloads=draft.workloads,
+        raw_workload_options=draft.workload_option_values,
+        workload_classes=workload_classes,
+        errors=errors,
+    )
+
+    if not draft.ordering_modes:
+        errors["ordering-modes"] = "Select at least one ordering mode."
+
+    skip_baseline = draft.switch_values["skip-baseline"]
+    skip_async = draft.switch_values["skip-async"]
+    skip_process = draft.switch_values["skip-process"]
+    if skip_baseline and skip_async and skip_process:
+        errors["skip-phase-group"] = "Keep at least one execution mode enabled."
+
+    if errors:
+        return OptionsValidationResult(state=None, errors=errors)
+
+    state = replace(
+        base_state,
+        bootstrap_servers=draft.input_values["bootstrap-servers"],
+        json_output=draft.input_values["json-output"],
+        num_messages=parsed_ints["num-messages"],
+        num_keys=parsed_ints["num-keys"],
+        num_partitions=parsed_ints["num-partitions"],
+        timeout_sec=parsed_ints["timeout-sec"],
+        metrics_port=parsed_ints["metrics-port"],
+        process_count=parsed_ints.get("process-count"),
+        process_transport=draft.select_values["process-transport"],
+        process_batch_size=parsed_ints.get("process-batch-size"),
+        process_max_batch_wait_ms=parsed_ints.get("process-max-batch-wait-ms"),
+        route_batch_size=parsed_ints["route-batch-size"],
+        topic_prefix=draft.input_values["topic-prefix"],
+        workloads=draft.workloads,
+        ordering_modes=draft.ordering_modes,
+        log_level=draft.select_values["log-level"],
+        skip_reset=draft.switch_values["skip-reset"],
+        profiling_enabled=profiling_enabled,
+        profile=draft.switch_values["profile"],
+        profile_dir=draft.input_values["profile-dir"],
+        py_spy=draft.switch_values["py-spy"],
+        py_spy_output=draft.input_values["py-spy-output"],
+        skip_baseline=skip_baseline,
+        skip_async=skip_async,
+        skip_process=skip_process,
+        profile_top_n=parsed_ints.get("profile-top-n", base_state.profile_top_n),
+        py_spy_format=draft.select_values["py-spy-format"],
+        py_spy_native=draft.switch_values["py-spy-native"],
+        py_spy_idle=draft.switch_values["py-spy-idle"],
+        worker_sleep_ms=_float_workload_option_value(
+            workload_options, "sleep", "sleep_ms", base_state.worker_sleep_ms
+        ),
+        worker_cpu_iterations=_int_workload_option_value(
+            workload_options,
+            "cpu",
+            "iterations",
+            base_state.worker_cpu_iterations,
+        ),
+        worker_io_sleep_ms=_float_workload_option_value(
+            workload_options, "io", "sleep_ms", base_state.worker_io_sleep_ms
+        ),
+        workload_options=workload_options,
+    )
+    return OptionsValidationResult(state=state, errors={})
+
+
+def _validate_workload_option_fields(
+    *,
+    workloads: tuple[str, ...],
+    raw_workload_options: dict[str, dict[str, object]],
+    workload_classes: dict[str, type[BenchmarkWorkload[object]]],
+    errors: dict[str, str],
+) -> dict[str, dict[str, object]]:
+    """Validate selected dynamic workload option values."""
+    workload_options: dict[str, dict[str, object]] = {}
+    for workload in workloads:
+        workload_cls = workload_classes.get(workload)
+        if workload_cls is None:
+            continue
+        raw_options = raw_workload_options.get(workload, {})
+        if not raw_options:
+            continue
+        schemas = describe_workload_options(workload_cls)
+        visible_schemas = [
+            schema for schema in schemas if schema.field_name in raw_options
+        ]
+        try:
+            options = build_workload_options(
+                workload_cls,
+                workload_options={workload: raw_options},
+            )
+        except ValueError as exc:
+            schema = visible_schemas[0] if visible_schemas else schemas[0]
+            errors[workload_option_widget_id(workload, schema.field_name)] = str(exc)
+            continue
+
+        selected_options: dict[str, object] = {}
+        for schema in visible_schemas:
+            selected_options[schema.field_name] = getattr(options, schema.field_name)
+        if selected_options:
+            workload_options[workload] = selected_options
+    return workload_options
+
+
+def _validate_int(
+    draft: OptionsFormDraft,
+    widget_id: str,
+    minimum: int,
+    parsed_values: dict[str, int],
+    errors: dict[str, str],
+) -> None:
+    """Validate a required integer field from a raw form draft."""
+    raw_value = draft.input_values[widget_id].strip()
+    try:
+        value = int(raw_value)
+    except ValueError:
+        errors[widget_id] = "Enter a whole number."
+        return
+    if value < minimum:
+        errors[widget_id] = "Enter a whole number >= %d." % minimum
+        return
+    parsed_values[widget_id] = value
+
+
+def _validate_optional_int(
+    draft: OptionsFormDraft,
+    widget_id: str,
+    minimum: int,
+    parsed_values: dict[str, int],
+    errors: dict[str, str],
+) -> None:
+    """Validate an optional integer field from a raw form draft."""
+    raw_value = draft.input_values[widget_id].strip()
+    if not raw_value:
+        return
+    try:
+        value = int(raw_value)
+    except ValueError:
+        errors[widget_id] = "Enter a whole number or leave blank."
+        return
+    if value < minimum:
+        errors[widget_id] = "Enter a whole number >= %d or leave blank." % minimum
+        return
+    parsed_values[widget_id] = value
+
+
+def _validate_float(
+    draft: OptionsFormDraft,
+    widget_id: str,
+    minimum: float,
+    parsed_values: dict[str, float],
+    errors: dict[str, str],
+) -> None:
+    """Validate a required floating-point field from a raw form draft."""
+    raw_value = draft.input_values[widget_id].strip()
+    try:
+        value = float(raw_value)
+    except ValueError:
+        errors[widget_id] = "Enter a number."
+        return
+    if value < minimum:
+        errors[widget_id] = "Enter a number >= %.1f." % minimum
+        return
+    parsed_values[widget_id] = value
+
+
+def _float_workload_option_value(
+    workload_options: dict[str, dict[str, object]],
+    workload: str,
+    option_name: str,
+    default: float,
+) -> float:
+    """Return a validated workload option value as float."""
+    value = workload_options.get(workload, {}).get(option_name, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RuntimeError(
+            "Validated workload option %s.%s is not numeric" % (workload, option_name)
+        )
+    return float(value)
+
+
+def _int_workload_option_value(
+    workload_options: dict[str, dict[str, object]],
+    workload: str,
+    option_name: str,
+    default: int,
+) -> int:
+    """Return a validated workload option value as int."""
+    value = workload_options.get(workload, {}).get(option_name, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RuntimeError(
+            "Validated workload option %s.%s is not an integer"
+            % (workload, option_name)
+        )
+    return value

--- a/benchmarks/tui/screens/options.py
+++ b/benchmarks/tui/screens/options.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import shlex
-from dataclasses import dataclass, replace
+from dataclasses import replace
 from pathlib import Path
 from typing import cast
 
@@ -23,48 +23,28 @@ from textual.widgets import (
 )
 
 from benchmarks.tui.option_help import OPTION_HELP, PROFILING_CONTROL_IDS
+from benchmarks.tui.options_form import (
+    OPTIONAL_NON_NEGATIVE_INT_FIELDS,
+    OPTIONAL_POSITIVE_INT_FIELDS,
+    POSITIVE_INT_FIELDS,
+    OptionsFormDraft,
+    OptionsValidationResult,
+    validate_options_form,
+    workload_option_widget_id,
+)
 from benchmarks.tui.path_picker import DirectoryPickerScreen
 from benchmarks.tui.screens.run import RunScreen
 from benchmarks.tui.state import BenchmarkTuiState
-from benchmarks.workloads import (
-    all_records,
-    build_workload_options,
-    describe_workload_options,
-)
+from benchmarks.workloads import all_records, describe_workload_options
 from benchmarks.workloads.base import BenchmarkWorkload, WorkloadOptionSchema
 
-
-@dataclass(slots=True)
-class _ValidationResult:
-    """Represent validation result data used by options."""
-
-    state: BenchmarkTuiState | None
-    errors: dict[str, str]
+_ValidationResult = OptionsValidationResult
 
 
 class OptionsScreen(Screen[None]):
     """Represent options screen data used by options."""
 
     BINDINGS = [("q", "app.quit", "Quit")]
-    _POSITIVE_INT_FIELDS = {
-        "num-messages": 1,
-        "num-keys": 1,
-        "num-partitions": 1,
-        "timeout-sec": 1,
-        "route-batch-size": 1,
-    }
-    _NON_NEGATIVE_INT_FIELDS = {
-        "metrics-port": 0,
-        "profile-top-n": 0,
-    }
-    _OPTIONAL_POSITIVE_INT_FIELDS = {
-        "process-count": 1,
-        "process-batch-size": 1,
-    }
-    _OPTIONAL_NON_NEGATIVE_INT_FIELDS = {
-        "process-max-batch-wait-ms": 0,
-    }
-    _NON_NEGATIVE_FLOAT_FIELDS: dict[str, float] = {}
 
     def __init__(self, initial_state: BenchmarkTuiState | None = None) -> None:
         super().__init__()
@@ -233,7 +213,7 @@ class OptionsScreen(Screen[None]):
     @staticmethod
     def _workload_option_widget_id(workload: str, field_name: str) -> str:
         """Return the stable widget id for one workload option field."""
-        return "workload-option-%s-%s" % (workload, field_name)
+        return workload_option_widget_id(workload, field_name)
 
     @classmethod
     def _workload_option_controls(cls, state: BenchmarkTuiState) -> ComposeResult:
@@ -715,142 +695,76 @@ class OptionsScreen(Screen[None]):
             widget.display = True
             widget.update(message)
 
-    def _validate_form(self) -> _ValidationResult:
+    def _validate_form(self) -> OptionsValidationResult:
         """Validate form for options."""
-        errors: dict[str, str] = {}
-        parsed_ints: dict[str, int] = {}
-        parsed_floats: dict[str, float] = {}
-
-        profiling_enabled = self.query_one("#profiling-enabled", Switch).value
-
-        for widget_id, minimum in self._POSITIVE_INT_FIELDS.items():
-            self._validate_int(widget_id, minimum, parsed_ints, errors)
-        for widget_id, minimum in self._NON_NEGATIVE_INT_FIELDS.items():
-            if widget_id == "profile-top-n" and not profiling_enabled:
-                continue
-            self._validate_int(widget_id, minimum, parsed_ints, errors)
-        for widget_id, minimum in self._OPTIONAL_POSITIVE_INT_FIELDS.items():
-            self._validate_optional_int(widget_id, minimum, parsed_ints, errors)
-        for widget_id, minimum in self._OPTIONAL_NON_NEGATIVE_INT_FIELDS.items():
-            self._validate_optional_int(widget_id, minimum, parsed_ints, errors)
-        for widget_id, minimum_float in self._NON_NEGATIVE_FLOAT_FIELDS.items():
-            self._validate_float(widget_id, minimum_float, parsed_floats, errors)
-
         workloads = tuple(self.query_one("#workloads", SelectionList).selected)
-        if not workloads:
-            errors["workloads"] = "Select at least one workload."
-        unavailable_workloads = self._unavailable_workload_reasons()
-        selected_unavailable = [
-            workload for workload in workloads if workload in unavailable_workloads
-        ]
-        if selected_unavailable:
-            workload = selected_unavailable[0]
-            errors["workloads"] = "Workload %s is unavailable: %s" % (
-                workload,
-                unavailable_workloads[workload],
-            )
-
-        workload_options = self._validate_workload_option_fields(workloads, errors)
-
         ordering_modes = tuple(
             self.query_one("#ordering-modes", SelectionList).selected
         )
-        if not ordering_modes:
-            errors["ordering-modes"] = "Select at least one ordering mode."
-
-        skip_baseline = self.query_one("#skip-baseline", Switch).value
-        skip_async = self.query_one("#skip-async", Switch).value
-        skip_process = self.query_one("#skip-process", Switch).value
-        if skip_baseline and skip_async and skip_process:
-            errors["skip-phase-group"] = "Keep at least one execution mode enabled."
-
-        if errors:
-            return _ValidationResult(state=None, errors=errors)
-
-        base_state = self._last_valid_state
-        state = replace(
-            base_state,
-            bootstrap_servers=self.query_one("#bootstrap-servers", Input).value,
-            json_output=self.query_one("#json-output", Input).value,
-            num_messages=parsed_ints["num-messages"],
-            num_keys=parsed_ints["num-keys"],
-            num_partitions=parsed_ints["num-partitions"],
-            timeout_sec=parsed_ints["timeout-sec"],
-            metrics_port=parsed_ints["metrics-port"],
-            process_count=parsed_ints.get("process-count"),
-            process_transport=str(self.query_one("#process-transport", Select).value),
-            process_batch_size=parsed_ints.get("process-batch-size"),
-            process_max_batch_wait_ms=parsed_ints.get("process-max-batch-wait-ms"),
-            route_batch_size=parsed_ints["route-batch-size"],
-            topic_prefix=self.query_one("#topic-prefix", Input).value,
+        draft = OptionsFormDraft(
+            input_values=self._form_input_values(),
+            switch_values=self._form_switch_values(),
+            select_values=self._form_select_values(),
             workloads=workloads,
             ordering_modes=ordering_modes,
-            log_level=str(self.query_one("#log-level", Select).value),
-            skip_reset=self.query_one("#skip-reset", Switch).value,
-            profiling_enabled=profiling_enabled,
-            profile=self.query_one("#profile", Switch).value,
-            profile_dir=self.query_one("#profile-dir", Input).value,
-            py_spy=self.query_one("#py-spy", Switch).value,
-            py_spy_output=self.query_one("#py-spy-output", Input).value,
-            skip_baseline=skip_baseline,
-            skip_async=skip_async,
-            skip_process=skip_process,
-            profile_top_n=parsed_ints.get("profile-top-n", base_state.profile_top_n),
-            py_spy_format=str(self.query_one("#py-spy-format", Select).value),
-            py_spy_native=self.query_one("#py-spy-native", Switch).value,
-            py_spy_idle=self.query_one("#py-spy-idle", Switch).value,
-            worker_sleep_ms=self._float_workload_option_value(
-                workload_options, "sleep", "sleep_ms", base_state.worker_sleep_ms
-            ),
-            worker_cpu_iterations=self._int_workload_option_value(
-                workload_options,
-                "cpu",
-                "iterations",
-                base_state.worker_cpu_iterations,
-            ),
-            worker_io_sleep_ms=self._float_workload_option_value(
-                workload_options, "io", "sleep_ms", base_state.worker_io_sleep_ms
-            ),
-            workload_options=workload_options,
+            workload_option_values=self._visible_workload_option_values(workloads),
         )
-        return _ValidationResult(state=state, errors={})
+        return validate_options_form(
+            draft,
+            base_state=self._last_valid_state,
+            unavailable_workloads=self._unavailable_workload_reasons(),
+            workload_classes=self._available_workload_classes(),
+        )
 
-    @staticmethod
-    def _float_workload_option_value(
-        workload_options: dict[str, dict[str, object]],
-        workload: str,
-        option_name: str,
-        default: float,
-    ) -> float:
-        """Return a validated workload option value as float."""
-        value = workload_options.get(workload, {}).get(option_name, default)
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise RuntimeError(
-                "Validated workload option %s.%s is not numeric"
-                % (workload, option_name)
-            )
-        return float(value)
+    def _form_input_values(self) -> dict[str, str]:
+        """Collect raw input widget values for form validation."""
+        widget_ids = {
+            "bootstrap-servers",
+            "json-output",
+            "topic-prefix",
+            "profile-dir",
+            "py-spy-output",
+            *POSITIVE_INT_FIELDS,
+            "metrics-port",
+            "profile-top-n",
+            *OPTIONAL_POSITIVE_INT_FIELDS,
+            *OPTIONAL_NON_NEGATIVE_INT_FIELDS,
+        }
+        return {
+            widget_id: self.query_one("#%s" % widget_id, Input).value
+            for widget_id in widget_ids
+        }
 
-    @staticmethod
-    def _int_workload_option_value(
-        workload_options: dict[str, dict[str, object]],
-        workload: str,
-        option_name: str,
-        default: int,
-    ) -> int:
-        """Return a validated workload option value as int."""
-        value = workload_options.get(workload, {}).get(option_name, default)
-        if isinstance(value, bool) or not isinstance(value, int):
-            raise RuntimeError(
-                "Validated workload option %s.%s is not an integer"
-                % (workload, option_name)
-            )
-        return value
+    def _form_switch_values(self) -> dict[str, bool]:
+        """Collect switch widget values for form validation."""
+        widget_ids = {
+            "profiling-enabled",
+            "skip-reset",
+            "profile",
+            "py-spy",
+            "skip-baseline",
+            "skip-async",
+            "skip-process",
+            "py-spy-native",
+            "py-spy-idle",
+        }
+        return {
+            widget_id: self.query_one("#%s" % widget_id, Switch).value
+            for widget_id in widget_ids
+        }
 
-    def _validate_workload_option_fields(
-        self, workloads: tuple[str, ...], errors: dict[str, str]
+    def _form_select_values(self) -> dict[str, str]:
+        """Collect select widget values for form validation."""
+        widget_ids = {"process-transport", "log-level", "py-spy-format"}
+        return {
+            widget_id: str(self.query_one("#%s" % widget_id, Select).value)
+            for widget_id in widget_ids
+        }
+
+    def _visible_workload_option_values(
+        self, workloads: tuple[str, ...]
     ) -> dict[str, dict[str, object]]:
-        """Validate selected dynamic workload option controls."""
+        """Collect visible dynamic workload option values from widgets."""
         workload_classes = self._available_workload_classes()
         workload_options: dict[str, dict[str, object]] = {}
         for workload in workloads:
@@ -858,9 +772,7 @@ class OptionsScreen(Screen[None]):
             if workload_cls is None:
                 continue
             schemas = describe_workload_options(workload_cls)
-            selected_options: dict[str, object] = {}
             raw_options: dict[str, object] = {}
-            visible_schemas: list[WorkloadOptionSchema] = []
             for schema in schemas:
                 widget_id = self._workload_option_widget_id(workload, schema.field_name)
                 if not self.query("#%s" % widget_id):
@@ -868,26 +780,9 @@ class OptionsScreen(Screen[None]):
                 raw_options[schema.field_name] = self._raw_workload_option_value(
                     widget_id, schema
                 )
-                visible_schemas.append(schema)
             if not raw_options:
                 continue
-            try:
-                options = build_workload_options(
-                    workload_cls,
-                    workload_options={workload: raw_options},
-                )
-            except ValueError as exc:
-                schema = visible_schemas[0]
-                errors[
-                    self._workload_option_widget_id(workload, schema.field_name)
-                ] = str(exc)
-                continue
-            for schema in visible_schemas:
-                selected_options[schema.field_name] = getattr(
-                    options, schema.field_name
-                )
-            if selected_options:
-                workload_options[workload] = selected_options
+            workload_options[workload] = raw_options
         return workload_options
 
     def _raw_workload_option_value(
@@ -899,66 +794,6 @@ class OptionsScreen(Screen[None]):
         if schema.annotation is str and schema.metadata.choices:
             return str(self.query_one("#%s" % widget_id, Select).value)
         return self.query_one("#%s" % widget_id, Input).value
-
-    def _validate_int(
-        self,
-        widget_id: str,
-        minimum: int,
-        parsed_values: dict[str, int],
-        errors: dict[str, str],
-    ) -> None:
-        """Validate int for options."""
-        raw_value = self.query_one("#%s" % widget_id, Input).value.strip()
-        try:
-            value = int(raw_value)
-        except ValueError:
-            errors[widget_id] = "Enter a whole number."
-            return
-        if value < minimum:
-            comparator = ">="
-            errors[widget_id] = "Enter a whole number %s %d." % (comparator, minimum)
-            return
-        parsed_values[widget_id] = value
-
-    def _validate_optional_int(
-        self,
-        widget_id: str,
-        minimum: int,
-        parsed_values: dict[str, int],
-        errors: dict[str, str],
-    ) -> None:
-        """Validate optional int for options."""
-        raw_value = self.query_one("#%s" % widget_id, Input).value.strip()
-        if not raw_value:
-            return
-        try:
-            value = int(raw_value)
-        except ValueError:
-            errors[widget_id] = "Enter a whole number or leave blank."
-            return
-        if value < minimum:
-            errors[widget_id] = "Enter a whole number >= %d or leave blank." % minimum
-            return
-        parsed_values[widget_id] = value
-
-    def _validate_float(
-        self,
-        widget_id: str,
-        minimum: float,
-        parsed_values: dict[str, float],
-        errors: dict[str, str],
-    ) -> None:
-        """Validate float for options."""
-        raw_value = self.query_one("#%s" % widget_id, Input).value.strip()
-        try:
-            value = float(raw_value)
-        except ValueError:
-            errors[widget_id] = "Enter a number."
-            return
-        if value < minimum:
-            errors[widget_id] = "Enter a number >= %.1f." % minimum
-            return
-        parsed_values[widget_id] = value
 
     def _sync_profiling_controls(self) -> None:
         """Handle sync profiling controls within options."""

--- a/tests/unit/benchmarks/test_benchmark_runtime.py
+++ b/tests/unit/benchmarks/test_benchmark_runtime.py
@@ -347,6 +347,188 @@ def test_run_benchmark_expands_adaptive_concurrency_modes(
     ]
 
 
+def test_build_benchmark_run_plans_expands_selected_workloads_and_orderings() -> None:
+    plans = run_parallel_benchmark._build_benchmark_run_plans(
+        _build_args(
+            workloads=["sleep", "cpu"],
+            order=["key_hash", "partition"],
+            skip_process=False,
+        )
+    )
+
+    assert [
+        (plan.kind, plan.run_name, plan.workload, plan.ordering) for plan in plans
+    ] == [
+        ("baseline", "sleep-key_hash-baseline", "sleep", "key_hash"),
+        ("async", "sleep-key_hash-pyrallel-async", "sleep", "key_hash"),
+        ("process", "sleep-key_hash-pyrallel-process", "sleep", "key_hash"),
+        ("baseline", "sleep-partition-baseline", "sleep", "partition"),
+        ("async", "sleep-partition-pyrallel-async", "sleep", "partition"),
+        ("process", "sleep-partition-pyrallel-process", "sleep", "partition"),
+        ("baseline", "cpu-key_hash-baseline", "cpu", "key_hash"),
+        ("async", "cpu-key_hash-pyrallel-async", "cpu", "key_hash"),
+        ("process", "cpu-key_hash-pyrallel-process", "cpu", "key_hash"),
+        ("baseline", "cpu-partition-baseline", "cpu", "partition"),
+        ("async", "cpu-partition-pyrallel-async", "cpu", "partition"),
+        ("process", "cpu-partition-pyrallel-process", "cpu", "partition"),
+    ]
+
+
+def test_build_benchmark_run_plans_preserves_mode_suffixes_and_options() -> None:
+    plans = run_parallel_benchmark._build_benchmark_run_plans(
+        _build_args(
+            skip_baseline=True,
+            skip_process=False,
+            strict_completion_monitor=["on", "off"],
+            adaptive_concurrency=["off", "on"],
+            workload_options={"sleep": {"sleep_ms": 1.25}},
+        )
+    )
+
+    assert [
+        (
+            plan.kind,
+            plan.run_name,
+            plan.topic_name,
+            plan.group_id,
+            plan.strict_completion_monitor_enabled,
+            plan.adaptive_concurrency_enabled,
+            plan.workload_options,
+        )
+        for plan in plans
+    ] == [
+        (
+            "async",
+            "sleep-key_hash-pyrallel-async-strict-on-adaptive-off",
+            "demo-topic-sleep-key_hash-async-strict-on-adaptive-off",
+            "async-group-sleep-key_hash-strict-on-adaptive-off",
+            True,
+            False,
+            {"sleep": {"sleep_ms": 1.25}},
+        ),
+        (
+            "process",
+            "sleep-key_hash-pyrallel-process-strict-on-adaptive-off",
+            "demo-topic-sleep-key_hash-process-strict-on-adaptive-off",
+            "process-group-sleep-key_hash-strict-on-adaptive-off",
+            True,
+            False,
+            {"sleep": {"sleep_ms": 1.25}},
+        ),
+        (
+            "async",
+            "sleep-key_hash-pyrallel-async-strict-on-adaptive-on",
+            "demo-topic-sleep-key_hash-async-strict-on-adaptive-on",
+            "async-group-sleep-key_hash-strict-on-adaptive-on",
+            True,
+            True,
+            {"sleep": {"sleep_ms": 1.25}},
+        ),
+        (
+            "process",
+            "sleep-key_hash-pyrallel-process-strict-on-adaptive-on",
+            "demo-topic-sleep-key_hash-process-strict-on-adaptive-on",
+            "process-group-sleep-key_hash-strict-on-adaptive-on",
+            True,
+            True,
+            {"sleep": {"sleep_ms": 1.25}},
+        ),
+        (
+            "async",
+            "sleep-key_hash-pyrallel-async-strict-off-adaptive-off",
+            "demo-topic-sleep-key_hash-async-strict-off-adaptive-off",
+            "async-group-sleep-key_hash-strict-off-adaptive-off",
+            False,
+            False,
+            {"sleep": {"sleep_ms": 1.25}},
+        ),
+        (
+            "process",
+            "sleep-key_hash-pyrallel-process-strict-off-adaptive-off",
+            "demo-topic-sleep-key_hash-process-strict-off-adaptive-off",
+            "process-group-sleep-key_hash-strict-off-adaptive-off",
+            False,
+            False,
+            {"sleep": {"sleep_ms": 1.25}},
+        ),
+        (
+            "async",
+            "sleep-key_hash-pyrallel-async-strict-off-adaptive-on",
+            "demo-topic-sleep-key_hash-async-strict-off-adaptive-on",
+            "async-group-sleep-key_hash-strict-off-adaptive-on",
+            False,
+            True,
+            {"sleep": {"sleep_ms": 1.25}},
+        ),
+        (
+            "process",
+            "sleep-key_hash-pyrallel-process-strict-off-adaptive-on",
+            "demo-topic-sleep-key_hash-process-strict-off-adaptive-on",
+            "process-group-sleep-key_hash-strict-off-adaptive-on",
+            False,
+            True,
+            {"sleep": {"sleep_ms": 1.25}},
+        ),
+    ]
+
+
+def test_run_benchmark_preserves_event_loop_per_workload_ordering(
+    monkeypatch: pytest.MonkeyPatch,
+    benchmark_result: BenchmarkResult,
+) -> None:
+    loop_runs: list[int] = []
+    real_asyncio_run = asyncio.run
+
+    monkeypatch.setattr(
+        run_parallel_benchmark, "_check_kafka_connection", lambda _bootstrap: None
+    )
+    monkeypatch.setattr(
+        run_parallel_benchmark,
+        "_select_workers",
+        lambda **_kwargs: (
+            lambda _payload: None,
+            lambda _item: None,
+            lambda _item: None,
+        ),
+    )
+    monkeypatch.setattr(run_parallel_benchmark, "_print_table", lambda _results: None)
+    monkeypatch.setattr(
+        run_parallel_benchmark,
+        "write_results_json",
+        lambda _results, _path, options=None, artifact_metadata=None: None,
+    )
+
+    async def _async_round(**_kwargs) -> BenchmarkResult:
+        return benchmark_result
+
+    def _record_asyncio_run(coro):
+        loop_runs.append(1)
+        return real_asyncio_run(coro)
+
+    monkeypatch.setattr(run_parallel_benchmark, "_run_pyrparallel_round", _async_round)
+    monkeypatch.setattr(run_parallel_benchmark.asyncio, "run", _record_asyncio_run)
+
+    run_parallel_benchmark.run_benchmark(
+        _build_args(
+            skip_baseline=True,
+            skip_process=False,
+            skip_reset=True,
+            workloads=["sleep", "cpu"],
+            order=["key_hash", "partition"],
+        ),
+        raw_argv=[
+            "--skip-baseline",
+            "--skip-reset",
+            "--workloads",
+            "sleep,cpu",
+            "--order",
+            "key_hash,partition",
+        ],
+    )
+
+    assert loop_runs == [1, 1, 1, 1]
+
+
 def test_build_artifact_metadata_prefers_github_environment() -> None:
     metadata = run_parallel_benchmark._build_artifact_metadata(
         output_path="benchmarks/results/release-gate.json",
@@ -918,6 +1100,90 @@ async def test_wait_for_partition_assignment_raises_clear_error_for_topic() -> N
             topic_name="demo-topic",
             timeout_sec=0.0,
         )
+
+
+def test_benchmark_metrics_observer_records_success_and_stops_at_target() -> None:
+    completion_event = asyncio.Event()
+    stats = BenchmarkStats(
+        run_name="demo",
+        run_type="async",
+        workload="sleep",
+        topic="demo-topic",
+        ordering="key_hash",
+        target_messages=1,
+    )
+    consumption_stats = pyrallel_consumer_test.ConsumptionStats(target=1)
+    completions: list[tuple[TopicPartition, CompletionStatus, float]] = []
+
+    class _FakePrometheusExporter:
+        def observe_completion(self, tp, status, duration_seconds: float) -> None:
+            completions.append((tp, status, duration_seconds))
+
+    observer = pyrallel_consumer_test.BenchmarkMetricsObserver(
+        benchmark_stats=stats,
+        cons_stats=consumption_stats,
+        completion_event=completion_event,
+        prometheus_metrics_exporter=cast(Any, _FakePrometheusExporter()),
+    )
+    tp = TopicPartition(topic="demo-topic", partition=0)
+
+    observer.observe_completion(tp, CompletionStatus.SUCCESS, 0.01)
+
+    assert completions == [(tp, CompletionStatus.SUCCESS, 0.01)]
+    assert consumption_stats.processed == 1
+    assert stats.processed == 1
+    assert completion_event.is_set() is True
+    assert observer.failure_error is None
+
+
+def test_benchmark_metrics_observer_reports_completion_failure() -> None:
+    completion_event = asyncio.Event()
+    observer = pyrallel_consumer_test.BenchmarkMetricsObserver(
+        benchmark_stats=None,
+        cons_stats=pyrallel_consumer_test.ConsumptionStats(target=1),
+        completion_event=completion_event,
+    )
+
+    observer.observe_completion(
+        TopicPartition(topic="demo-topic", partition=0),
+        CompletionStatus.FAILURE,
+        0.01,
+    )
+
+    assert observer.failure_error == (
+        "Benchmark worker failure on demo-topic[0]: completion failed"
+    )
+    assert completion_event.is_set() is True
+
+
+def test_record_release_gate_metrics_from_snapshot_sums_partition_metrics() -> None:
+    stats = BenchmarkStats(
+        run_name="demo",
+        run_type="async",
+        workload="sleep",
+        topic="demo-topic",
+        ordering="key_hash",
+    )
+    metrics = SimpleNamespace(
+        partitions=[
+            SimpleNamespace(true_lag=3, gap_count=1),
+            SimpleNamespace(true_lag=5, gap_count=2),
+        ]
+    )
+
+    pyrallel_consumer_test._record_release_gate_metrics_from_snapshot(
+        stats,
+        cast(Any, metrics),
+        elapsed_sec=1.25,
+    )
+
+    assert stats._release_gate_observations == [
+        {
+            "elapsed_sec": 1.25,
+            "consumer_parallel_lag": 8,
+            "consumer_gap_count": 3,
+        }
+    ]
 
 
 def test_build_kafka_config_sets_strict_completion_monitor_flag() -> None:

--- a/tests/unit/benchmarks/test_tui_options_form.py
+++ b/tests/unit/benchmarks/test_tui_options_form.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import cast
+
+from benchmarks.tui.options_form import OptionsFormDraft, validate_options_form
+from benchmarks.tui.state import BenchmarkTuiState
+from benchmarks.workloads.base import BenchmarkWorkload
+from benchmarks.workloads.sleep import SleepWorkload
+
+
+def _workload_classes() -> dict[str, type[BenchmarkWorkload[object]]]:
+    return {"sleep": cast(type[BenchmarkWorkload[object]], SleepWorkload)}
+
+
+def _draft(
+    *,
+    input_values: dict[str, str] | None = None,
+    switch_values: dict[str, bool] | None = None,
+    workload_option_values: dict[str, dict[str, object]] | None = None,
+) -> OptionsFormDraft:
+    state = BenchmarkTuiState()
+    default_input_values = {
+        "bootstrap-servers": state.bootstrap_servers,
+        "json-output": state.json_output,
+        "num-messages": str(state.num_messages),
+        "num-keys": str(state.num_keys),
+        "num-partitions": str(state.num_partitions),
+        "timeout-sec": str(state.timeout_sec),
+        "metrics-port": str(state.metrics_port),
+        "process-count": ""
+        if state.process_count is None
+        else str(state.process_count),
+        "process-batch-size": ""
+        if state.process_batch_size is None
+        else str(state.process_batch_size),
+        "process-max-batch-wait-ms": ""
+        if state.process_max_batch_wait_ms is None
+        else str(state.process_max_batch_wait_ms),
+        "route-batch-size": str(state.route_batch_size),
+        "topic-prefix": state.topic_prefix,
+        "profile-dir": state.profile_dir,
+        "profile-top-n": str(state.profile_top_n),
+        "py-spy-output": state.py_spy_output,
+    }
+    default_switch_values = {
+        "profiling-enabled": state.profiling_enabled,
+        "skip-reset": state.skip_reset,
+        "profile": state.profile,
+        "py-spy": state.py_spy,
+        "skip-baseline": state.skip_baseline,
+        "skip-async": state.skip_async,
+        "skip-process": state.skip_process,
+        "py-spy-native": state.py_spy_native,
+        "py-spy-idle": state.py_spy_idle,
+    }
+    select_values = {
+        "process-transport": state.process_transport,
+        "log-level": state.log_level,
+        "py-spy-format": state.py_spy_format,
+    }
+    return OptionsFormDraft(
+        input_values=input_values or default_input_values,
+        switch_values=switch_values or default_switch_values,
+        select_values=select_values,
+        workloads=state.workloads,
+        ordering_modes=state.ordering_modes,
+        workload_option_values=workload_option_values or {},
+    )
+
+
+def test_tui_app_preserves_validation_result_export() -> None:
+    from benchmarks.tui import app as tui_app
+    from benchmarks.tui.options_form import OptionsValidationResult
+
+    assert tui_app._ValidationResult is OptionsValidationResult
+
+
+def test_validate_options_form_rejects_invalid_numeric_input() -> None:
+    draft = _draft(
+        input_values={
+            **_draft().input_values,
+            "num-messages": "oops",
+        }
+    )
+
+    result = validate_options_form(
+        draft,
+        base_state=BenchmarkTuiState(),
+        unavailable_workloads={},
+        workload_classes=_workload_classes(),
+    )
+
+    assert result.state is None
+    assert result.errors["num-messages"] == "Enter a whole number."
+
+
+def test_validate_options_form_builds_state_with_workload_options() -> None:
+    result = validate_options_form(
+        _draft(workload_option_values={"sleep": {"sleep_ms": "1.25"}}),
+        base_state=BenchmarkTuiState(),
+        unavailable_workloads={},
+        workload_classes=_workload_classes(),
+    )
+
+    assert result.errors == {}
+    assert result.state is not None
+    assert result.state.worker_sleep_ms == 1.25
+    assert result.state.workload_options == {"sleep": {"sleep_ms": 1.25}}
+
+
+def test_validate_options_form_rejects_all_execution_modes_skipped() -> None:
+    draft = _draft(
+        switch_values={
+            **_draft().switch_values,
+            "skip-baseline": True,
+            "skip-async": True,
+            "skip-process": True,
+        }
+    )
+
+    result = validate_options_form(
+        draft,
+        base_state=BenchmarkTuiState(),
+        unavailable_workloads={},
+        workload_classes=_workload_classes(),
+    )
+
+    assert result.state is None
+    assert (
+        result.errors["skip-phase-group"] == "Keep at least one execution mode enabled."
+    )


### PR DESCRIPTION
## Summary
- Extract benchmark run planning from `run_benchmark()` into `BenchmarkRunPlan` helpers while preserving run naming, reset/profile flow, and per-workload/order event-loop isolation.
- Move TUI option parsing and validation into `benchmarks.tui.options_form`, keeping `OptionsScreen` focused on widget snapshots, rendering, preview, copy command, and path picker behavior.
- Promote benchmark metrics observer and runtime diagnostics/metrics/finalization helpers out of `run_pyrallel_consumer_test()` and remove an unused baseline delivery callback.

## Validation
- `uv run pytest -q` -> 962 passed, 1 skipped, 29 warnings
- `uv run pytest tests/unit/benchmarks -q` -> 269 passed
- `uv run pre-commit run --files benchmarks/baseline_consumer.py benchmarks/pyrallel_consumer_test.py benchmarks/run_parallel_benchmark.py benchmarks/tui/app.py benchmarks/tui/options_form.py benchmarks/tui/screens/options.py tests/unit/benchmarks/test_benchmark_runtime.py tests/unit/benchmarks/test_tui_options_form.py` -> passed

Refs: #136