### PR TITLE
fix(tui): reorder benchmark option selectors

### DIFF
--- a/benchmarks/tui/screens/options.py
+++ b/benchmarks/tui/screens/options.py
@@ -365,11 +365,6 @@ class OptionsScreen(Screen[None]):
                         "Configure the Kafka target and choose the workload shape to run."
                     )
                     yield from self._labeled_selection_list(
-                        option_id="workloads",
-                        selections=self._workload_selections(state),
-                        widget_id="workloads",
-                    )
-                    yield from self._labeled_selection_list(
                         option_id="ordering-modes",
                         selections=[
                             (
@@ -399,6 +394,11 @@ class OptionsScreen(Screen[None]):
                         "",
                         id=self._error_id("skip-phase-group"),
                         classes="field-error",
+                    )
+                    yield from self._labeled_selection_list(
+                        option_id="workloads",
+                        selections=self._workload_selections(state),
+                        widget_id="workloads",
                     )
                     yield from self._workload_option_controls(state)
                     yield from self._labeled_input(

--- a/tests/unit/benchmarks/test_tui_app.py
+++ b/tests/unit/benchmarks/test_tui_app.py
@@ -338,20 +338,20 @@ async def test_options_screen_places_representative_fields_in_expected_sections(
 
 
 @pytest.mark.asyncio
-async def test_options_screen_places_workload_matrix_before_detail_knobs() -> None:
+async def test_options_screen_places_mode_selectors_before_workload_options() -> None:
     app = BenchmarkTuiApp()
 
     async with app.run_test() as pilot:
         await pilot.pause()
-        workloads = app.screen.query_one("#option-block-workloads")
         ordering_modes = app.screen.query_one("#option-block-ordering-modes")
         execution_modes = app.screen.query_one("#option-block-execution-modes")
+        workloads = app.screen.query_one("#option-block-workloads")
         workload_options = app.screen.query_one("#workload-options")
         bootstrap = app.screen.query_one("#option-block-bootstrap-servers")
         positions = (
-            workloads.region.y,
             ordering_modes.region.y,
             execution_modes.region.y,
+            workloads.region.y,
             workload_options.region.y,
             bootstrap.region.y,
         )


### PR DESCRIPTION
## Summary
- reorder benchmark options selector flow to Ordering -> Execution -> Workload
- keep workload-specific controls directly below workload selection
- update TUI layout test to lock the intended ordering

## Verification
- uv run pytest tests/unit/benchmarks/test_tui_app.py tests/unit/benchmarks/test_tui_options_form.py
- uv run ruff check benchmarks/tui/screens/options.py tests/unit/benchmarks/test_tui_app.py