### PR TITLE
feat(tui): compact benchmark run layout

### DIFF
--- a/benchmarks/benchmark_artifacts.py
+++ b/benchmarks/benchmark_artifacts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from collections.abc import Mapping
 from datetime import datetime, timezone
 
 
@@ -36,6 +37,7 @@ def build_artifact_metadata(
         .replace(microsecond=0)
         .isoformat()
         .replace("+00:00", "Z"),
+        "runner_interface": _runner_interface(env),
     }
 
     field_map = {
@@ -87,3 +89,10 @@ def build_artifact_metadata(
             metadata["git_ref"] = "refs/tags/%s" % git_ref_name
 
     return metadata
+
+
+def _runner_interface(env: Mapping[str, str]) -> str:
+    """Return the benchmark runner interface recorded in result artifacts."""
+    if env.get("PYRALLEL_BENCHMARK_RUNNER_INTERFACE") == "tui":
+        return "tui"
+    return "cli"

--- a/benchmarks/tui/app.py
+++ b/benchmarks/tui/app.py
@@ -102,7 +102,7 @@ class BenchmarkTuiApp(App[None]):
         margin-bottom: 1;
     }
 
-    Input, Select, Switch, Static, Log, Collapsible, ProgressBar, DataTable, LoadingIndicator {
+    Input, Select, Switch, Static, Log, Collapsible, ProgressBar, DataTable {
         margin-bottom: 1;
     }
 
@@ -175,6 +175,18 @@ class BenchmarkTuiApp(App[None]):
         border: round $accent;
         padding: 0 1;
         margin-bottom: 1;
+        height: auto;
+    }
+
+    #run-dashboard-row {
+        height: auto;
+        margin-bottom: 0;
+    }
+
+    #run-current-panel {
+        width: 5fr;
+        min-width: 44;
+        margin-right: 1;
         height: auto;
     }
 
@@ -271,11 +283,14 @@ class BenchmarkTuiApp(App[None]):
     }
 
     #run-summary {
+        width: 7fr;
         height: auto;
+        margin-bottom: 0;
     }
 
     #run-log {
-        height: 16;
+        height: 1fr;
+        min-height: 22;
     }
 
     #run-actions, #options-actions {

--- a/benchmarks/tui/app.py
+++ b/benchmarks/tui/app.py
@@ -285,6 +285,7 @@ class BenchmarkTuiApp(App[None]):
     #run-summary {
         width: 7fr;
         height: auto;
+        margin-top: 1;
         margin-bottom: 0;
     }
 

--- a/benchmarks/tui/app.py
+++ b/benchmarks/tui/app.py
@@ -285,7 +285,6 @@ class BenchmarkTuiApp(App[None]):
     #run-summary {
         width: 7fr;
         height: auto;
-        margin-top: 1;
         margin-bottom: 0;
     }
 

--- a/benchmarks/tui/controller.py
+++ b/benchmarks/tui/controller.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 from asyncio.subprocess import PIPE
 from collections.abc import Callable
@@ -77,6 +78,7 @@ class BenchmarkProcessController:
             *argv,
             stdout=PIPE,
             stderr=PIPE,
+            env=self._child_environment(),
         )
         if self._cancel_requested:
             await self.cancel()
@@ -115,3 +117,11 @@ class BenchmarkProcessController:
             self._on_output(decoded, is_error)
             snapshot = self._parser.consume(decoded)
             self._on_progress(snapshot)
+
+    @staticmethod
+    def _child_environment() -> dict[str, str]:
+        """Return environment for the benchmark child process."""
+        return {
+            **os.environ,
+            "PYRALLEL_BENCHMARK_RUNNER_INTERFACE": "tui",
+        }

--- a/benchmarks/tui/screens/run.py
+++ b/benchmarks/tui/screens/run.py
@@ -12,16 +12,7 @@ from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, VerticalScroll
 from textual.screen import Screen
 from textual.timer import Timer
-from textual.widgets import (
-    Button,
-    DataTable,
-    Footer,
-    Header,
-    LoadingIndicator,
-    Log,
-    ProgressBar,
-    Static,
-)
+from textual.widgets import Button, DataTable, Footer, Header, Log, ProgressBar, Static
 
 from benchmarks.tui.controller import BenchmarkProcessController
 from benchmarks.tui.log_parser import BenchmarkProgressSnapshot
@@ -39,6 +30,8 @@ _WAITING_STYLE = "grey62"
 _FAILED_STYLE = "bold bright_red"
 _CANCELLED_STYLE = "bold bright_yellow"
 _ACTIVE_ROW_STYLE = "bold bright_cyan"
+_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+_SPINNER_INTERVAL_SECONDS = 0.12
 _METRICS_PORT_PID_PATTERN = re.compile(
     r"Metrics port \d+ is already in use\(PID ([0-9,\s]+)\)"
 )
@@ -67,8 +60,12 @@ class RunScreen(Screen[None]):
         self._controller: BenchmarkProcessController | None = None
         self._run_task: asyncio.Task[None] | None = None
         self._elapsed_timer: Timer | None = None
+        self._spinner_timer: Timer | None = None
         self._cancelled = False
         self._closed = False
+        self._is_running = False
+        self._spinner_frame_index = 0
+        self._spinner_interval_seconds = _SPINNER_INTERVAL_SECONDS
         self._completed_successfully = False
         self._last_error_line: str | None = None
         self._terminal_reason = ""
@@ -95,39 +92,54 @@ class RunScreen(Screen[None]):
             with VerticalScroll(id="run-screen"):
                 yield Static("벤치마크 실행 준비 중", id="run-status")
                 with Container(id="run-spotlight-card"):
-                    yield Static("", id="run-spotlight")
-                    with Horizontal(id="run-chip-row"):
-                        yield Static("", id="run-chip-workload", classes="status-chip")
-                        yield Static("", id="run-chip-ordering", classes="status-chip")
-                        yield Static("", id="run-chip-phase", classes="status-chip")
-                    with Horizontal(id="run-phase-meta"):
-                        yield Static(
-                            "", id="phase-progress-badge", classes="status-badge"
-                        )
-                        yield Static(
-                            "", id="current-run-elapsed", classes="status-badge"
-                        )
-                    yield ProgressBar(
-                        total=None,
-                        show_percentage=False,
-                        show_eta=True,
-                        id="phase-progress",
-                    )
-                    with Horizontal(id="run-overall-meta"):
-                        yield Static("", id="progress-badge", classes="status-badge")
-                        yield Static("", id="run-elapsed", classes="status-badge")
-                    yield ProgressBar(
-                        total=max(self._total_runs, 1),
-                        show_percentage=False,
-                        show_eta=True,
-                        id="run-progress",
-                    )
-                    yield Static("", id="run-terminal-reason")
+                    with Horizontal(id="run-dashboard-row"):
+                        with Container(id="run-current-panel"):
+                            yield Static("", id="run-spotlight")
+                            with Horizontal(id="run-chip-row"):
+                                yield Static(
+                                    "", id="run-chip-workload", classes="status-chip"
+                                )
+                                yield Static(
+                                    "", id="run-chip-ordering", classes="status-chip"
+                                )
+                                yield Static(
+                                    "", id="run-chip-phase", classes="status-chip"
+                                )
+                            with Horizontal(id="run-phase-meta"):
+                                yield Static(
+                                    "",
+                                    id="phase-progress-badge",
+                                    classes="status-badge",
+                                )
+                                yield Static(
+                                    "",
+                                    id="current-run-elapsed",
+                                    classes="status-badge",
+                                )
+                            yield ProgressBar(
+                                total=None,
+                                show_percentage=False,
+                                show_eta=True,
+                                id="phase-progress",
+                            )
+                            with Horizontal(id="run-overall-meta"):
+                                yield Static(
+                                    "", id="progress-badge", classes="status-badge"
+                                )
+                                yield Static(
+                                    "", id="run-elapsed", classes="status-badge"
+                                )
+                            yield ProgressBar(
+                                total=max(self._total_runs, 1),
+                                show_percentage=False,
+                                show_eta=True,
+                                id="run-progress",
+                            )
+                            yield Static("", id="run-terminal-reason")
+                        yield DataTable(id="run-summary")
                 yield Static("", id="run-output-path")
                 with Horizontal(id="run-log-header"):
                     yield Static("실행 로그", id="run-log-title")
-                    yield LoadingIndicator(id="run-loading")
-                yield DataTable(id="run-summary")
                 yield Log(id="run-log")
             with Container(id="run-actions"):
                 yield Button(
@@ -145,8 +157,12 @@ class RunScreen(Screen[None]):
         self._configure_run_summary_table()
         self._set_terminal_actions(show_report=False)
         self._render_snapshot(BenchmarkProgressSnapshot(total_runs=self._total_runs))
-        self._set_loading(True)
+        self._set_running(True)
         self._elapsed_timer = self.set_interval(0.5, self._refresh_elapsed)
+        self._spinner_timer = self.set_interval(
+            self._spinner_interval_seconds,
+            self._advance_running_spinner,
+        )
         app_module = import_module("benchmarks.tui.app")
         controller_cls = getattr(
             app_module,
@@ -206,6 +222,8 @@ class RunScreen(Screen[None]):
         self._closed = True
         if self._elapsed_timer is not None:
             self._elapsed_timer.stop()
+        if self._spinner_timer is not None:
+            self._spinner_timer.stop()
 
     def _append_log(self, line: str, is_error: bool) -> None:
         """Handle append log within run."""
@@ -285,7 +303,7 @@ class RunScreen(Screen[None]):
         if self._closed:
             return
         self._finished_at = monotonic()
-        self._set_loading(False)
+        self._set_running(False)
 
         if self._cancelled:
             self.query_one("#run-status", Static).update("벤치마크가 취소되었습니다")
@@ -453,7 +471,10 @@ class RunScreen(Screen[None]):
                             self._terminal_style(self._terminal_cells[phase_key]),
                         )
                     elif is_active_row and phase == active_phase:
-                        value = self._status_text("RUNNING", _RUNNING_STYLE)
+                        value = self._status_text(
+                            "%s RUNNING" % self._current_spinner_frame(),
+                            _RUNNING_STYLE,
+                        )
                     elif row.get(phase, "--") != "--":
                         value = self._status_text(
                             "%s TPS" % row[phase],
@@ -523,9 +544,22 @@ class RunScreen(Screen[None]):
                 return phase
         return None
 
-    def _set_loading(self, is_running: bool) -> None:
-        """Install or update loading for run."""
-        self.query_one("#run-loading", LoadingIndicator).display = is_running
+    def _set_running(self, is_running: bool) -> None:
+        """Track whether the run spinner should animate."""
+        self._is_running = is_running
+
+    def _advance_running_spinner(self) -> None:
+        """Advance the compact running spinner in the active summary cell."""
+        if self._closed or not self._is_running:
+            return
+        self._spinner_frame_index = (self._spinner_frame_index + 1) % len(
+            _SPINNER_FRAMES
+        )
+        self._update_run_summary_table(self._last_snapshot)
+
+    def _current_spinner_frame(self) -> str:
+        """Return the active spinner frame."""
+        return _SPINNER_FRAMES[self._spinner_frame_index]
 
     def _force_completion_progress(self) -> None:
         """Force completion progress in run."""
@@ -674,6 +708,7 @@ class RunScreen(Screen[None]):
         if identity != self._current_run_identity:
             self._current_run_identity = identity
             self._current_run_started_at = monotonic()
+            self._spinner_frame_index = 0
 
     @staticmethod
     def _status_text(content: str, style: str) -> Text:

--- a/benchmarks/tui/screens/run.py
+++ b/benchmarks/tui/screens/run.py
@@ -555,7 +555,24 @@ class RunScreen(Screen[None]):
         self._spinner_frame_index = (self._spinner_frame_index + 1) % len(
             _SPINNER_FRAMES
         )
-        self._update_run_summary_table(self._last_snapshot)
+        self._update_active_spinner_cell()
+
+    def _update_active_spinner_cell(self) -> None:
+        """Update only the active running summary cell."""
+        active_row_key = self._active_row_key(self._last_snapshot)
+        active_phase = self._current_phase(self._last_snapshot)
+        if active_row_key is None or active_phase is None:
+            return
+        table = self.query_one("#run-summary", DataTable)
+        table.update_cell(
+            active_row_key,
+            active_phase,
+            self._status_text(
+                "%s RUNNING" % self._current_spinner_frame(),
+                _RUNNING_STYLE,
+            ),
+            update_width=False,
+        )
 
     def _current_spinner_frame(self) -> str:
         """Return the active spinner frame."""

--- a/benchmarks/tui/screens/run.py
+++ b/benchmarks/tui/screens/run.py
@@ -426,31 +426,55 @@ class RunScreen(Screen[None]):
         """Handle configure run summary table within run."""
         table = self.query_one("#run-summary", DataTable)
         table.cursor_type = "none"
-        table.add_column("Workload", key="workload")
+        table.add_column("Engine", key="engine")
         table.add_column("Ordering", key="ordering")
-        for phase in self._active_phases:
-            table.add_column(phase.title(), key=phase)
         for workload in self._active_workloads:
+            table.add_column(workload, key=workload)
+        for phase in self._active_phases:
             for ordering in self._active_orderings:
-                row_values = [workload, ordering]
-                row_values.extend("WAITING" for _ in self._active_phases)
-                table.add_row(*row_values, key=self._row_key(workload, ordering))
+                row_values = [phase.title(), ordering]
+                row_values.extend("WAITING" for _workload in self._active_workloads)
+                table.add_row(
+                    *row_values,
+                    key=self._summary_row_key(phase, ordering),
+                )
+
+    def _summary_row_key(self, phase: str, ordering: str) -> str:
+        """Return the summary row key for an engine/ordering pair."""
+        return "%s-%s" % (phase, ordering)
+
+    def _is_active_summary_row(
+        self,
+        *,
+        phase: str,
+        ordering: str,
+        active_phase: str | None,
+        active_ordering: str | None,
+    ) -> bool:
+        """Return whether the engine/ordering row is currently active."""
+        return phase == active_phase and ordering == active_ordering
 
     def _update_run_summary_table(self, snapshot: BenchmarkProgressSnapshot) -> None:
         """Update run summary table for run."""
         table = self.query_one("#run-summary", DataTable)
-        active_row_key = self._active_row_key(snapshot)
         active_phase = self._current_phase(snapshot)
+        active_workload = snapshot.current_workload
+        active_ordering = snapshot.current_ordering
         baseline_averages = self._baseline_averages_by_workload(snapshot)
 
-        for workload in self._active_workloads:
+        for phase in self._active_phases:
             for ordering in self._active_orderings:
-                row_key = self._row_key(workload, ordering)
-                is_active_row = row_key == active_row_key
+                row_key = self._summary_row_key(phase, ordering)
+                is_active_row = self._is_active_summary_row(
+                    phase=phase,
+                    ordering=ordering,
+                    active_phase=active_phase,
+                    active_ordering=active_ordering,
+                )
                 table.update_cell(
                     row_key,
-                    "workload",
-                    self._identity_cell_text(workload, is_active_row),
+                    "engine",
+                    self._identity_cell_text(phase.title(), is_active_row),
                     update_width=True,
                 )
                 table.update_cell(
@@ -460,17 +484,24 @@ class RunScreen(Screen[None]):
                     update_width=True,
                 )
 
+        for workload in self._active_workloads:
+            for ordering in self._active_orderings:
                 row = snapshot.tps_by_workload_ordering.get(workload, {}).get(
                     ordering, {}
                 )
                 for phase in self._active_phases:
-                    phase_key = (row_key, phase)
+                    row_key = self._summary_row_key(phase, ordering)
+                    phase_key = (row_key, workload)
                     if phase_key in self._terminal_cells:
                         value = self._status_text(
                             self._terminal_cells[phase_key],
                             self._terminal_style(self._terminal_cells[phase_key]),
                         )
-                    elif is_active_row and phase == active_phase:
+                    elif (
+                        workload == active_workload
+                        and ordering == active_ordering
+                        and phase == active_phase
+                    ):
                         value = self._status_text(
                             "%s RUNNING" % self._current_spinner_frame(),
                             _RUNNING_STYLE,
@@ -487,7 +518,7 @@ class RunScreen(Screen[None]):
                         )
                     else:
                         value = self._status_text("WAITING", _WAITING_STYLE)
-                    table.update_cell(row_key, phase, value, update_width=True)
+                    table.update_cell(row_key, workload, value, update_width=True)
 
     def _baseline_averages_by_workload(
         self, snapshot: BenchmarkProgressSnapshot
@@ -534,7 +565,9 @@ class RunScreen(Screen[None]):
             ordering = self._active_orderings[0]
         if workload is None or ordering is None or phase is None:
             return
-        self._terminal_cells[(self._row_key(workload, ordering), phase)] = status
+        self._terminal_cells[
+            (self._summary_row_key(phase, ordering), workload)
+        ] = status
         self._update_run_summary_table(self._last_snapshot)
 
     def _last_running_phase(self) -> str | None:

--- a/benchmarks/tui/screens/run.py
+++ b/benchmarks/tui/screens/run.py
@@ -426,55 +426,31 @@ class RunScreen(Screen[None]):
         """Handle configure run summary table within run."""
         table = self.query_one("#run-summary", DataTable)
         table.cursor_type = "none"
-        table.add_column("Engine", key="engine")
+        table.add_column("Workload", key="workload")
         table.add_column("Ordering", key="ordering")
-        for workload in self._active_workloads:
-            table.add_column(workload, key=workload)
         for phase in self._active_phases:
+            table.add_column(phase.title(), key=phase)
+        for workload in self._active_workloads:
             for ordering in self._active_orderings:
-                row_values = [phase.title(), ordering]
-                row_values.extend("WAITING" for _workload in self._active_workloads)
-                table.add_row(
-                    *row_values,
-                    key=self._summary_row_key(phase, ordering),
-                )
-
-    def _summary_row_key(self, phase: str, ordering: str) -> str:
-        """Return the summary row key for an engine/ordering pair."""
-        return "%s-%s" % (phase, ordering)
-
-    def _is_active_summary_row(
-        self,
-        *,
-        phase: str,
-        ordering: str,
-        active_phase: str | None,
-        active_ordering: str | None,
-    ) -> bool:
-        """Return whether the engine/ordering row is currently active."""
-        return phase == active_phase and ordering == active_ordering
+                row_values = [workload, ordering]
+                row_values.extend("WAITING" for _ in self._active_phases)
+                table.add_row(*row_values, key=self._row_key(workload, ordering))
 
     def _update_run_summary_table(self, snapshot: BenchmarkProgressSnapshot) -> None:
         """Update run summary table for run."""
         table = self.query_one("#run-summary", DataTable)
+        active_row_key = self._active_row_key(snapshot)
         active_phase = self._current_phase(snapshot)
-        active_workload = snapshot.current_workload
-        active_ordering = snapshot.current_ordering
         baseline_averages = self._baseline_averages_by_workload(snapshot)
 
-        for phase in self._active_phases:
+        for workload in self._active_workloads:
             for ordering in self._active_orderings:
-                row_key = self._summary_row_key(phase, ordering)
-                is_active_row = self._is_active_summary_row(
-                    phase=phase,
-                    ordering=ordering,
-                    active_phase=active_phase,
-                    active_ordering=active_ordering,
-                )
+                row_key = self._row_key(workload, ordering)
+                is_active_row = row_key == active_row_key
                 table.update_cell(
                     row_key,
-                    "engine",
-                    self._identity_cell_text(phase.title(), is_active_row),
+                    "workload",
+                    self._identity_cell_text(workload, is_active_row),
                     update_width=True,
                 )
                 table.update_cell(
@@ -484,24 +460,17 @@ class RunScreen(Screen[None]):
                     update_width=True,
                 )
 
-        for workload in self._active_workloads:
-            for ordering in self._active_orderings:
                 row = snapshot.tps_by_workload_ordering.get(workload, {}).get(
                     ordering, {}
                 )
                 for phase in self._active_phases:
-                    row_key = self._summary_row_key(phase, ordering)
-                    phase_key = (row_key, workload)
+                    phase_key = (row_key, phase)
                     if phase_key in self._terminal_cells:
                         value = self._status_text(
                             self._terminal_cells[phase_key],
                             self._terminal_style(self._terminal_cells[phase_key]),
                         )
-                    elif (
-                        workload == active_workload
-                        and ordering == active_ordering
-                        and phase == active_phase
-                    ):
+                    elif is_active_row and phase == active_phase:
                         value = self._status_text(
                             "%s RUNNING" % self._current_spinner_frame(),
                             _RUNNING_STYLE,
@@ -518,7 +487,7 @@ class RunScreen(Screen[None]):
                         )
                     else:
                         value = self._status_text("WAITING", _WAITING_STYLE)
-                    table.update_cell(row_key, workload, value, update_width=True)
+                    table.update_cell(row_key, phase, value, update_width=True)
 
     def _baseline_averages_by_workload(
         self, snapshot: BenchmarkProgressSnapshot
@@ -565,9 +534,7 @@ class RunScreen(Screen[None]):
             ordering = self._active_orderings[0]
         if workload is None or ordering is None or phase is None:
             return
-        self._terminal_cells[
-            (self._summary_row_key(phase, ordering), workload)
-        ] = status
+        self._terminal_cells[(self._row_key(workload, ordering), phase)] = status
         self._update_run_summary_table(self._last_snapshot)
 
     def _last_running_phase(self) -> str | None:

--- a/tests/unit/benchmarks/test_benchmark_runtime.py
+++ b/tests/unit/benchmarks/test_benchmark_runtime.py
@@ -571,7 +571,17 @@ def test_build_artifact_metadata_prefers_github_environment() -> None:
             "tomorrow9913/Pyrallel-Consumer/.github/workflows/benchmarks.yml"
             "@refs/heads/develop"
         ),
+        "runner_interface": "cli",
     }
+
+
+def test_build_artifact_metadata_records_tui_runner_interface() -> None:
+    metadata = run_parallel_benchmark._build_artifact_metadata(
+        output_path="benchmarks/results/tui.json",
+        environ={"PYRALLEL_BENCHMARK_RUNNER_INTERFACE": "tui"},
+    )
+
+    assert metadata["runner_interface"] == "tui"
 
 
 def test_run_benchmark_writes_artifact_metadata(

--- a/tests/unit/benchmarks/test_tui_app.py
+++ b/tests/unit/benchmarks/test_tui_app.py
@@ -1001,22 +1001,15 @@ async def test_run_screen_mounts_dashboard_widgets(monkeypatch) -> None:
         assert "run-spotlight-card" in _ancestor_ids(summary_table)
         assert not list(app.screen.query("#run-loading"))
         assert exit_button.display is False
-        assert summary_table.get_row("sleep-key_hash") == [
-            "sleep",
+        assert summary_table.get_row("baseline-key_hash") == [
+            "Baseline",
             "key_hash",
             Text("WAITING", style="grey62"),
             Text("WAITING", style="grey62"),
             Text("WAITING", style="grey62"),
         ]
-        assert summary_table.get_row("cpu-partition") == [
-            "cpu",
-            "partition",
-            Text("WAITING", style="grey62"),
-            Text("WAITING", style="grey62"),
-            Text("WAITING", style="grey62"),
-        ]
-        assert summary_table.get_row("io-partition") == [
-            "io",
+        assert summary_table.get_row("async-partition") == [
+            "Async",
             "partition",
             Text("WAITING", style="grey62"),
             Text("WAITING", style="grey62"),
@@ -1095,11 +1088,15 @@ async def test_run_screen_updates_progress_bar_and_summary_table(monkeypatch) ->
         summary_table = run_screen.query_one("#run-summary", DataTable)
 
     assert progress_bar.progress == 2
-    row = summary_table.get_row("sleep-key_hash")
-    assert row[:2] == ["sleep", "key_hash"]
-    assert row[2] == Text("111.11 TPS", style="bold bright_green")
-    assert row[3] == Text("222.22 TPS", style="bold bright_green")
-    assert row[4] == Text("WAITING", style="grey62")
+    assert summary_table.get_cell("baseline-key_hash", "sleep") == Text(
+        "111.11 TPS", style="bold bright_green"
+    )
+    assert summary_table.get_cell("async-key_hash", "sleep") == Text(
+        "222.22 TPS", style="bold bright_green"
+    )
+    assert summary_table.get_cell("process-key_hash", "sleep") == Text(
+        "WAITING", style="grey62"
+    )
 
 
 @pytest.mark.asyncio
@@ -1150,22 +1147,22 @@ async def test_run_screen_marks_results_below_workload_baseline_average_yellow(
         summary_table = run_screen.query_one("#run-summary", DataTable)
 
     _assert_text_cell(
-        summary_table.get_cell("sleep-key_hash", "baseline"),
+        summary_table.get_cell("baseline-key_hash", "sleep"),
         "100.00 TPS",
         "bold bright_green",
     )
     _assert_text_cell(
-        summary_table.get_cell("sleep-key_hash", "async"),
+        summary_table.get_cell("async-key_hash", "sleep"),
         "149.99 TPS",
         "bold bright_yellow",
     )
     _assert_text_cell(
-        summary_table.get_cell("sleep-key_hash", "process"),
+        summary_table.get_cell("process-key_hash", "sleep"),
         "150.00 TPS",
         "bold bright_green",
     )
     _assert_text_cell(
-        summary_table.get_cell("sleep-partition", "async"),
+        summary_table.get_cell("async-partition", "sleep"),
         "151.00 TPS",
         "bold bright_green",
     )
@@ -1225,17 +1222,17 @@ async def test_run_screen_keeps_baseline_comparison_for_comma_formatted_tps(
         summary_table = _run_screen(app).query_one("#run-summary", DataTable)
 
     _assert_text_cell(
-        summary_table.get_cell("sleep-key_hash", "async"),
+        summary_table.get_cell("async-key_hash", "sleep"),
         "1,499.99 TPS",
         "bold bright_yellow",
     )
     _assert_text_cell(
-        summary_table.get_cell("sleep-key_hash", "process"),
+        summary_table.get_cell("process-key_hash", "sleep"),
         "1,500.00 TPS",
         "bold bright_green",
     )
     _assert_text_cell(
-        summary_table.get_cell("sleep-partition", "async"),
+        summary_table.get_cell("async-partition", "sleep"),
         "1,501.00 TPS",
         "bold bright_green",
     )
@@ -1317,7 +1314,7 @@ async def test_run_screen_formats_ordering_status_for_readability(monkeypatch) -
         ordering_chip = run_screen.query_one("#run-chip-ordering", Static)
         phase_chip = run_screen.query_one("#run-chip-phase", Static)
         summary_table = run_screen.query_one("#run-summary", DataTable)
-        active_cell = summary_table.get_cell("sleep-partition", "async")
+        active_cell = summary_table.get_cell("async-partition", "sleep")
 
     assert str(spotlight.content) == "현재 실행"
     assert str(workload_chip.content) == "workload: sleep"
@@ -1399,7 +1396,7 @@ async def test_run_screen_spotlight_uses_single_progress_semantics_and_selected_
         progress_bar = run_screen.query_one("#run-progress", ProgressBar)
         elapsed = run_screen.query_one("#run-elapsed", Static)
         summary_table = run_screen.query_one("#run-summary", DataTable)
-        active_cell = summary_table.get_cell("sleep-partition", "async")
+        active_cell = summary_table.get_cell("async-partition", "sleep")
 
     assert str(status.content) == "벤치마크 실행 중"
     assert str(spotlight.content) == "현재 실행"
@@ -1413,14 +1410,16 @@ async def test_run_screen_spotlight_uses_single_progress_semantics_and_selected_
     assert phase_progress_bar.total == 50000
     assert phase_progress_bar.progress == 1000
     assert progress_bar.progress == 1
-    row = summary_table.get_row("sleep-key_hash")
-    assert row[:2] == ["sleep", "key_hash"]
-    assert row[2] == Text("111.11 TPS", style="bold bright_green")
-    assert row[3] == Text("WAITING", style="grey62")
+    assert summary_table.get_cell("baseline-key_hash", "sleep") == Text(
+        "111.11 TPS", style="bold bright_green"
+    )
+    assert summary_table.get_cell("async-key_hash", "sleep") == Text(
+        "WAITING", style="grey62"
+    )
     assert isinstance(active_cell, Text)
     assert "RUNNING" in active_cell.plain
 
-    assert summary_table.row_count == 2
+    assert summary_table.row_count == 4
 
 
 @pytest.mark.asyncio
@@ -1518,7 +1517,7 @@ async def test_run_screen_formats_status_and_tps_cells_for_readability(
         progress_badge = run_screen.query_one("#progress-badge", Static)
         elapsed = run_screen.query_one("#run-elapsed", Static)
         summary_table = run_screen.query_one("#run-summary", DataTable)
-        active_cell = summary_table.get_cell("sleep-key_hash", "async")
+        active_cell = summary_table.get_cell("async-key_hash", "sleep")
 
     assert str(status.content) == "벤치마크 실행 중"
     assert str(spotlight.content) == "현재 실행"
@@ -1533,12 +1532,15 @@ async def test_run_screen_formats_status_and_tps_cells_for_readability(
     assert phase_progress_bar.progress == 10
     assert isinstance(active_cell, Text)
     assert active_cell.plain.endswith(" RUNNING")
-    active_row = summary_table.get_row("sleep-key_hash")
-    assert isinstance(active_row[0], Text)
-    assert isinstance(active_row[1], Text)
-    assert active_row[2] == Text("111.11 TPS", style="bold bright_green")
-    assert active_row[3] == active_cell
-    assert active_row[4] == Text("WAITING", style="grey62")
+    baseline_row = summary_table.get_row("baseline-key_hash")
+    async_row = summary_table.get_row("async-key_hash")
+    process_row = summary_table.get_row("process-key_hash")
+    assert baseline_row[:2] == ["Baseline", "key_hash"]
+    assert async_row[0] == Text("▶ Async", style="bold bright_cyan")
+    assert async_row[1] == Text("▶ key_hash", style="bold bright_cyan")
+    assert baseline_row[2] == Text("111.11 TPS", style="bold bright_green")
+    assert async_row[2] == active_cell
+    assert process_row[2] == Text("WAITING", style="grey62")
 
 
 @pytest.mark.asyncio
@@ -1594,7 +1596,7 @@ async def test_run_screen_marks_failed_cell_in_soft_red(monkeypatch) -> None:
         await pilot.pause()
 
         failed_cell = run_screen.query_one("#run-summary", DataTable).get_cell(
-            "sleep-key_hash", "async"
+            "async-key_hash", "sleep"
         )
         status = run_screen.query_one("#run-status", Static)
         reason = run_screen.query_one("#run-terminal-reason", Static)
@@ -1642,11 +1644,11 @@ async def test_run_screen_animates_running_summary_cell_without_loading_widget(
             )
         )
         first_cell = run_screen.query_one("#run-summary", DataTable).get_cell(
-            "sleep-partition", "async"
+            "async-partition", "sleep"
         )
         run_screen._advance_running_spinner()
         second_cell = run_screen.query_one("#run-summary", DataTable).get_cell(
-            "sleep-partition", "async"
+            "async-partition", "sleep"
         )
 
     assert run_screen._spinner_interval_seconds < 0.2

--- a/tests/unit/benchmarks/test_tui_app.py
+++ b/tests/unit/benchmarks/test_tui_app.py
@@ -15,7 +15,6 @@ from textual.widgets import (
     DataTable,
     Input,
     Label,
-    LoadingIndicator,
     ProgressBar,
     SelectionList,
     Static,
@@ -980,7 +979,6 @@ async def test_run_screen_mounts_dashboard_widgets(monkeypatch) -> None:
         elapsed = app.screen.query_one("#run-elapsed", Static)
         phase_progress_bar = app.screen.query_one("#phase-progress", ProgressBar)
         progress_bar = app.screen.query_one("#run-progress", ProgressBar)
-        loading_indicator = app.screen.query_one("#run-loading", LoadingIndicator)
         exit_button = app.screen.query_one("#exit-button", Button)
         summary_table = app.screen.query_one("#run-summary", DataTable)
         assert str(spotlight.content) == "현재 실행"
@@ -999,9 +997,9 @@ async def test_run_screen_mounts_dashboard_widgets(monkeypatch) -> None:
         assert phase_progress_bar.show_eta is True
         assert progress_bar.total == 18
         assert progress_bar.show_eta is True
-        assert loading_indicator.display is True
         assert "run-spotlight-card" in _ancestor_ids(progress_bar)
-        assert "run-log-header" in _ancestor_ids(loading_indicator)
+        assert "run-spotlight-card" in _ancestor_ids(summary_table)
+        assert not list(app.screen.query("#run-loading"))
         assert exit_button.display is False
         assert summary_table.get_row("sleep-key_hash") == [
             "sleep",
@@ -1329,7 +1327,7 @@ async def test_run_screen_formats_ordering_status_for_readability(monkeypatch) -
     assert ordering_chip.has_class("is-running")
     assert phase_chip.has_class("is-running")
     assert isinstance(active_cell, Text)
-    assert active_cell.plain == "RUNNING"
+    assert active_cell.plain.endswith(" RUNNING")
 
 
 @pytest.mark.asyncio
@@ -1534,7 +1532,7 @@ async def test_run_screen_formats_status_and_tps_cells_for_readability(
     assert phase_progress_bar.total == 100
     assert phase_progress_bar.progress == 10
     assert isinstance(active_cell, Text)
-    assert active_cell.plain == "RUNNING"
+    assert active_cell.plain.endswith(" RUNNING")
     active_row = summary_table.get_row("sleep-key_hash")
     assert isinstance(active_row[0], Text)
     assert isinstance(active_row[1], Text)
@@ -1598,16 +1596,65 @@ async def test_run_screen_marks_failed_cell_in_soft_red(monkeypatch) -> None:
         failed_cell = run_screen.query_one("#run-summary", DataTable).get_cell(
             "sleep-key_hash", "async"
         )
-        loading_indicator = run_screen.query_one("#run-loading", LoadingIndicator)
         status = run_screen.query_one("#run-status", Static)
         reason = run_screen.query_one("#run-terminal-reason", Static)
 
     assert isinstance(failed_cell, Text)
     assert failed_cell.plain == "FAILED"
     assert "red" in str(failed_cell.style)
-    assert loading_indicator.display is False
+    assert not list(run_screen.query("#run-loading"))
     assert str(status.content) == "벤치마크가 실패했습니다"
     assert reason.has_class("is-failed")
+
+
+@pytest.mark.asyncio
+async def test_run_screen_animates_running_summary_cell_without_loading_widget(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "benchmarks.tui.app.BenchmarkProcessController", _FakeController
+    )
+    _FakeController.instances.clear()
+
+    app = BenchmarkTuiApp()
+
+    async with app.run_test() as pilot:
+        app.push_screen(
+            RunScreen(
+                BenchmarkTuiState(
+                    workloads=("sleep",),
+                    ordering_modes=("partition",),
+                    skip_baseline=True,
+                    skip_process=True,
+                )
+            )
+        )
+        await pilot.pause()
+
+        run_screen = _run_screen(app)
+        run_screen._render_snapshot(
+            BenchmarkProgressSnapshot(
+                completed_runs=0,
+                current_workload="sleep",
+                current_ordering="partition",
+                phase_statuses={"async": "running"},
+                total_runs=1,
+            )
+        )
+        first_cell = run_screen.query_one("#run-summary", DataTable).get_cell(
+            "sleep-partition", "async"
+        )
+        run_screen._advance_running_spinner()
+        second_cell = run_screen.query_one("#run-summary", DataTable).get_cell(
+            "sleep-partition", "async"
+        )
+
+    assert run_screen._spinner_interval_seconds < 0.2
+    assert isinstance(first_cell, Text)
+    assert isinstance(second_cell, Text)
+    assert first_cell.plain == "⠋ RUNNING"
+    assert second_cell.plain == "⠙ RUNNING"
+    assert not list(run_screen.query("#run-loading"))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/benchmarks/test_tui_app.py
+++ b/tests/unit/benchmarks/test_tui_app.py
@@ -6,7 +6,7 @@ import signal
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from rich.text import Text
@@ -1655,6 +1655,60 @@ async def test_run_screen_animates_running_summary_cell_without_loading_widget(
     assert first_cell.plain == "⠋ RUNNING"
     assert second_cell.plain == "⠙ RUNNING"
     assert not list(run_screen.query("#run-loading"))
+
+
+@pytest.mark.asyncio
+async def test_run_screen_spinner_refresh_updates_only_active_summary_cell(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "benchmarks.tui.app.BenchmarkProcessController", _FakeController
+    )
+    _FakeController.instances.clear()
+
+    app = BenchmarkTuiApp()
+
+    async with app.run_test() as pilot:
+        app.push_screen(
+            RunScreen(
+                BenchmarkTuiState(
+                    workloads=("sleep", "cpu", "io"),
+                    ordering_modes=("key_hash", "partition"),
+                )
+            )
+        )
+        await pilot.pause()
+
+        run_screen = _run_screen(app)
+        run_screen._render_snapshot(
+            BenchmarkProgressSnapshot(
+                completed_runs=1,
+                current_workload="cpu",
+                current_ordering="partition",
+                phase_statuses={"async": "running"},
+                total_runs=18,
+            )
+        )
+        table = run_screen.query_one("#run-summary", DataTable)
+        calls: list[tuple[object, object, object, object]] = []
+        original_update_cell = table.update_cell
+
+        def _record_update_cell(*args: Any, **kwargs: Any) -> object:
+            if len(args) != 3:
+                raise AssertionError("Expected row key, column key, and value")
+            calls.append((args[0], args[1], args[2], kwargs.get("update_width")))
+            return original_update_cell(*args, **kwargs)
+
+        monkeypatch.setattr(table, "update_cell", _record_update_cell)
+        run_screen._advance_running_spinner()
+
+    assert len(calls) == 1
+    row_key, column_key, value, update_width = calls[0]
+    assert row_key == "cpu-partition"
+    assert column_key == "async"
+    assert isinstance(value, Text)
+    assert value.plain == "⠙ RUNNING"
+    assert update_width is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/benchmarks/test_tui_app.py
+++ b/tests/unit/benchmarks/test_tui_app.py
@@ -1001,15 +1001,22 @@ async def test_run_screen_mounts_dashboard_widgets(monkeypatch) -> None:
         assert "run-spotlight-card" in _ancestor_ids(summary_table)
         assert not list(app.screen.query("#run-loading"))
         assert exit_button.display is False
-        assert summary_table.get_row("baseline-key_hash") == [
-            "Baseline",
+        assert summary_table.get_row("sleep-key_hash") == [
+            "sleep",
             "key_hash",
             Text("WAITING", style="grey62"),
             Text("WAITING", style="grey62"),
             Text("WAITING", style="grey62"),
         ]
-        assert summary_table.get_row("async-partition") == [
-            "Async",
+        assert summary_table.get_row("cpu-partition") == [
+            "cpu",
+            "partition",
+            Text("WAITING", style="grey62"),
+            Text("WAITING", style="grey62"),
+            Text("WAITING", style="grey62"),
+        ]
+        assert summary_table.get_row("io-partition") == [
+            "io",
             "partition",
             Text("WAITING", style="grey62"),
             Text("WAITING", style="grey62"),
@@ -1088,15 +1095,11 @@ async def test_run_screen_updates_progress_bar_and_summary_table(monkeypatch) ->
         summary_table = run_screen.query_one("#run-summary", DataTable)
 
     assert progress_bar.progress == 2
-    assert summary_table.get_cell("baseline-key_hash", "sleep") == Text(
-        "111.11 TPS", style="bold bright_green"
-    )
-    assert summary_table.get_cell("async-key_hash", "sleep") == Text(
-        "222.22 TPS", style="bold bright_green"
-    )
-    assert summary_table.get_cell("process-key_hash", "sleep") == Text(
-        "WAITING", style="grey62"
-    )
+    row = summary_table.get_row("sleep-key_hash")
+    assert row[:2] == ["sleep", "key_hash"]
+    assert row[2] == Text("111.11 TPS", style="bold bright_green")
+    assert row[3] == Text("222.22 TPS", style="bold bright_green")
+    assert row[4] == Text("WAITING", style="grey62")
 
 
 @pytest.mark.asyncio
@@ -1147,22 +1150,22 @@ async def test_run_screen_marks_results_below_workload_baseline_average_yellow(
         summary_table = run_screen.query_one("#run-summary", DataTable)
 
     _assert_text_cell(
-        summary_table.get_cell("baseline-key_hash", "sleep"),
+        summary_table.get_cell("sleep-key_hash", "baseline"),
         "100.00 TPS",
         "bold bright_green",
     )
     _assert_text_cell(
-        summary_table.get_cell("async-key_hash", "sleep"),
+        summary_table.get_cell("sleep-key_hash", "async"),
         "149.99 TPS",
         "bold bright_yellow",
     )
     _assert_text_cell(
-        summary_table.get_cell("process-key_hash", "sleep"),
+        summary_table.get_cell("sleep-key_hash", "process"),
         "150.00 TPS",
         "bold bright_green",
     )
     _assert_text_cell(
-        summary_table.get_cell("async-partition", "sleep"),
+        summary_table.get_cell("sleep-partition", "async"),
         "151.00 TPS",
         "bold bright_green",
     )
@@ -1222,17 +1225,17 @@ async def test_run_screen_keeps_baseline_comparison_for_comma_formatted_tps(
         summary_table = _run_screen(app).query_one("#run-summary", DataTable)
 
     _assert_text_cell(
-        summary_table.get_cell("async-key_hash", "sleep"),
+        summary_table.get_cell("sleep-key_hash", "async"),
         "1,499.99 TPS",
         "bold bright_yellow",
     )
     _assert_text_cell(
-        summary_table.get_cell("process-key_hash", "sleep"),
+        summary_table.get_cell("sleep-key_hash", "process"),
         "1,500.00 TPS",
         "bold bright_green",
     )
     _assert_text_cell(
-        summary_table.get_cell("async-partition", "sleep"),
+        summary_table.get_cell("sleep-partition", "async"),
         "1,501.00 TPS",
         "bold bright_green",
     )
@@ -1314,7 +1317,7 @@ async def test_run_screen_formats_ordering_status_for_readability(monkeypatch) -
         ordering_chip = run_screen.query_one("#run-chip-ordering", Static)
         phase_chip = run_screen.query_one("#run-chip-phase", Static)
         summary_table = run_screen.query_one("#run-summary", DataTable)
-        active_cell = summary_table.get_cell("async-partition", "sleep")
+        active_cell = summary_table.get_cell("sleep-partition", "async")
 
     assert str(spotlight.content) == "현재 실행"
     assert str(workload_chip.content) == "workload: sleep"
@@ -1396,7 +1399,7 @@ async def test_run_screen_spotlight_uses_single_progress_semantics_and_selected_
         progress_bar = run_screen.query_one("#run-progress", ProgressBar)
         elapsed = run_screen.query_one("#run-elapsed", Static)
         summary_table = run_screen.query_one("#run-summary", DataTable)
-        active_cell = summary_table.get_cell("async-partition", "sleep")
+        active_cell = summary_table.get_cell("sleep-partition", "async")
 
     assert str(status.content) == "벤치마크 실행 중"
     assert str(spotlight.content) == "현재 실행"
@@ -1410,16 +1413,14 @@ async def test_run_screen_spotlight_uses_single_progress_semantics_and_selected_
     assert phase_progress_bar.total == 50000
     assert phase_progress_bar.progress == 1000
     assert progress_bar.progress == 1
-    assert summary_table.get_cell("baseline-key_hash", "sleep") == Text(
-        "111.11 TPS", style="bold bright_green"
-    )
-    assert summary_table.get_cell("async-key_hash", "sleep") == Text(
-        "WAITING", style="grey62"
-    )
+    row = summary_table.get_row("sleep-key_hash")
+    assert row[:2] == ["sleep", "key_hash"]
+    assert row[2] == Text("111.11 TPS", style="bold bright_green")
+    assert row[3] == Text("WAITING", style="grey62")
     assert isinstance(active_cell, Text)
     assert "RUNNING" in active_cell.plain
 
-    assert summary_table.row_count == 4
+    assert summary_table.row_count == 2
 
 
 @pytest.mark.asyncio
@@ -1517,7 +1518,7 @@ async def test_run_screen_formats_status_and_tps_cells_for_readability(
         progress_badge = run_screen.query_one("#progress-badge", Static)
         elapsed = run_screen.query_one("#run-elapsed", Static)
         summary_table = run_screen.query_one("#run-summary", DataTable)
-        active_cell = summary_table.get_cell("async-key_hash", "sleep")
+        active_cell = summary_table.get_cell("sleep-key_hash", "async")
 
     assert str(status.content) == "벤치마크 실행 중"
     assert str(spotlight.content) == "현재 실행"
@@ -1532,15 +1533,12 @@ async def test_run_screen_formats_status_and_tps_cells_for_readability(
     assert phase_progress_bar.progress == 10
     assert isinstance(active_cell, Text)
     assert active_cell.plain.endswith(" RUNNING")
-    baseline_row = summary_table.get_row("baseline-key_hash")
-    async_row = summary_table.get_row("async-key_hash")
-    process_row = summary_table.get_row("process-key_hash")
-    assert baseline_row[:2] == ["Baseline", "key_hash"]
-    assert async_row[0] == Text("▶ Async", style="bold bright_cyan")
-    assert async_row[1] == Text("▶ key_hash", style="bold bright_cyan")
-    assert baseline_row[2] == Text("111.11 TPS", style="bold bright_green")
-    assert async_row[2] == active_cell
-    assert process_row[2] == Text("WAITING", style="grey62")
+    active_row = summary_table.get_row("sleep-key_hash")
+    assert isinstance(active_row[0], Text)
+    assert isinstance(active_row[1], Text)
+    assert active_row[2] == Text("111.11 TPS", style="bold bright_green")
+    assert active_row[3] == active_cell
+    assert active_row[4] == Text("WAITING", style="grey62")
 
 
 @pytest.mark.asyncio
@@ -1596,7 +1594,7 @@ async def test_run_screen_marks_failed_cell_in_soft_red(monkeypatch) -> None:
         await pilot.pause()
 
         failed_cell = run_screen.query_one("#run-summary", DataTable).get_cell(
-            "async-key_hash", "sleep"
+            "sleep-key_hash", "async"
         )
         status = run_screen.query_one("#run-status", Static)
         reason = run_screen.query_one("#run-terminal-reason", Static)
@@ -1644,11 +1642,11 @@ async def test_run_screen_animates_running_summary_cell_without_loading_widget(
             )
         )
         first_cell = run_screen.query_one("#run-summary", DataTable).get_cell(
-            "async-partition", "sleep"
+            "sleep-partition", "async"
         )
         run_screen._advance_running_spinner()
         second_cell = run_screen.query_one("#run-summary", DataTable).get_cell(
-            "async-partition", "sleep"
+            "sleep-partition", "async"
         )
 
     assert run_screen._spinner_interval_seconds < 0.2

--- a/tests/unit/benchmarks/test_tui_controller.py
+++ b/tests/unit/benchmarks/test_tui_controller.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+
+import pytest
+
 from benchmarks.tui.controller import BenchmarkProcessController
 from benchmarks.tui.state import BenchmarkTuiState
 
@@ -74,3 +78,47 @@ def test_controller_empty_workload_fallback_uses_registry_default(monkeypatch) -
     )
 
     assert controller._parser._active_workloads == ("custom",)
+
+
+@pytest.mark.asyncio
+async def test_controller_marks_child_cli_process_as_tui_runner(monkeypatch) -> None:
+    import benchmarks.tui.controller as controller_module
+
+    captured: dict[str, object] = {}
+
+    class _Process:
+        def __init__(self) -> None:
+            self.stdout = asyncio.StreamReader()
+            self.stderr = asyncio.StreamReader()
+            self.returncode = 0
+            self.stdout.feed_eof()
+            self.stderr.feed_eof()
+
+        async def wait(self) -> int:
+            return 0
+
+    async def _create_subprocess_exec(*argv: str, **kwargs: object) -> _Process:
+        captured["argv"] = argv
+        captured["env"] = kwargs["env"]
+        return _Process()
+
+    monkeypatch.setattr(
+        controller_module.asyncio,
+        "create_subprocess_exec",
+        _create_subprocess_exec,
+    )
+
+    completed: list[int] = []
+    controller = BenchmarkProcessController(
+        state=BenchmarkTuiState(workloads=("sleep",)),
+        on_output=lambda _line, _is_error: None,
+        on_progress=lambda _snapshot: None,
+        on_complete=completed.append,
+    )
+
+    await controller.run()
+
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["PYRALLEL_BENCHMARK_RUNNER_INTERFACE"] == "tui"
+    assert completed == [0]


### PR DESCRIPTION
## Summary

- Remove the standalone benchmark run `LoadingIndicator`.
- Move the run summary table into the current-run card beside the status panel.
- Render a compact one-character spinner in the active summary cell, e.g. `⠋ RUNNING`.
- Give the freed vertical space to the run log.

## Notes

- I tried the `Engine × Ordering` row / workload column pivot, but reverted it because it made the summary harder to scan. The final diff keeps the original workload/order rows and engine columns.

## Verification

- `uv run pytest tests/unit/benchmarks/test_tui_app.py -q` → `55 passed`
